### PR TITLE
Parallel data representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ See file LICENSE.txt
 
 # Changelog
 
+* 2025-09-11 v2.16
+  * add parallel corpus information to machine-readable metadata
+  * add parallel data support with parallel_id metadata
 * 2021-11-15 v2.9 **(UD_Japanese-GSDLUW)**
   * New word segmentation (LUW) is introduced.
   
@@ -184,7 +187,7 @@ See https://github.com/ryanmcd/uni-dep-tb for more details
 Data available since: UD v2.9
 License: CC BY-SA 4.0
 Includes text: yes
-Parallel: no
+Parallel: jagsd
 Genre: news blog
 Lemmas: converted from manual
 UPOS: converted from manual

--- a/ja_gsdluw-ud-dev.conllu
+++ b/ja_gsdluw-ud-dev.conllu
@@ -1,6 +1,6 @@
 # newdoc id = dev-s1
 # sent_id = dev-s1
-# parallel_id = jagsdluw/dev1
+# parallel_id = jagsd/dev1
 # text = ただし、50周年ソングに変更後は、EDも歌つきのものが使われた。
 1	ただし	但し	CCONJ	接続詞	_	14	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -22,7 +22,7 @@
 
 # newdoc id = dev-s2
 # sent_id = dev-s2
-# parallel_id = jagsdluw/dev2
+# parallel_id = jagsd/dev2
 # text = 私は初めてだったんだけど思っていたよりも魚は新鮮でした。
 1	私	私	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -45,7 +45,7 @@
 
 # newdoc id = dev-s4
 # sent_id = dev-s4
-# parallel_id = jagsdluw/dev4
+# parallel_id = jagsd/dev4
 # text = セントラル・リーグ審判員の水落朋大は実兄。
 1	セントラル・リーグ審判員	セントラル・リーグ審判員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セントラル;;リーグ;シンパン;イン,セントラル;・;リーグ;審判;員,セントラル;・;リーグ;審判;員,セントラル;・;リーグ;審判;員,セントラル;;リーグ;シンパン;イン,;;;;,;;;;,セントラル;;リーグ;シンパン;イン,セントラルリーグシンパンイン,セントラル・リーグ審判員
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -56,7 +56,7 @@
 
 # newdoc id = dev-s5
 # sent_id = dev-s5
-# parallel_id = jagsdluw/dev5
+# parallel_id = jagsd/dev5
 # text = 多彩なライブアクトとともに、祝日前の渋谷の夜を盛り上げてくれそうだ。
 1	多彩	多彩	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タサイ,多彩,多彩,多彩,タサイ,,,タサイ,タサイ,多彩
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -79,7 +79,7 @@
 
 # newdoc id = dev-s6
 # sent_id = dev-s6
-# parallel_id = jagsdluw/dev6
+# parallel_id = jagsd/dev6
 # text = 今作品では大会でのパラメータUPが非常に大きく、ALL999への育成は回復アイテムを投与しつつ、冬眠、復活を繰り返し大会に連続して出すという方法が取られた。
 1	今作品	今作品	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コン;サクヒン,今;作品,今;作品,今;作品,コン;サクヒン,;,;,コン;サクヒン,コンサクヒン,今作品
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -123,7 +123,7 @@
 
 # newdoc id = dev-s7
 # sent_id = dev-s7
-# parallel_id = jagsdluw/dev7
+# parallel_id = jagsd/dev7
 # text = ゲーム入力のレスポンスをよくするためには、これを1秒間に通常30回以上行う必要があり、実際に得られたデータの回数と値はゲームコントローラ内の抵抗や回路上のノイズやCPUスピード、ゲームコントローラ全体の容量からくるRC回路・時定数に依存する。
 1	ゲーム入力	ゲーム入力	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲーム;ニュウリョク,ゲーム;入力,ゲーム;入力,ゲーム;入力,ゲーム;ニューリョク,;,;,ゲーム;ニュウリョク,ゲームニュウリョク,ゲーム入力
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -178,7 +178,7 @@
 
 # newdoc id = dev-s8
 # sent_id = dev-s8
-# parallel_id = jagsdluw/dev8
+# parallel_id = jagsd/dev8
 # text = 姉と同じ先生だったので、話やすかったです。
 1	姉	姉	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アネ,姉,姉,姉,アネ,,,アネ,アネ,姉
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -195,7 +195,7 @@
 
 # newdoc id = dev-s9
 # sent_id = dev-s9
-# parallel_id = jagsdluw/dev9
+# parallel_id = jagsd/dev9
 # text = 同僚教師のすみれと彩はそんな夕子と意気投合し、問題を解決するため行動を共にする。
 1	同僚教師	同僚教師	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウリョウ;キョウシ,同僚;教師,同僚;教師,同僚;教師,ドーリョー;キョーシ,;,;,ドウリョウ;キョウシ,ドウリョウキョウシ,同僚教師
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -221,7 +221,7 @@
 
 # newdoc id = dev-s10
 # sent_id = dev-s10
-# parallel_id = jagsdluw/dev10
+# parallel_id = jagsd/dev10
 # text = ほかの複数の信者も女性宅近くで付きまとい行為をしていたとみられ,統一教会の組織的な関与の有無を慎重に調べている。
 1	ほか	他	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -256,7 +256,7 @@
 
 # newdoc id = dev-s11
 # sent_id = dev-s11
-# parallel_id = jagsdluw/dev11
+# parallel_id = jagsd/dev11
 # text = 背中に背負ったブースターを使って空中飛行を行う。
 1	背中	背中	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セナカ,背中,背中,背中,セナカ,,,セナカ,セナカ,背中
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -273,7 +273,7 @@
 
 # newdoc id = dev-s12
 # sent_id = dev-s12
-# parallel_id = jagsdluw/dev12
+# parallel_id = jagsd/dev12
 # text = また、最新版のウェブブラウザを利用していても、OSやコンポーネント側にセキュリティホールが存在すれば、そこを突かれる可能性がある。
 1	また	又	CCONJ	接続詞	_	27	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -306,7 +306,7 @@
 
 # newdoc id = dev-s13
 # sent_id = dev-s13
-# parallel_id = jagsdluw/dev13
+# parallel_id = jagsd/dev13
 # text = しかも、熱々の料理はとても美味しかったです。
 1	しかも	然も	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカモ,然も,しかも,しかも,シカモ,,,シカモ,シカモ,然も
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -322,7 +322,7 @@
 
 # newdoc id = dev-s14
 # sent_id = dev-s14
-# parallel_id = jagsdluw/dev14
+# parallel_id = jagsd/dev14
 # text = 取り調べ段階では黙秘を貫き“全ては裁判官の前で話す”としていた被告は,犯行を認めたものの教祖への逮捕状発布の経緯に関し“捜査当局の不手際,失態”と元同僚らを非難,法廷は一時元警視の独壇場となった。
 1	取り調べ段階	取り調べ段階	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トリシラベ;ダンカイ,取り調べ;段階,取り調べ;段階,取り調べ;段階,トリシラベ;ダンカイ,;,;,トリシラベ;ダンカイ,トリシラベダンカイ,取り調べ段階
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -384,7 +384,7 @@
 
 # newdoc id = dev-s15
 # sent_id = dev-s15
-# parallel_id = jagsdluw/dev15
+# parallel_id = jagsd/dev15
 # text = 今回、日本のメディアもこのテストに参加することができたので、最新バージョンの出来具合をレポートしていきたい。
 1	今回	今回	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンカイ,今回,今回,今回,コンカイ,,,コンカイ,コンカイ,今回
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -411,7 +411,7 @@
 
 # newdoc id = dev-s16
 # sent_id = dev-s16
-# parallel_id = jagsdluw/dev16
+# parallel_id = jagsd/dev16
 # text = 大正期から、ノンフィクション、推理小説などを訳した。
 1	大正期	大正期	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイショウ;キ,大正;期,大正;期,大正;期,タイショー;キ,;,;,タイショウ;キ,タイショウキ,大正期
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -427,7 +427,7 @@
 
 # newdoc id = dev-s17
 # sent_id = dev-s17
-# parallel_id = jagsdluw/dev17
+# parallel_id = jagsd/dev17
 # text = 市内のユダヤ人は1942年までにその全員が逃亡するか、強制収容所に送致されるかのいずれかであった。
 1	市内	市内	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シナイ,市内,市内,市内,シナイ,,,シナイ,シナイ,市内
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -456,7 +456,7 @@
 
 # newdoc id = dev-s18
 # sent_id = dev-s18
-# parallel_id = jagsdluw/dev18
+# parallel_id = jagsd/dev18
 # text = ほとんどは浅海生だが、水深数百mほどの深海まで生息するものもいる。
 1	ほとんど	殆ど	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホトンド,殆ど,ほとんど,ほとんど,ホトンド,,,ホトンド,ホトンド,殆ど
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -478,7 +478,7 @@
 
 # newdoc id = dev-s19
 # sent_id = dev-s19
-# parallel_id = jagsdluw/dev19
+# parallel_id = jagsd/dev19
 # text = 価格に見合う満足感を感じます。
 1	価格	価格	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カカク,価格,価格,価格,カカク,,,カカク,カカク,価格
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -491,7 +491,7 @@
 
 # newdoc id = dev-s20
 # sent_id = dev-s20
-# parallel_id = jagsdluw/dev20
+# parallel_id = jagsd/dev20
 # text = 一方B国では輸出により小麦の量が減るので、小麦の価格は上がる。
 1	一方	一方	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	B国	B国	NOUN	名詞-普通名詞-一般	_	18	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビー;コク,Ｂ;国,B;国,B;国,ビー;コク,;,;,ビー;コク,ビーコク,B国
@@ -515,7 +515,7 @@
 
 # newdoc id = dev-s21
 # sent_id = dev-s21
-# parallel_id = jagsdluw/dev21
+# parallel_id = jagsd/dev21
 # text = インターナショナル・マネジメント・グループをはじめとする投資家によって所有しているが、中でも元テニス選手ピート・サンプラスとアンドレ・アガシも投資されている。
 1	インターナショナル・マネジメント・グループ	インターナショナル・マネジメント・グループ	PROPN	名詞-固有名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=インターナショナル;;マネージメント;;グループ,インターナショナル;・;マネージメント;・;グループ,インターナショナル;・;マネジメント;・;グループ,インターナショナル;・;マネジメント;・;グループ,インターナショナル;;マネジメント;;グループ,;;;;,;;;;,インターナショナル;;マネジメント;;グループ,インターナショナルマネージメントグループ,インターナショナル・マネージメント・グループ
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -543,7 +543,7 @@
 
 # newdoc id = dev-s22
 # sent_id = dev-s22
-# parallel_id = jagsdluw/dev22
+# parallel_id = jagsd/dev22
 # text = 聖書に当てはめた場合、最も分かりやすいのがノアの方舟伝説である。
 1	聖書	聖書	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイショ,聖書,聖書,聖書,セーショ,,,セイショ,セイショ,聖書
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -564,7 +564,7 @@
 
 # newdoc id = dev-s23
 # sent_id = dev-s23
-# parallel_id = jagsdluw/dev23
+# parallel_id = jagsd/dev23
 # text = 海は油膜を貼って青白く光っており、無数の漂着物が流れている。
 1	海	海	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウミ,海,海,海,ウミ,,,ウミ,ウミ,海
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -586,7 +586,7 @@
 
 # newdoc id = dev-s24
 # sent_id = dev-s24
-# parallel_id = jagsdluw/dev24
+# parallel_id = jagsd/dev24
 # text = 一つに,書籍や講演会,施設,HPなどで教祖と幹部の本音,生活,人間性などの真実の情報を手に入れることです。
 1	一つ	一つ	NUM	名詞-数詞	_	31	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒト;ツ,一;つ,一;つ,一;つ,ヒト;ツ,;,;,ヒト;ツ,ヒトツ,一つ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -624,7 +624,7 @@
 
 # newdoc id = dev-s25
 # sent_id = dev-s25
-# parallel_id = jagsdluw/dev25
+# parallel_id = jagsd/dev25
 # text = 麺棒は直径2~3cm、長さ1m程度のものが一般的という。
 1	麺棒	麺棒	NOUN	名詞-普通名詞-一般	_	13	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メンボウ,麺棒,麺棒,麺棒,メンボー,,,メンボウ,メンボウ,麺棒
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -643,7 +643,7 @@
 
 # newdoc id = dev-s26
 # sent_id = dev-s26
-# parallel_id = jagsdluw/dev26
+# parallel_id = jagsd/dev26
 # text = グレたのは、母を亡くし父が仕事で忙しい事が原因らしい。
 1	グレ	ぐれる	VERB	動詞-一般-下一段-ラ行	_	16	csubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=グレル,ぐれる,グレ,グレる,グレ,,,グレル,グレル,ぐれる
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -666,7 +666,7 @@
 
 # newdoc id = dev-s27
 # sent_id = dev-s27
-# parallel_id = jagsdluw/dev27
+# parallel_id = jagsd/dev27
 # text = スタッフさんも親切に接してくれたので、緊張せずに居心地が良かったです。
 1	スタッフさん	スタッフさん	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタッフ;サン,スタッフ;さん,スタッフ;さん,スタッフ;さん,スタッフ;サン,;,;,スタッフ;サン,スタッフサン,スタッフさん
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -689,14 +689,14 @@
 
 # newdoc id = dev-s28
 # sent_id = dev-s28
-# parallel_id = jagsdluw/dev28
+# parallel_id = jagsd/dev28
 # text = 元広島県議会議員。
 1	元広島県議会議員	元広島県議会議員	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=モト;ヒロシマ;ケン;ギカイ;ギイン,元;ヒロシマ;県;議会;議員,元;広島;県;議会;議員,元;広島;県;議会;議員,モト;ヒロシマ;ケン;ギカイ;ギイン,;;;;,;;;;,モト;ヒロシマ;ケン;ギカイ;ギイン,モトヒロシマケンギカイギイン,元広島県議会議員
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s29
 # sent_id = dev-s29
-# parallel_id = jagsdluw/dev29
+# parallel_id = jagsd/dev29
 # text = 地域別では「高台」を選んだのは田老66・0%、仙台39・6%と地域差が大きかった。
 1	地域別	地域別	NOUN	名詞-普通名詞-一般	_	20	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チイキ;ベツ,地域;別,地域;別,地域;別,チイキ;ベツ,;,;,チイキ;ベツ,チイキベツ,地域別
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -723,7 +723,7 @@
 
 # newdoc id = dev-s30
 # sent_id = dev-s30
-# parallel_id = jagsdluw/dev30
+# parallel_id = jagsd/dev30
 # text = 演芸では,昨年の後夜祭で大受けをとった米粒写経が登場。
 1	演芸	演芸	NOUN	名詞-普通名詞-一般	_	15	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エンゲイ,演芸,演芸,演芸,エンゲー,,,エンゲイ,エンゲイ,演芸
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -744,7 +744,7 @@
 
 # newdoc id = dev-s31
 # sent_id = dev-s31
-# parallel_id = jagsdluw/dev31
+# parallel_id = jagsd/dev31
 # text = ロングヘアーの色黒の女性。
 1	ロングヘアー	ロングヘアー	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ロング;ヘア,ロング;ヘア,ロング;ヘアー,ロング;ヘアー,ロング;ヘアー,;,;,ロング;ヘアー,ロングヘアー,ロングヘアー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -755,7 +755,7 @@
 
 # newdoc id = dev-s33
 # sent_id = dev-s33
-# parallel_id = jagsdluw/dev33
+# parallel_id = jagsd/dev33
 # text = ここ数年,統一教会の関連会社による霊感商法で信者の逮捕者が続出しています。
 1	ここ	此処	PRON	代名詞	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
 2	数年	数年	NUM	名詞-数詞	_	14	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スウ;ネン,数;年,数;年,数;年,スー;ネン,;,;,スウ;ネン,スウネン,数年
@@ -777,7 +777,7 @@
 
 # newdoc id = dev-s34
 # sent_id = dev-s34
-# parallel_id = jagsdluw/dev34
+# parallel_id = jagsd/dev34
 # text = やはり、個室って隔たりがあるのでプライベートな話やビジネスの大事な話もお食事やお酒を飲みながらできるというのがとても大きなメリットであることが分かりました。
 1	やはり	矢張り	ADV	副詞	_	35	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤハリ,矢張り,やはり,やはり,ヤハリ,,,ヤハリ,ヤハリ,矢張り
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -820,7 +820,7 @@
 
 # newdoc id = dev-s35
 # sent_id = dev-s35
-# parallel_id = jagsdluw/dev35
+# parallel_id = jagsd/dev35
 # text = 精神科へ通院する人の中には、病院へ通院したり予約時間までの間待ち続けるだけでも消耗する人もいます。
 1	精神科	精神科	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイシン;カ,精神;科,精神;科,精神;科,セーシン;カ,;,;,セイシン;カ,セイシンカ,精神科
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -852,7 +852,7 @@
 
 # newdoc id = dev-s36
 # sent_id = dev-s36
-# parallel_id = jagsdluw/dev36
+# parallel_id = jagsd/dev36
 # text = また、前年16本だったホームランは19本まで増えた。
 1	また	又	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -870,7 +870,7 @@
 
 # newdoc id = dev-s37
 # sent_id = dev-s37
-# parallel_id = jagsdluw/dev37
+# parallel_id = jagsd/dev37
 # text = 久しぶりにうまいコーヒーが飲めました。
 1	久しぶり	久し振り	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒサシイ;ブリ,久しい;振り,久し;ぶり,久しい;ぶり,ヒサシ;ブリ,;,;,ヒサシイ;ブリ,ヒサシブリ,久し振り
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -884,7 +884,7 @@
 
 # newdoc id = dev-s38
 # sent_id = dev-s38
-# parallel_id = jagsdluw/dev38
+# parallel_id = jagsd/dev38
 # text = これはほとんどのユーザーには問題なかったが、一部のゲームではコピープロテクト用の未フォーマット領域やディスクにたくさんのデータを詰め込む方法として拡張トラックを使用しており、カスタムフォーマットユーティリティでは80トラックのディスクに86のトラックを作るフォーマットが容量拡張の手段として一般的に選べた。
 1	これ	此れ	PRON	代名詞	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -947,7 +947,7 @@
 
 # newdoc id = dev-s39
 # sent_id = dev-s39
-# parallel_id = jagsdluw/dev39
+# parallel_id = jagsd/dev39
 # text = 現在は空き名跡となっている。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -959,7 +959,7 @@
 
 # newdoc id = dev-s40
 # sent_id = dev-s40
-# parallel_id = jagsdluw/dev40
+# parallel_id = jagsd/dev40
 # text = 元文3年の一門家新設時は加治木家と垂水家がこの家格とされたが、同年に成立した重富家も加わり、重富家の前身、越前島津家が室町幕府の直勤だったため、一門家筆頭とされた。
 1	元文	元文	PROPN	名詞-固有名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ゲンブン,元文,元文,元文,ゲンブン,,,ゲンブン,ゲンブン,元文
 2	3年	3年	NUM	名詞-数詞	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ネン,三;年,3;年,3;年,サン;ネン,;,;,サン;ネン,サンネン,3年
@@ -1008,7 +1008,7 @@
 
 # newdoc id = dev-s41
 # sent_id = dev-s41
-# parallel_id = jagsdluw/dev41
+# parallel_id = jagsd/dev41
 # text = 色の指定にtealと指定すると、16進数表記で#008080と表現される色が発色される。
 1	色	色	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イロ,色,色,色,イロ,,,イロ,イロ,色
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1033,7 +1033,7 @@
 
 # newdoc id = dev-s42
 # sent_id = dev-s42
-# parallel_id = jagsdluw/dev42
+# parallel_id = jagsd/dev42
 # text = 晩年は霧ケ峰牧場で余生を過ごしたといわれている。
 1	晩年	晩年	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バンネン,晩年,晩年,晩年,バンネン,,,バンネン,バンネン,晩年
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1051,7 +1051,7 @@
 
 # newdoc id = dev-s43
 # sent_id = dev-s43
-# parallel_id = jagsdluw/dev43
+# parallel_id = jagsd/dev43
 # text = 以上の操作を再帰的に繰り返すと以下のような決定木が出力される。
 1	以上	以上	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イジョウ,以上,以上,以上,イジョー,,,イジョウ,イジョウ,以上
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1073,7 +1073,7 @@
 
 # newdoc id = dev-s44
 # sent_id = dev-s44
-# parallel_id = jagsdluw/dev44
+# parallel_id = jagsd/dev44
 # text = どこにするか迷ってる方がいたら、ぜひともここをオススメします。
 1	どこ	何処	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドコ,何処,どこ,どこ,ドコ,,,ドコ,ドコ,何処
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1095,7 +1095,7 @@
 
 # newdoc id = dev-s45
 # sent_id = dev-s45
-# parallel_id = jagsdluw/dev45
+# parallel_id = jagsd/dev45
 # text = これはおそらくタバコを普及させたウォルター・ローリー卿が伝説の黄金の都市エル・ドラードを求めてガイアナのオリノコ川を遡った1580年の遠征の栄誉を称えたものと見られている。
 1	これ	此れ	PRON	代名詞	_	36	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1139,7 +1139,7 @@
 
 # newdoc id = dev-s46
 # sent_id = dev-s46
-# parallel_id = jagsdluw/dev46
+# parallel_id = jagsd/dev46
 # text = 16日の東京株式市場も主力輸出株はさえない。
 1	16日	16日	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ロク;ニチ,一;六;日,1;6;日,1;6;日,イチ;ロク;ニチ,;;,;;,イチ;ロク;ニチ,イチロクニチ,16日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1153,7 +1153,7 @@
 
 # newdoc id = dev-s47
 # sent_id = dev-s47
-# parallel_id = jagsdluw/dev47
+# parallel_id = jagsd/dev47
 # text = これらが順に収縮することで食物を胃に送り出すような動きをする。
 1	これら	此れ等	PRON	代名詞	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ;ラ,此れ;等,これ;ら,これ;ら,コレ;ラ,;,;,コレ;ラ,コレラ,此れ等
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1176,7 +1176,7 @@
 
 # newdoc id = dev-s48
 # sent_id = dev-s48
-# parallel_id = jagsdluw/dev48
+# parallel_id = jagsd/dev48
 # text = 実際廃止された区間の復旧再開も京義・東海線とともに検討され、1991年にすでに用地買取や設計などが済まされていたが、地形的理由で見送られてきた。
 1	実際	実際	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジッサイ,実際,実際,実際,ジッサイ,,,ジッサイ,ジッサイ,実際
 2	廃止さ	廃止する	VERB	動詞-一般-サ行変格	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハイシ;スル,廃止;為る,廃止;さ,廃止;する,ハイシ;サ,;,;,ハイシ;スル,ハイシスル,廃止する
@@ -1217,7 +1217,7 @@
 
 # newdoc id = dev-s49
 # sent_id = dev-s49
-# parallel_id = jagsdluw/dev49
+# parallel_id = jagsd/dev49
 # text = 蔵前国技館跡地は東京都に売却し、その売却益が両国国技館建設の資金となった。
 1	蔵前国技館跡地	蔵前国技館跡地	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クラマエ;コクギ;カン;アトチ,クラマエ;国技;館;跡地,蔵前;国技;館;跡地,蔵前;国技;館;跡地,クラマエ;コクギ;カン;アトチ,;;;,;;;,クラマエ;コクギ;カン;アトチ,クラマエコクギカンアトチ,蔵前国技館跡地
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1238,7 +1238,7 @@
 
 # newdoc id = dev-s50
 # sent_id = dev-s50
-# parallel_id = jagsdluw/dev50
+# parallel_id = jagsd/dev50
 # text = ヴィクトル・ユゴーなどフランス・ロマン派を専門とした。
 1	ヴィクトル・ユゴー	ヴィクトル・ユゴー	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビクトル;;ユーゴー,ビクトル;・;ユーゴー,ヴィクトル;・;ユゴー,ヴィクトル;・;ユゴー,ビクトル;;ユゴー,;;,;;,ビクトル;;ユゴー,ビクトルユゴー,ヴィクトル・ユゴー
 2	など	など	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナド,など,など,など,ナド,,,ナド,ナド,など
@@ -1252,7 +1252,7 @@
 
 # newdoc id = dev-s51
 # sent_id = dev-s51
-# parallel_id = jagsdluw/dev51
+# parallel_id = jagsd/dev51
 # text = イーアスの中にある映画館なので、駐車場が広いのもGood。
 1	イーアス	イーアス	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イーアス,イーアス,イーアス,イーアス,イーアス,,,イーアス,イーアス,イーアス
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1273,7 +1273,7 @@
 
 # newdoc id = dev-s52
 # sent_id = dev-s52
-# parallel_id = jagsdluw/dev52
+# parallel_id = jagsd/dev52
 # text = 府中や国立の辺りの土地が得意とのことで、色々と紹介してもらうことができました。
 1	府中	府中	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フチュウ,フチュウ,府中,府中,フチュー,,,フチュウ,フチュウ,府中
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -1300,7 +1300,7 @@
 
 # newdoc id = dev-s53
 # sent_id = dev-s53
-# parallel_id = jagsdluw/dev53
+# parallel_id = jagsd/dev53
 # text = 日本貝類学会役員、東京貝類同好会名誉会長を務めた貝類収集家としても知られた。
 1	日本貝類学会役員	日本介類学会役員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン;カイルイ;ガッカイ;ヤクイン,日本;介類;学会;役員,日本;貝類;学会;役員,日本;貝類;学会;役員,ニッポン;カイルイ;ガッカイ;ヤクイン,;;;,;;;,ニッポン;カイルイ;ガッカイ;ヤクイン,ニッポンカイルイガッカイヤクイン,日本介類学会役員
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1319,7 +1319,7 @@
 
 # newdoc id = dev-s54
 # sent_id = dev-s54
-# parallel_id = jagsdluw/dev54
+# parallel_id = jagsd/dev54
 # text = 富士通は、産業機械だけでなく、社会インフラや物流業界などに対してM2Mサービスを提供する。
 1	富士通	富士通	PROPN	名詞-固有名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フジツウ,富士通,富士通,富士通,フジツー,,,フジツウ,フジツウ,富士通
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1339,7 +1339,7 @@
 
 # newdoc id = dev-s55
 # sent_id = dev-s55
-# parallel_id = jagsdluw/dev55
+# parallel_id = jagsd/dev55
 # text = 第一次世界大戦終結後、ヴェルサイユ条約によって大砲の保有を禁止されたドイツから戦争賠償としてベルギーが残存砲を接収して装備した。
 1	第一次世界大戦終結後	第一次世界大戦終結後	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;イチ;ジ;セカイ;タイセン;シュウケツ;ゴ,第;一;次;世界;大戦;終結;後,第;一;次;世界;大戦;終結;後,第;一;次;世界;大戦;終結;後,ダイ;イチ;ジ;セカイ;タイセン;シューケツ;ゴ,;;;;;;,;;;;;;,ダイ;イチ;ジ;セカイ;タイセン;シュウケツ;ゴ,ダイイチジセカイタイセンシュウケツゴ,第一次世界大戦終結後
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1368,7 +1368,7 @@
 
 # newdoc id = dev-s56
 # sent_id = dev-s56
-# parallel_id = jagsdluw/dev56
+# parallel_id = jagsd/dev56
 # text = やはり、おすすめは焼き物ですね。
 1	やはり	矢張り	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤハリ,矢張り,やはり,やはり,ヤハリ,,,ヤハリ,ヤハリ,矢張り
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1381,7 +1381,7 @@
 
 # newdoc id = dev-s57
 # sent_id = dev-s57
-# parallel_id = jagsdluw/dev57
+# parallel_id = jagsd/dev57
 # text = いなべ市藤原町坂本-同市藤原町下野尻を以下の路線バスが通過する。
 1	いなべ市	いなべ市	PROPN	名詞-固有名詞-地名-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イナベ;シ,イナベ;市,いなべ;市,いなべ;市,イナベ;シ,;,;,イナベ;シ,イナベシ,いなべ市
 2	藤原町	藤原町	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フジワラ;チョウ,フジワラ;町,藤原;町,藤原;町,フジワラ;チョー,;,;,フジワラ;チョウ,フジワラチョウ,藤原町
@@ -1400,7 +1400,7 @@
 
 # newdoc id = dev-s58
 # sent_id = dev-s58
-# parallel_id = jagsdluw/dev58
+# parallel_id = jagsd/dev58
 # text = ロイツェは沖縄戦終結後の7月10日に慶良間を離れてグアム、真珠湾を経由してサンフランシスコに到着し、8月3日からハンターズ・ポイント海軍造船所で修理が開始されたが、終戦により修理は停止された。
 1	ロイツェ	ロイツェ	PROPN	名詞-固有名詞-人名-一般	_	20	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ロイツェ,ロイツェ,ロイツェ,ロイツェ,ロイツェ,,,ロイツェ,ロイツェ,ロイツェ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1446,7 +1446,7 @@
 
 # newdoc id = dev-s59
 # sent_id = dev-s59
-# parallel_id = jagsdluw/dev59
+# parallel_id = jagsd/dev59
 # text = その際,国会議員に対して請願を行う予定と見られています。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	際	際	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイ,際,際,際,サイ,,,サイ,サイ,際
@@ -1466,7 +1466,7 @@
 
 # newdoc id = dev-s60
 # sent_id = dev-s60
-# parallel_id = jagsdluw/dev60
+# parallel_id = jagsd/dev60
 # text = かつては、農業が圧倒的で、バーデン=ヴュルテンベルク州内で最も脆弱な経済基盤の郡であったが、近年は構造変化を成し遂げている。
 1	かつて	嘗て	ADV	副詞	_	16	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カツテ,嘗て,かつて,かつて,カツテ,,,カツテ,カツテ,嘗て
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1498,7 +1498,7 @@
 
 # newdoc id = dev-s61
 # sent_id = dev-s61
-# parallel_id = jagsdluw/dev61
+# parallel_id = jagsd/dev61
 # text = 人を人として思わないような,尋常ではないこの現実をみなさんにお伝えしたいのです。
 1	人	人	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒト,人,人,人,ヒト,,,ヒト,ヒト,人
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -1523,7 +1523,7 @@
 
 # newdoc id = dev-s62
 # sent_id = dev-s62
-# parallel_id = jagsdluw/dev62
+# parallel_id = jagsd/dev62
 # text = ハンマーはやめて!
 1	ハンマー	ハンマー	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハンマー,ハンマー,ハンマー,ハンマー,ハンマー,,,ハンマー,ハンマー,ハンマー
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1533,7 +1533,7 @@
 
 # newdoc id = dev-s63
 # sent_id = dev-s63
-# parallel_id = jagsdluw/dev63
+# parallel_id = jagsd/dev63
 # text = 大きな拍手が巻き起こりました。
 1	大きな	大きな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキナ,大きな,大きな,大きな,オーキナ,,,オオキナ,オオキナ,大きな
 2	拍手	拍手	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハクシュ,拍手,拍手,拍手,ハクシュ,,,ハクシュ,ハクシュ,拍手
@@ -1545,7 +1545,7 @@
 
 # newdoc id = dev-s64
 # sent_id = dev-s64
-# parallel_id = jagsdluw/dev64
+# parallel_id = jagsd/dev64
 # text = リミテッド・シリーズの『マーベル1602』で、「スティーブン・ストレンジ卿」は専属医師兼魔術師としてエリザベス1世に仕えた。
 1	リミテッド・シリーズ	リミテッド・シリーズ	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リミテッド;;シリーズ,リミテッド;・;シリーズ,リミテッド;・;シリーズ,リミテッド;・;シリーズ,リミテッド;;シリーズ,;;,;;,リミテッド;;シリーズ,リミテッドシリーズ,リミテッド・シリーズ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1570,7 +1570,7 @@
 
 # newdoc id = dev-s65
 # sent_id = dev-s65
-# parallel_id = jagsdluw/dev65
+# parallel_id = jagsd/dev65
 # text = 果肉は橙色で、肉質はやや硬いが多汁である。
 1	果肉	果肉	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カニク,果肉,果肉,果肉,カニク,,,カニク,カニク,果肉
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1588,7 +1588,7 @@
 
 # newdoc id = dev-s66
 # sent_id = dev-s66
-# parallel_id = jagsdluw/dev66
+# parallel_id = jagsd/dev66
 # text = 戸籍上は女性として生まれたが、幼い頃から「自分は男性である」との性自認を持っていた。
 1	戸籍上	戸籍上	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コセキ;ジョウ,戸籍;上,戸籍;上,戸籍;上,コセキ;ジョー,;,;,コセキ;ジョウ,コセキジョウ,戸籍上
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1618,7 +1618,7 @@
 
 # newdoc id = dev-s67
 # sent_id = dev-s67
-# parallel_id = jagsdluw/dev67
+# parallel_id = jagsd/dev67
 # text = 中日新聞社が後援している。
 1	中日新聞社	中日新聞社	PROPN	名詞-固有名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウニチ;シンブン;シャ,中日;新聞;社,中日;新聞;社,中日;新聞;社,チューニチ;シンブン;シャ,;;,;;,チュウニチ;シンブン;シャ,チュウニチシンブンシャ,中日新聞社
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1628,7 +1628,7 @@
 
 # newdoc id = dev-s68
 # sent_id = dev-s68
-# parallel_id = jagsdluw/dev68
+# parallel_id = jagsd/dev68
 # text = カラフルで色合いがいいデザインがあったので気に入りました。
 1	カラフル	カラフル	ADJ	形状詞-一般	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カラフル,カラフル,カラフル,カラフル,カラフル,,,カラフル,カラフル,カラフル
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -1649,7 +1649,7 @@
 
 # newdoc id = dev-s69
 # sent_id = dev-s69
-# parallel_id = jagsdluw/dev69
+# parallel_id = jagsd/dev69
 # text = クルマにまつわるエピソードをTwitterで投稿する同キャンペーン。
 1	クルマ	車	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クルマ,車,クルマ,クルマ,クルマ,,,クルマ,クルマ,車
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1664,7 +1664,7 @@
 
 # newdoc id = dev-s70
 # sent_id = dev-s70
-# parallel_id = jagsdluw/dev70
+# parallel_id = jagsd/dev70
 # text = ビッグ・モーラが破壊されたときには、彼らの策略のために、既にかつての威光はなくなっていた。
 1	ビッグ・モーラ	ビッグ・モーラ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビッグ;;モーラ,ビッグ;・;モーラ,ビッグ;・;モーラ,ビッグ;・;モーラ,ビッグ;;モーラ,;;,;;,ビッグ;;モーラ,ビッグモーラ,ビッグ・モーラ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1694,7 +1694,7 @@
 
 # newdoc id = dev-s71
 # sent_id = dev-s71
-# parallel_id = jagsdluw/dev71
+# parallel_id = jagsd/dev71
 # text = 北朝鮮についてはホームでの対戦もすんなりとはいかない。
 1	北朝鮮	北朝鮮	PROPN	名詞-固有名詞-地名-国	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キタチョウセン,北朝鮮,北朝鮮,北朝鮮,キタチョーセン,,,キタチョウセン,キタチョウセン,北朝鮮
 2	について	について	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ツク;テ,に;つく;て,に;つい;て,に;つく;て,ニ;ツイ;テ,;;,;;,ニ;ツク;テ,ニツイテ,について
@@ -1713,7 +1713,7 @@
 
 # newdoc id = dev-s72
 # sent_id = dev-s72
-# parallel_id = jagsdluw/dev72
+# parallel_id = jagsd/dev72
 # text = 定期的にイベントしてるらしくて要チェックです。
 1	定期的	定期的	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テイキ;テキ,定期;的,定期;的,定期;的,テーキ;テキ,;,;,テイキ;テキ,テイキテキ,定期的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -1727,7 +1727,7 @@
 
 # newdoc id = dev-s73
 # sent_id = dev-s73
-# parallel_id = jagsdluw/dev73
+# parallel_id = jagsd/dev73
 # text = 中日の次期監督に決まっている高木守道氏からラブコールを送られている福留に、巨人も再び手を伸ばすことになるかどうか。
 1	中日	中日	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウニチ,中日,中日,中日,チューニチ,,,チュウニチ,チュウニチ,中日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1759,7 +1759,7 @@
 
 # newdoc id = dev-s74
 # sent_id = dev-s74
-# parallel_id = jagsdluw/dev74
+# parallel_id = jagsd/dev74
 # text = 施設は大阪市が所有し、指定管理者は財団法人大阪市スポーツ・みどり振興協会である。
 1	施設	施設	NOUN	名詞-普通名詞-一般	_	5	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シセツ,施設,施設,施設,シセツ,,,シセツ,シセツ,施設
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1775,7 +1775,7 @@
 
 # newdoc id = dev-s75
 # sent_id = dev-s75
-# parallel_id = jagsdluw/dev75
+# parallel_id = jagsd/dev75
 # text = 私は住民に事実を伝えるのが仕事ですから。
 1	私	私	PRON	代名詞	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1793,7 +1793,7 @@
 
 # newdoc id = dev-s76
 # sent_id = dev-s76
-# parallel_id = jagsdluw/dev76
+# parallel_id = jagsd/dev76
 # text = ヨーロッパ各国の航空機メーカのコンソーシアムであるエアバス社は、政治的な理由によりヨーロッパ各地に部品工場を保有しており、最終組み立てのため機体部品の輸送が課題であった。
 1	ヨーロッパ各国	ヨーロッパ各国	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨーロッパ;カッコク,ヨーロッパ;各国,ヨーロッパ;各国,ヨーロッパ;各国,ヨーロッパ;カッコク,;,;,ヨーロッパ;カッコク,ヨーロッパカッコク,ヨーロッパ各国
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1829,7 +1829,7 @@
 
 # newdoc id = dev-s77
 # sent_id = dev-s77
-# parallel_id = jagsdluw/dev77
+# parallel_id = jagsd/dev77
 # text = 途中でジュールが亡くなったため兄エドモンが完成。
 1	途中	途中	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トチュウ,途中,途中,途中,トチュー,,,トチュウ,トチュウ,途中
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -1845,7 +1845,7 @@
 
 # newdoc id = dev-s78
 # sent_id = dev-s78
-# parallel_id = jagsdluw/dev78
+# parallel_id = jagsd/dev78
 # text = 同社の不燃木材は浅野木材工業の浅野成昭が開発し、2001年に日本で初めて国土交通省から不燃材料の認定を受けた。
 1	同社	同社	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウシャ,同社,同社,同社,ドーシャ,,,ドウシャ,ドウシャ,同社
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1874,7 +1874,7 @@
 
 # newdoc id = dev-s79
 # sent_id = dev-s79
-# parallel_id = jagsdluw/dev79
+# parallel_id = jagsd/dev79
 # text = 堀田は仙台藩伊達家を「家元」と宇和島藩伊達家を「家別レ」とするといった調停案を示した。
 1	堀田	堀田	PROPN	名詞-固有名詞-人名-姓	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホッタ,ホッタ,堀田,堀田,ホッタ,,,ホッタ,ホッタ,堀田
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1900,7 +1900,7 @@
 
 # newdoc id = dev-s80
 # sent_id = dev-s80
-# parallel_id = jagsdluw/dev80
+# parallel_id = jagsd/dev80
 # text = ホームページが出来たみたいです。
 1	ホームページ	ホームページ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホーム;ページ,ホーム;ページ,ホーム;ページ,ホーム;ページ,ホーム;ページ,;,;,ホーム;ページ,ホームページ,ホームページ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1912,7 +1912,7 @@
 
 # newdoc id = dev-s81
 # sent_id = dev-s81
-# parallel_id = jagsdluw/dev81
+# parallel_id = jagsd/dev81
 # text = また、10月には販売網の強化と顧客へのサービスの充実を図るため、神奈川県藤沢市に営業所を開設。
 1	また	又	CCONJ	接続詞	_	25	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1943,7 +1943,7 @@
 
 # newdoc id = dev-s82
 # sent_id = dev-s82
-# parallel_id = jagsdluw/dev82
+# parallel_id = jagsd/dev82
 # text = JBS日本福祉放送は社会福祉法人“視覚障害者文化振興協会”が運営する視覚障害者専用放送だ。
 1	JBS日本福祉放送	JBS日本福祉放送	PROPN	名詞-固有名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェービーエス;ニッポン;フクシ;ホウソウ,ＪＢＳ;日本;福祉;放送,JBS;日本;福祉;放送,JBS;日本;福祉;放送,ジェービーエス;ニッポン;フクシ;ホーソー,;;;,;;;,ジェービーエス;ニッポン;フクシ;ホウソウ,ジェービーエスニッポンフクシホウソウ,JBS日本福祉放送
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1959,7 +1959,7 @@
 
 # newdoc id = dev-s83
 # sent_id = dev-s83
-# parallel_id = jagsdluw/dev83
+# parallel_id = jagsd/dev83
 # text = 1986年より開発はフェイズ2に移行し機体の改修作業が行われた。
 1	1986年	1986年	NUM	名詞-数詞	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ハチ;ロク;ネン,一;九;八;六;年,1;9;8;6;年,1;9;8;6;年,イチ;キュー;ハチ;ロク;ネン,;;;;,;;;;,イチ;キュウ;ハチ;ロク;ネン,イチキュウハチロクネン,1986年
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -1979,7 +1979,7 @@
 
 # newdoc id = dev-s84
 # sent_id = dev-s84
-# parallel_id = jagsdluw/dev84
+# parallel_id = jagsd/dev84
 # text = 米議会内でもビンラディンが殺害されたことを確認するうえでも公表すべきだとの声が高まっていた。
 1	米議会内	米議会内	NOUN	名詞-普通名詞-一般	_	21	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベイ;ギカイ;ナイ,米;議会;内,米;議会;内,米;議会;内,ベー;ギカイ;ナイ,;;,;;,ベイ;ギカイ;ナイ,ベイギカイナイ,米議会内
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -2008,7 +2008,7 @@
 
 # newdoc id = dev-s85
 # sent_id = dev-s85
-# parallel_id = jagsdluw/dev85
+# parallel_id = jagsd/dev85
 # text = ただし、個別の作品に関する話題はエロゲー作品別板で扱う。
 1	ただし	但し	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2025,7 +2025,7 @@
 
 # newdoc id = dev-s86
 # sent_id = dev-s86
-# parallel_id = jagsdluw/dev86
+# parallel_id = jagsd/dev86
 # text = そのような活動を止めるどころか,顕進氏は,自分は創始者と協力しており,真の御父母様の遺されたものを維持しようとしているのだという錯覚を,積極的に助長してきています。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	よう	様	NOUN	形状詞-助動詞語幹	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=ヨウ,様,よう,よう,ヨー,,,ヨウ,ヨウ,様
@@ -2074,7 +2074,7 @@
 
 # newdoc id = dev-s87
 # sent_id = dev-s87
-# parallel_id = jagsdluw/dev87
+# parallel_id = jagsd/dev87
 # text = 私はクートラ医師の所有するストリックランドの果物絵を見て恐ろしさを感じていた。
 1	私	私	PRON	代名詞	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2096,7 +2096,7 @@
 
 # newdoc id = dev-s88
 # sent_id = dev-s88
-# parallel_id = jagsdluw/dev88
+# parallel_id = jagsd/dev88
 # text = その保健室の養護教諭が,生徒からバカにされていた様子がうかがえます。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	保健室	保健室	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホケン;シツ,保健;室,保健;室,保健;室,ホケン;シツ,;,;,ホケン;シツ,ホケンシツ,保健室
@@ -2120,7 +2120,7 @@
 
 # newdoc id = dev-s89
 # sent_id = dev-s89
-# parallel_id = jagsdluw/dev89
+# parallel_id = jagsd/dev89
 # text = 今回が初のツアー競技挑戦だ。
 1	今回	今回	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンカイ,今回,今回,今回,コンカイ,,,コンカイ,コンカイ,今回
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -2132,7 +2132,7 @@
 
 # newdoc id = dev-s90
 # sent_id = dev-s90
-# parallel_id = jagsdluw/dev90
+# parallel_id = jagsd/dev90
 # text = やはり、日常的に利用されることが多い業者だけあって、非常に慣れた感じはあります。
 1	やはり	矢張り	ADV	副詞	_	21	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤハリ,矢張り,やはり,やはり,ヤハリ,,,ヤハリ,ヤハリ,矢張り
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2160,7 +2160,7 @@
 
 # newdoc id = dev-s91
 # sent_id = dev-s91
-# parallel_id = jagsdluw/dev91
+# parallel_id = jagsd/dev91
 # text = 流出したものとされる資料群の中に,“日本における国産テロリストの脅威について”というタイトルのPDFファイルがありました。
 1	流出し	流出する	VERB	動詞-一般-サ行変格	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リュウシュツ;スル,流出;為る,流出;し,流出;する,リューシュツ;シ,;,;,リュウシュツ;スル,リュウシュツスル,流出する
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -2193,7 +2193,7 @@
 
 # newdoc id = dev-s92
 # sent_id = dev-s92
-# parallel_id = jagsdluw/dev92
+# parallel_id = jagsd/dev92
 # text = しかしながら、中心部の温度は、約5,000°Cである。
 1	しかしながら	然しながら	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ;ナガラ,然し;ながら,しかし;ながら,しかし;ながら,シカシ;ナガラ,;,;,シカシ;ナガラ,シカシナガラ,然しながら
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2208,7 +2208,7 @@
 
 # newdoc id = dev-s93
 # sent_id = dev-s93
-# parallel_id = jagsdluw/dev93
+# parallel_id = jagsd/dev93
 # text = 歯のかみ合わせを考えて治療をしてくれる歯科なので、満足のいく治療をしてもらえます。
 1	歯	歯	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハ,歯,歯,歯,ハ,,,ハ,ハ,歯
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2236,7 +2236,7 @@
 
 # newdoc id = dev-s94
 # sent_id = dev-s94
-# parallel_id = jagsdluw/dev94
+# parallel_id = jagsd/dev94
 # text = そして、寛永期以降の蝦夷地幕領化の中で「松前稼」と呼ばれた、蝦夷地への労働力移動が可能であり、飢餓期の困窮を一時的に回避することができた。
 1	そして	そして	CCONJ	接続詞	_	31	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2275,7 +2275,7 @@
 
 # newdoc id = dev-s95
 # sent_id = dev-s95
-# parallel_id = jagsdluw/dev95
+# parallel_id = jagsd/dev95
 # text = 建設中や計画中のラインがさらに8つあるという。
 1	建設中	建設中	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケンセツ;チュウ,建設;中,建設;中,建設;中,ケンセツ;チュー,;,;,ケンセツ;チュウ,ケンセツチュウ,建設中
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -2292,7 +2292,7 @@
 
 # newdoc id = dev-s96
 # sent_id = dev-s96
-# parallel_id = jagsdluw/dev96
+# parallel_id = jagsd/dev96
 # text = ぬーとぴあのシェアメイトは、優太を除きなんと全員女性。
 1	ぬーとぴあ	ぬーとぴあ	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヌートピア,ぬーとぴあ,ぬーとぴあ,ぬーとぴあ,ヌートピア,,,ヌートピア,ヌートピア,ぬーとぴあ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2308,7 +2308,7 @@
 
 # newdoc id = dev-s97
 # sent_id = dev-s97
-# parallel_id = jagsdluw/dev97
+# parallel_id = jagsd/dev97
 # text = 体育科2年2組所属の少年。
 1	体育科	体育科	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=タイイク;カ,体育;科,体育;科,体育;科,タイイク;カ,;,;,タイイク;カ,タイイクカ,体育科
 2	2年	2年	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ネン,二;年,2;年,2;年,ニ;ネン,;,;,ニ;ネン,ニネン,2年
@@ -2319,7 +2319,7 @@
 
 # newdoc id = dev-s98
 # sent_id = dev-s98
-# parallel_id = jagsdluw/dev98
+# parallel_id = jagsd/dev98
 # text = 誕生日用にホールケーキを予約してくれたのですが、これが美味!
 1	誕生日用	誕生日用	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タンジョウ;ヒ;ヨウ,誕生;日;用,誕生;日;用,誕生;日;用,タンジョー;ビ;ヨー,;;,;;,タンジョウ;ヒ;ヨウ,タンジョウビヨウ,誕生日用
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2338,7 +2338,7 @@
 
 # newdoc id = dev-s99
 # sent_id = dev-s99
-# parallel_id = jagsdluw/dev99
+# parallel_id = jagsd/dev99
 # text = 組内外から高い評価を受けていたやり手で、二代目海江田組では実質的な運営を担っていた。
 1	組内外	組内外	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クミ;ナイガイ,組;内外,組;内外,組;内外,クミ;ナイガイ,;,;,クミ;ナイガイ,クミナイガイ,組内外
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -2365,7 +2365,7 @@
 
 # newdoc id = dev-s100
 # sent_id = dev-s100
-# parallel_id = jagsdluw/dev100
+# parallel_id = jagsd/dev100
 # text = 実際はガセの情報だったのだが、レコードは自主回収となり、ナゴム閉社への決定打のひとつとなってしまう。
 1	実際	実際	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジッサイ,実際,実際,実際,ジッサイ,,,ジッサイ,ジッサイ,実際
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2396,7 +2396,7 @@
 
 # newdoc id = dev-s101
 # sent_id = dev-s101
-# parallel_id = jagsdluw/dev101
+# parallel_id = jagsd/dev101
 # text = HDCD対応デジフィルの殆ど全てのICでは必ず-1dB絞っているので、通常の音楽CD盤を再生したとき、そのD/A変換回路のフルスケールは用いられていないことになる。
 1	HDCD対応デジフィル	HDCD対応デジフィル	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エイチディーシーディー;タイオウ;デジ;フィル,ＨＤＣＤ;対応;デジ;フィル,HDCD;対応;デジ;フィル,HDCD;対応;デジ;フィル,エーチディーシーディー;タイオー;デジ;フィル,;;;,;;;,エイチディーシーディー;タイオウ;デジ;フィル,エイチディーシーディータイオウデジフィル,HDCD対応デジフィル
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2435,7 +2435,7 @@
 
 # newdoc id = dev-s102
 # sent_id = dev-s102
-# parallel_id = jagsdluw/dev102
+# parallel_id = jagsd/dev102
 # text = われわれの組織がつぶれれば良いと日共や権力が願望をもっても今のところ手を下す方法がない。
 1	われわれ	我々	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワレワレ,我々,われわれ,われわれ,ワレワレ,,,ワレワレ,ワレワレ,我々
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2466,7 +2466,7 @@
 
 # newdoc id = dev-s103
 # sent_id = dev-s103
-# parallel_id = jagsdluw/dev103
+# parallel_id = jagsd/dev103
 # text = 外に出るのは、産後1か月で始めたヨガのレッスンに通う程度。
 1	外	外	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソト,外,外,外,ソト,,,ソト,ソト,外
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2489,7 +2489,7 @@
 
 # newdoc id = dev-s104
 # sent_id = dev-s104
-# parallel_id = jagsdluw/dev104
+# parallel_id = jagsd/dev104
 # text = 来年の春、すぐ近くにある大きな公園で、子供たちと一緒に桜をみるのが、今からとても楽しみです。
 1	来年	来年	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ライネン,来年,来年,来年,ライネン,,,ライネン,ライネン,来年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2522,7 +2522,7 @@
 
 # newdoc id = dev-s105
 # sent_id = dev-s105
-# parallel_id = jagsdluw/dev105
+# parallel_id = jagsd/dev105
 # text = これは後に本居宣長によって、現在と同じような位置に訂正された。
 1	これ	此れ	PRON	代名詞	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2545,7 +2545,7 @@
 
 # newdoc id = dev-s106
 # sent_id = dev-s106
-# parallel_id = jagsdluw/dev106
+# parallel_id = jagsd/dev106
 # text = まんまとお店側の思惑にハマっている私でした。
 1	まんまと	まんまと	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マンマト,まんまと,まんまと,まんまと,マンマト,,,マンマト,マンマト,まんまと
 2	お店側	御店側	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセガワ,御;店側,お;店側,お;店側,オ;ミセガワ,;,;,オ;ミセガワ,オミセガワ,御店側
@@ -2561,7 +2561,7 @@
 
 # newdoc id = dev-s107
 # sent_id = dev-s107
-# parallel_id = jagsdluw/dev107
+# parallel_id = jagsd/dev107
 # text = 小規模の駅前広場を持つ。
 1	小規模	小規模	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウ;キボ,小;規模,小;規模,小;規模,ショー;キボ,;,;,ショウ;キボ,ショウキボ,小規模
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2572,7 +2572,7 @@
 
 # newdoc id = dev-s108
 # sent_id = dev-s108
-# parallel_id = jagsdluw/dev108
+# parallel_id = jagsd/dev108
 # text = 身長172cm、体重60kg。
 1	身長	身長	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=シンチョウ,身長,身長,身長,シンチョー,,,シンチョウ,シンチョウ,身長
 2	172cm	172cm	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ナナ;ニ;センチメートル,一;七;二;センチメートル,1;7;2;cm,1;7;2;cm,イチ;ナナ;ニ;センチメートル,;;;,;;;,イチ;ナナ;ニ;センチメートル,イチナナニセンチメートル,172cm
@@ -2583,7 +2583,7 @@
 
 # newdoc id = dev-s109
 # sent_id = dev-s109
-# parallel_id = jagsdluw/dev109
+# parallel_id = jagsd/dev109
 # text = 胸部は格納庫になっており、弾薬など物資を積むことが可能。
 1	胸部	胸部	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウブ,胸部,胸部,胸部,キョーブ,,,キョウブ,キョウブ,胸部
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2604,7 +2604,7 @@
 
 # newdoc id = dev-s110
 # sent_id = dev-s110
-# parallel_id = jagsdluw/dev110
+# parallel_id = jagsd/dev110
 # text = このような大型のゲル、大型のゲルを中心とした遊牧民の宮廷のことをふつうオルドと呼んでおり、モンゴル帝国のハーンたちは非常に大きなゲルをオルドとしていたことが知られる。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	よう	様	NOUN	形状詞-助動詞語幹	_	6	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=ヨウ,様,よう,よう,ヨー,,,ヨウ,ヨウ,様
@@ -2655,7 +2655,7 @@
 
 # newdoc id = dev-s111
 # sent_id = dev-s111
-# parallel_id = jagsdluw/dev111
+# parallel_id = jagsd/dev111
 # text = 2011年3月期にLED関連照明事業で22億円の売り上げを目指す。
 1	2011年	2011年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;イチ;ネン,二;ゼロ;一;一;年,2;0;1;1;年,2;0;1;1;年,ニ;ゼロ;イチ;イチ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;イチ;ネン,ニゼロイチイチネン,2011年
 2	3月期	3月期	NOUN	名詞-普通名詞-一般	_	10	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ガツ;キ,三;月;期,3;月;期,3;月;期,サン;ガツ;キ,;;,;;,サン;ガツ;キ,サンガツキ,3月期
@@ -2671,7 +2671,7 @@
 
 # newdoc id = dev-s112
 # sent_id = dev-s112
-# parallel_id = jagsdluw/dev112
+# parallel_id = jagsd/dev112
 # text = 1987年の第1回授賞式以来、この賞はアフリカ系アメリカ人のミュージシャンにとって、大変重要な存在となっている。
 1	1987年	1987年	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ハチ;シチ;ネン,一;九;八;七;年,1;9;8;7;年,1;9;8;7;年,イチ;キュー;ハチ;シチ;ネン,;;;;,;;;;,イチ;キュウ;ハチ;シチ;ネン,イチキュウハチシチネン,1987年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2696,7 +2696,7 @@
 
 # newdoc id = dev-s113
 # sent_id = dev-s113
-# parallel_id = jagsdluw/dev113
+# parallel_id = jagsd/dev113
 # text = また同小説では藍染になすりつけられた罪は、元柳斎の尽力もあって藍染の謀略が認められたことから鉄裁・夜一の罪状共々取り消しとなったこと、商店も尸魂界公認となった上、破面篇で喜助の存在が広く知れ渡った為、現世駐在任務の死神が多数訪れるように手が足りなくなりつつある程忙しくなっていることが語られている。
 1	また	又	CCONJ	接続詞	_	77	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	同小説	同小説	NOUN	名詞-普通名詞-一般	_	77	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;ショウセツ,同;小説,同;小説,同;小説,ドー;ショーセツ,;,;,ドウ;ショウセツ,ドウショウセツ,同小説
@@ -2781,7 +2781,7 @@
 
 # newdoc id = dev-s114
 # sent_id = dev-s114
-# parallel_id = jagsdluw/dev114
+# parallel_id = jagsd/dev114
 # text = また、未来の高度に進化した人工知能は本質的に自己書き換えを行うはずだと主張する者もいる。
 1	また	又	CCONJ	接続詞	_	22	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2809,7 +2809,7 @@
 
 # newdoc id = dev-s115
 # sent_id = dev-s115
-# parallel_id = jagsdluw/dev115
+# parallel_id = jagsd/dev115
 # text = 体表面は水にぬれても毛の根元は油分により撥水効果をもち、これにより野生動物などは厳しい環境の寒暖の変化から体内の恒常性を守っている。
 1	体表面	体表面	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイヒョウ;メン,体表;面,体表;面,体表;面,タイヒョー;メン,;,;,タイヒョウ;メン,タイヒョウメン,体表面
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2850,7 +2850,7 @@
 
 # newdoc id = dev-s116
 # sent_id = dev-s116
-# parallel_id = jagsdluw/dev116
+# parallel_id = jagsd/dev116
 # text = 形態としてはコンビニATMに類似している。
 1	形態	形態	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイタイ,形態,形態,形態,ケータイ,,,ケイタイ,ケイタイ,形態
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -2863,7 +2863,7 @@
 
 # newdoc id = dev-s117
 # sent_id = dev-s117
-# parallel_id = jagsdluw/dev117
+# parallel_id = jagsd/dev117
 # text = 生まれついて“針”を持っており、それが彼女の能力に反映されている。
 1	生まれつい	生まれ付く	VERB	動詞-一般-五段-カ行	_	7	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウマレツク,生まれ付く,生まれつい,生まれつく,ウマレツイ,,,ウマレツク,ウマレツク,生まれ付く
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -2887,7 +2887,7 @@
 
 # newdoc id = dev-s118
 # sent_id = dev-s118
-# parallel_id = jagsdluw/dev118
+# parallel_id = jagsd/dev118
 # text = 「CS 5」シリーズの中でもWebデザイナー向け製品である「Web Premium」に含まれるアプリケーションについての全体像と、それぞれの製品の役割について紹介していこう。
 1	「	「	PUNCT	補助記号-括弧開	_	4	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	CS 5	CS 5	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=シーエス;ファイブ,ＣＳ;ファイブ,CS;5,CS;5,シーエス;ファイブ,;,;,シーエス;ファイブ,シーエスファイブ,CS5
@@ -2923,7 +2923,7 @@
 
 # newdoc id = dev-s119
 # sent_id = dev-s119
-# parallel_id = jagsdluw/dev119
+# parallel_id = jagsd/dev119
 # text = 日本基督教団阿佐ヶ谷教会の牧師を務める。
 1	日本基督教団阿佐ヶ谷教会	日本基督教団阿佐ヶ谷教会	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン;キリスト;キョウダン;アサガヤ;キョウカイ,日本;キリスト;教団;アサガヤ;教会,日本;基督;教団;阿佐ヶ谷;教会,日本;基督;教団;阿佐ヶ谷;教会,ニホン;キリスト;キョーダン;アサガヤ;キョーカイ,;;;;,;;;;,ニホン;キリスト;キョウダン;アサガヤ;キョウカイ,ニホンキリストキョウダンアサガヤキョウカイ,日本基督教団阿佐ヶ谷教会
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2934,7 +2934,7 @@
 
 # newdoc id = dev-s120
 # sent_id = dev-s120
-# parallel_id = jagsdluw/dev120
+# parallel_id = jagsd/dev120
 # text = 405法廷,吉田被告は前回公判時の手錠に腰縄の姿とは異なり上下黒のスーツ姿で現れた。
 1	405法廷	405法廷	NOUN	名詞-普通名詞-一般	_	19	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨン;ゼロ;ゴ;ホウテイ,四;ゼロ;五;法廷,4;0;5;法廷,4;0;5;法廷,ヨン;ゼロ;ゴ;ホーテー,;;;,;;;,ヨン;ゼロ;ゴ;ホウテイ,ヨンゼロゴホウテイ,405法廷
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -2960,7 +2960,7 @@
 
 # newdoc id = dev-s121
 # sent_id = dev-s121
-# parallel_id = jagsdluw/dev121
+# parallel_id = jagsd/dev121
 # text = まず予選7位の#1 ポルシェが抜群のスタートを決め、オープニングラップのグランプリコースの間にトップに浮上。
 1	まず	先ず	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マズ,先ず,まず,まず,マズ,,,マズ,マズ,先ず
 2	予選	予選	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ヨセン,予選,予選,予選,ヨセン,,,ヨセン,ヨセン,予選
@@ -2988,7 +2988,7 @@
 
 # newdoc id = dev-s122
 # sent_id = dev-s122
-# parallel_id = jagsdluw/dev122
+# parallel_id = jagsd/dev122
 # text = バイオリン弓毛替をやっています。
 1	バイオリン弓毛替	バイオリン弓毛替え	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バイオリン;ユミゲ;カエ,バイオリン;弓毛;替え,バイオリン;弓毛;替,バイオリン;弓毛;替,バイオリン;ユミゲ;カエ,;;,;;,バイオリン;ユミゲ;カエ,バイオリンユミゲカエ,バイオリン弓毛替え
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -2999,7 +2999,7 @@
 
 # newdoc id = dev-s123
 # sent_id = dev-s123
-# parallel_id = jagsdluw/dev123
+# parallel_id = jagsd/dev123
 # text = 施設に宿泊した人もいたようです。
 1	施設	施設	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シセツ,施設,施設,施設,シセツ,,,シセツ,シセツ,施設
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3015,14 +3015,14 @@
 
 # newdoc id = dev-s124
 # sent_id = dev-s124
-# parallel_id = jagsdluw/dev124
+# parallel_id = jagsd/dev124
 # text = マダガスカル・コモロ。
 1	マダガスカル・コモロ	マダガスカル・コモロ	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=マダガスカル;;コモロ,マダガスカル;・;コモロ,マダガスカル;・;コモロ,マダガスカル;・;コモロ,マダガスカル;;コモロ,;;,;;,マダガスカル;;コモロ,マダガスカルコモロ,マダガスカル・コモロ
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s125
 # sent_id = dev-s125
-# parallel_id = jagsdluw/dev125
+# parallel_id = jagsd/dev125
 # text = どこまでも自分しかいない、底なしの孤独。
 1	どこ	何処	PRON	代名詞	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドコ,何処,どこ,どこ,ドコ,,,ドコ,ドコ,何処
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -3039,7 +3039,7 @@
 
 # newdoc id = dev-s126
 # sent_id = dev-s126
-# parallel_id = jagsdluw/dev126
+# parallel_id = jagsd/dev126
 # text = 低公害車はそれほど多くはないが、ハイブリッドバスやCNGバスが導入されている。
 1	低公害車	低公害車	NOUN	名詞-普通名詞-一般	_	7	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テイ;コウガイ;シャ,低;公害;車,低;公害;車,低;公害;車,テー;コーガイ;シャ,;;,;;,テイ;コウガイ;シャ,テイコウガイシャ,低公害車
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3061,7 +3061,7 @@
 
 # newdoc id = dev-s127
 # sent_id = dev-s127
-# parallel_id = jagsdluw/dev127
+# parallel_id = jagsd/dev127
 # text = 8月31日の今日行ってきました。
 1	8月	8月	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ハチ;ガツ,八;月,8;月,8;月,ハチ;ガツ,;,;,ハチ;ガツ,ハチガツ,8月
 2	31日	31日	NUM	名詞-数詞	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;イチ;ニチ,三;一;日,3;1;日,3;1;日,サン;イチ;ニチ,;;,;;,サン;イチ;ニチ,サンイチニチ,31日
@@ -3075,7 +3075,7 @@
 
 # newdoc id = dev-s128
 # sent_id = dev-s128
-# parallel_id = jagsdluw/dev128
+# parallel_id = jagsd/dev128
 # text = 初めて行ったお店でしたが、価格も出来も満足しています。
 1	初めて	初めて	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハジメテ,初めて,初めて,初めて,ハジメテ,,,ハジメテ,ハジメテ,初めて
 2	行っ	行く	VERB	動詞-一般-五段-カ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イク,行く,行っ,行く,イッ,,,イク,イク,行く
@@ -3096,7 +3096,7 @@
 
 # newdoc id = dev-s129
 # sent_id = dev-s129
-# parallel_id = jagsdluw/dev129
+# parallel_id = jagsd/dev129
 # text = 超長距離戦に特化している分、自分から近い所には攻撃できない。
 1	超長距離戦	超長距離戦	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウ;チョウ;キョリ;セン,超;長;距離;戦,超;長;距離;戦,超;長;距離;戦,チョー;チョー;キョリ;セン,;;;,;;;,チョウ;チョウ;キョリ;セン,チョウチョウキョリセン,超長距離戦
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3116,7 +3116,7 @@
 
 # newdoc id = dev-s130
 # sent_id = dev-s130
-# parallel_id = jagsdluw/dev130
+# parallel_id = jagsd/dev130
 # text = 1934年にトーキーに初出演。
 1	1934年	1934年	NUM	名詞-数詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;サン;ヨン;ネン,一;九;三;四;年,1;9;3;4;年,1;9;3;4;年,イチ;キュー;サン;ヨ;ネン,;;;;,;;;;,イチ;キュウ;サン;ヨ;ネン,イチキュウサンヨンネン,1934年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3127,7 +3127,7 @@
 
 # newdoc id = dev-s131
 # sent_id = dev-s131
-# parallel_id = jagsdluw/dev131
+# parallel_id = jagsd/dev131
 # text = 願いがあって来ている!
 1	願い	願い	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネガイ,願い,願い,願い,ネガイ,,,ネガイ,ネガイ,願い
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3139,7 +3139,7 @@
 
 # newdoc id = dev-s132
 # sent_id = dev-s132
-# parallel_id = jagsdluw/dev132
+# parallel_id = jagsd/dev132
 # text = 結婚11年目の夫浮気報道が持ち上がったとき、ヴィクトリアは彼を信じていたそうだが、寝も歯もないことを噂する世間に対し行き場のない怒りが湧き上がってきたのも事実だったそう。
 1	結婚	結婚	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ケッコン,結婚,結婚,結婚,ケッコン,,,ケッコン,ケッコン,結婚
 2	11年目	11年目	NUM	名詞-数詞	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;イチ;ネン;メ,一;一;年;目,1;1;年;目,1;1;年;目,イチ;イチ;ネン;メ,;;;,;;;,イチ;イチ;ネン;メ,イチイチネンメ,11年目
@@ -3189,7 +3189,7 @@
 
 # newdoc id = dev-s133
 # sent_id = dev-s133
-# parallel_id = jagsdluw/dev133
+# parallel_id = jagsd/dev133
 # text = まずは,1996年の教団本部移転が隆法氏による“霊言”に振り回されたという“ドタバタ劇”のお話。
 1	まず	先ず	ADV	副詞	_	22	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マズ,先ず,まず,まず,マズ,,,マズ,マズ,先ず
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3217,7 +3217,7 @@
 
 # newdoc id = dev-s134
 # sent_id = dev-s134
-# parallel_id = jagsdluw/dev134
+# parallel_id = jagsd/dev134
 # text = 一方ポリュネイケスの子テルサンドロスは戦争に勝利した後、トロイア戦争に参加したが、ギリシア軍は間違ってミューシアに上陸し、テーレポス王と戦争になった。
 1	一方	一方	CCONJ	接続詞	_	31	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	ポリュネイケス	ポリュネイケス	PROPN	名詞-固有名詞-人名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ポリュネイケース,ポリュネイケース,ポリュネイケス,ポリュネイケス,ポリュネーケス,,,ポリュネイケス,ポリュネイケス,ポリュネイケス
@@ -3255,7 +3255,7 @@
 
 # newdoc id = dev-s135
 # sent_id = dev-s135
-# parallel_id = jagsdluw/dev135
+# parallel_id = jagsd/dev135
 # text = 現在は主に飼育下繁殖個体が流通する。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	6	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3267,7 +3267,7 @@
 
 # newdoc id = dev-s136
 # sent_id = dev-s136
-# parallel_id = jagsdluw/dev136
+# parallel_id = jagsd/dev136
 # text = 靴屋の父は、マックスが5歳の時に家族を捨て、マックスはパンや新聞の配達で家計を助けた。
 1	靴屋	靴屋	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クツヤ,靴屋,靴屋,靴屋,クツヤ,,,クツヤ,クツヤ,靴屋
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3300,7 +3300,7 @@
 
 # newdoc id = dev-s137
 # sent_id = dev-s137
-# parallel_id = jagsdluw/dev137
+# parallel_id = jagsd/dev137
 # text = 全員起立して迎える。
 1	全員	全員	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼンイン,全員,全員,全員,ゼンイン,,,ゼンイン,ゼンイン,全員
 2	起立し	起立する	VERB	動詞-一般-サ行変格	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キリツ;スル,起立;為る,起立;し,起立;する,キリツ;シ,;,;,キリツ;スル,キリツスル,起立する
@@ -3310,7 +3310,7 @@
 
 # newdoc id = dev-s138
 # sent_id = dev-s138
-# parallel_id = jagsdluw/dev138
+# parallel_id = jagsd/dev138
 # text = 大学で学生に教えていた経験からか人当たりも柔らかく実直な人物である。
 1	大学	大学	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイガク,大学,大学,大学,ダイガク,,,ダイガク,ダイガク,大学
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3333,7 +3333,7 @@
 
 # newdoc id = dev-s139
 # sent_id = dev-s139
-# parallel_id = jagsdluw/dev139
+# parallel_id = jagsd/dev139
 # text = 今日はランチにお刺身が食べたかったので、前々から気になっていたこちらにお邪魔しました。
 1	今日	今日	NOUN	名詞-普通名詞-一般	_	7	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウ,今日,今日,今日,キョー,,,キョウ,キョウ,今日
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3362,7 +3362,7 @@
 
 # newdoc id = dev-s140
 # sent_id = dev-s140
-# parallel_id = jagsdluw/dev140
+# parallel_id = jagsd/dev140
 # text = 微塵の良さもない!
 1	微塵	微塵	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミジン,微塵,微塵,微塵,ミジン,,,ミジン,ミジン,微塵
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3373,7 +3373,7 @@
 
 # newdoc id = dev-s141
 # sent_id = dev-s141
-# parallel_id = jagsdluw/dev141
+# parallel_id = jagsd/dev141
 # text = 説明も丁寧で分かりやすく、対応もとっても良かったです。
 1	説明	説明	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セツメイ,説明,説明,説明,セツメー,,,セツメイ,セツメイ,説明
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -3391,7 +3391,7 @@
 
 # newdoc id = dev-s142
 # sent_id = dev-s142
-# parallel_id = jagsdluw/dev142
+# parallel_id = jagsd/dev142
 # text = そこに当事者意識が生まれ,社会が実際に動いていく。
 1	そこ	其処	PRON	代名詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソコ,其処,そこ,そこ,ソコ,,,ソコ,ソコ,其処
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3409,7 +3409,7 @@
 
 # newdoc id = dev-s143
 # sent_id = dev-s143
-# parallel_id = jagsdluw/dev143
+# parallel_id = jagsd/dev143
 # text = 場所は多少わかりづらいんですけど、感じのいいところでした
 1	場所	場所	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バショ,場所,場所,場所,バショ,,,バショ,バショ,場所
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3427,7 +3427,7 @@
 
 # newdoc id = dev-s144
 # sent_id = dev-s144
-# parallel_id = jagsdluw/dev144
+# parallel_id = jagsd/dev144
 # text = 駅から遠く、お酒を楽しむには不便なリッチなのが最大のネックですが、ドライバーを一人連れてでも行きたいお店です☆
 1	駅	駅	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エキ,駅,駅,駅,エキ,,,エキ,エキ,駅
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -3465,7 +3465,7 @@
 
 # newdoc id = dev-s145
 # sent_id = dev-s145
-# parallel_id = jagsdluw/dev145
+# parallel_id = jagsd/dev145
 # text = そのため、三菱の携帯電話には、アニメっちゃのメール用画像素材やアプリがいくつか添付されている。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ため	為	NOUN	名詞-普通名詞-一般	_	18	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タメ,為,ため,ため,タメ,,,タメ,タメ,為
@@ -3491,7 +3491,7 @@
 
 # newdoc id = dev-s146
 # sent_id = dev-s146
-# parallel_id = jagsdluw/dev146
+# parallel_id = jagsd/dev146
 # text = 興行収入は32億円。
 1	興行収入	興行収入	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウギョウ;シュウニュウ,興行;収入,興行;収入,興行;収入,コーギョー;シューニュー,;,;,コウギョウ;シュウニュウ,コウギョウシュウニュウ,興行収入
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3500,7 +3500,7 @@
 
 # newdoc id = dev-s147
 # sent_id = dev-s147
-# parallel_id = jagsdluw/dev147
+# parallel_id = jagsd/dev147
 # text = 多くの欠陥を抱えていたため生産数は100門と少なく、短い期間運用されたM7 プリーストやセクストンに置き換えられる形で一線から退いた。
 1	多く	多く	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオク,多く,多く,多く,オーク,,,オオク,オオク,多く
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3537,7 +3537,7 @@
 
 # newdoc id = dev-s148
 # sent_id = dev-s148
-# parallel_id = jagsdluw/dev148
+# parallel_id = jagsd/dev148
 # text = 本気で譲ってほしいという人はいるのかしらん?
 1	本気	本気	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンキ,本気,本気,本気,ホンキ,,,ホンキ,ホンキ,本気
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -3553,7 +3553,7 @@
 
 # newdoc id = dev-s149
 # sent_id = dev-s149
-# parallel_id = jagsdluw/dev149
+# parallel_id = jagsd/dev149
 # text = この会が“家系のおはなし”なる講演会を毎月公共施設で開いているとの情報が潜入取材を敢行した。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	会	会	NOUN	名詞-普通名詞-一般	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイ,会,会,会,カイ,,,カイ,カイ,会
@@ -3583,7 +3583,7 @@
 
 # newdoc id = dev-s150
 # sent_id = dev-s150
-# parallel_id = jagsdluw/dev150
+# parallel_id = jagsd/dev150
 # text = 横浜市近辺で英会話を習いたいという人にはかなりいいのではないでしょうか?
 1	横浜市近辺	横浜市近辺	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨコハマ;シ;キンペン,ヨコハマ;市;近辺,横浜;市;近辺,横浜;市;近辺,ヨコハマ;シ;キンペン,;;,;;,ヨコハマ;シ;キンペン,ヨコハマシキンペン,横浜市近辺
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3604,7 +3604,7 @@
 
 # newdoc id = dev-s151
 # sent_id = dev-s151
-# parallel_id = jagsdluw/dev151
+# parallel_id = jagsd/dev151
 # text = 青雉に助けられた。
 1	青雉	青雉	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アオキジ,青雉,青雉,青雉,アオキジ,,,アオキジ,アオキジ,青雉
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3615,7 +3615,7 @@
 
 # newdoc id = dev-s152
 # sent_id = dev-s152
-# parallel_id = jagsdluw/dev152
+# parallel_id = jagsd/dev152
 # text = 一方,淑徳大学に飯田氏を紹介したコンサルタントは,自団体のウェブサイトなどから飯田氏関連の記述を削除。
 1	一方	一方	CCONJ	接続詞	_	21	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -3642,7 +3642,7 @@
 
 # newdoc id = dev-s153
 # sent_id = dev-s153
-# parallel_id = jagsdluw/dev153
+# parallel_id = jagsd/dev153
 # text = JTによると、廃作の募集は2004年に続いて2度目。
 1	JT	JT	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェーティー,ＪＴ,JT,JT,ジェーティー,,,ジェーティー,ジェーティー,JT
 2	によると	によると	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;ト,に;因る;と,に;よる;と,に;よる;と,ニ;ヨル;ト,;;,;;,ニ;ヨル;ト,ニヨルト,によると
@@ -3660,7 +3660,7 @@
 
 # newdoc id = dev-s154
 # sent_id = dev-s154
-# parallel_id = jagsdluw/dev154
+# parallel_id = jagsd/dev154
 # text = 従来の同社製より素材の伸長率が35%向上し、着脱しやすくなったという。
 1	従来	従来	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウライ,従来,従来,従来,ジューライ,,,ジュウライ,ジュウライ,従来
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3682,7 +3682,7 @@
 
 # newdoc id = dev-s155
 # sent_id = dev-s155
-# parallel_id = jagsdluw/dev155
+# parallel_id = jagsd/dev155
 # text = 球状星団としてはまばらな方で、口径20cm程度の望遠鏡で周辺部は完全に分離でき、口径30cmでは中心部まで分離できる。
 1	球状星団	球状星団	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウジョウ;セイダン,球状;星団,球状;星団,球状;星団,キュージョー;セーダン,;,;,キュウジョウ;セイダン,キュウジョウセイダン,球状星団
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -3714,7 +3714,7 @@
 
 # newdoc id = dev-s156
 # sent_id = dev-s156
-# parallel_id = jagsdluw/dev156
+# parallel_id = jagsd/dev156
 # text = 窓側の席で若い女性が信者から入会を強く勧められている様子が確認できた。
 1	窓側	窓側	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マドガワ,窓側,窓側,窓側,マドガワ,,,マドガワ,マドガワ,窓側
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3739,7 +3739,7 @@
 
 # newdoc id = dev-s157
 # sent_id = dev-s157
-# parallel_id = jagsdluw/dev157
+# parallel_id = jagsd/dev157
 # text = 山田が新作小説を発表しなくなってから、忍法帖シリーズに比べて正当に評価されていたとは言い難い作品群の再評価が始まった。
 1	山田	山田	PROPN	名詞-固有名詞-人名-姓	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤマダ,ヤマダ,山田,山田,ヤマダ,,,ヤマダ,ヤマダ,山田
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3774,7 +3774,7 @@
 
 # newdoc id = dev-s158
 # sent_id = dev-s158
-# parallel_id = jagsdluw/dev158
+# parallel_id = jagsd/dev158
 # text = その呼びかけに共感した淡井真紀、田中リタ、高原零、板倉あやのが秘密のアジトに集結した。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	呼びかけ	呼び掛け	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨビカケ,呼び掛け,呼びかけ,呼びかけ,ヨビカケ,,,ヨビカケ,ヨビカケ,呼び掛け
@@ -3799,7 +3799,7 @@
 
 # newdoc id = dev-s159
 # sent_id = dev-s159
-# parallel_id = jagsdluw/dev159
+# parallel_id = jagsd/dev159
 # text = 下記に主な代表作を記述する。
 1	下記	下記	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カキ,下記,下記,下記,カキ,,,カキ,カキ,下記
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3811,7 +3811,7 @@
 
 # newdoc id = dev-s160
 # sent_id = dev-s160
-# parallel_id = jagsdluw/dev160
+# parallel_id = jagsd/dev160
 # text = 憑いている“虫”は巨大ムカデ。
 1	憑い	付く	VERB	動詞-一般-五段-カ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツク,付く,憑い,憑く,ツイ,,,ツク,ツク,付く
 2	ている	ている	AUX	助動詞-上一段-ア行	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ;イル,て;居る,て;いる,て;いる,テ;イル,;,;,テ;イル,テイル,ている
@@ -3824,7 +3824,7 @@
 
 # newdoc id = dev-s161
 # sent_id = dev-s161
-# parallel_id = jagsdluw/dev161
+# parallel_id = jagsd/dev161
 # text = 現役時のポジションはゴールキーパー。
 1	現役時	現役時	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンエキ;ジ,現役;時,現役;時,現役;時,ゲンエキ;ジ,;,;,ゲンエキ;ジ,ゲンエキジ,現役時
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3835,7 +3835,7 @@
 
 # newdoc id = dev-s162
 # sent_id = dev-s162
-# parallel_id = jagsdluw/dev162
+# parallel_id = jagsd/dev162
 # text = この時代から、日本列島に人類が住んだ遺跡や遺物が多く発見されている。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	時代	時代	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジダイ,時代,時代,時代,ジダイ,,,ジダイ,ジダイ,時代
@@ -3859,7 +3859,7 @@
 
 # newdoc id = dev-s163
 # sent_id = dev-s163
-# parallel_id = jagsdluw/dev163
+# parallel_id = jagsd/dev163
 # text = 高橋由美子さんは創刊した1990年から登場。
 1	高橋由美子さん	高橋由美子さん	PROPN	名詞-固有名詞-人名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タカハシ;ユミコ;サン,タカハシ;ユミコ;さん,高橋;由美子;さん,高橋;由美子;さん,タカハシ;ユミコ;サン,;;,;;,タカハシ;ユミコ;サン,タカハシユミコサン,高橋由美子さん
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3872,7 +3872,7 @@
 
 # newdoc id = dev-s164
 # sent_id = dev-s164
-# parallel_id = jagsdluw/dev164
+# parallel_id = jagsd/dev164
 # text = クイズを行う場所や形式の関係上、早押しテーブルを設置することが困難な場合は、早押しボタンのボックスを挑戦者の手に持たせてクイズを行った。
 1	クイズ	クイズ	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クイズ,クイズ,クイズ,クイズ,クイズ,,,クイズ,クイズ,クイズ
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -3912,7 +3912,7 @@
 
 # newdoc id = dev-s165
 # sent_id = dev-s165
-# parallel_id = jagsdluw/dev165
+# parallel_id = jagsd/dev165
 # text = 一方、8市町以外で放射線量が高い場所が見つかった場合も、面積が広い場合には「国との協議で検討」し、局所的なら「補助金などの対象外」との認識が示された。
 1	一方	一方	CCONJ	接続詞	_	41	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3961,7 +3961,7 @@
 
 # newdoc id = dev-s167
 # sent_id = dev-s167
-# parallel_id = jagsdluw/dev167
+# parallel_id = jagsd/dev167
 # text = 先日はありがとうございました。部下はヘビーナイトとバッティ、ブルームハッター、トライデントナイト。
 1	先日	先日	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センジツ,先日,先日,先日,センジツ,,,センジツ,センジツ,先日
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3983,7 +3983,7 @@
 
 # newdoc id = dev-s168
 # sent_id = dev-s168
-# parallel_id = jagsdluw/dev168
+# parallel_id = jagsd/dev168
 # text = レジにて受け取る「プリペイド番号通知票」のQRコードより携帯サイトにログイン。
 1	レジ	レジ	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レジ,レジ,レジ,レジ,レジ,,,レジ,レジ,レジ
 2	にて	にて	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニテ,にて,にて,にて,ニテ,,,ニテ,ニテ,にて
@@ -4001,7 +4001,7 @@
 
 # newdoc id = dev-s169
 # sent_id = dev-s169
-# parallel_id = jagsdluw/dev169
+# parallel_id = jagsd/dev169
 # text = 通信教育で挫折したので資格までとれるのか心配でしたが、無事合格し、仕事も決まりました!
 1	通信教育	通信教育	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツウシン;キョウイク,通信;教育,通信;教育,通信;教育,ツーシン;キョーイク,;,;,ツウシン;キョウイク,ツウシンキョウイク,通信教育
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -4030,7 +4030,7 @@
 
 # newdoc id = dev-s170
 # sent_id = dev-s170
-# parallel_id = jagsdluw/dev170
+# parallel_id = jagsd/dev170
 # text = 試読もできます!
 1	試読	試読	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シドク,試読,試読,試読,シドク,,,シドク,シドク,試読
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4040,7 +4040,7 @@
 
 # newdoc id = dev-s171
 # sent_id = dev-s171
-# parallel_id = jagsdluw/dev171
+# parallel_id = jagsd/dev171
 # text = 南アフリカで開かれるサッカーのワールドカップに合わせて、旅行会社では日本代表の試合を観戦するツアーを販売していますが、現地の治安が悪いことなどを理由に参加を見送るサポーターも多く、開幕まであと6日に迫った今もツアーが売れ残る状況が続いています。
 1	南アフリカ	南アフリカ	PROPN	名詞-固有名詞-地名-国	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミナミアフリカ,南アフリカ,南アフリカ,南アフリカ,ミナミアフリカ,,,ミナミアフリカ,ミナミアフリカ,南アフリカ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -4106,7 +4106,7 @@
 
 # newdoc id = dev-s172
 # sent_id = dev-s172
-# parallel_id = jagsdluw/dev172
+# parallel_id = jagsd/dev172
 # text = 一方、BOφWY、JUDY AND MARYなど人気バンドが解散していくなかで、こうしたバンドのファンが新たにコピーバンドを結成するケースも目立つように各地で活動を継続している。
 1	一方	一方	CCONJ	接続詞	_	35	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4148,7 +4148,7 @@
 
 # newdoc id = dev-s173
 # sent_id = dev-s173
-# parallel_id = jagsdluw/dev173
+# parallel_id = jagsd/dev173
 # text = 診察をしながらささっと診察データを書き込んでいるようなので、患者と患者の待ち時間は少ないように思います。
 1	診察	診察	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンサツ,診察,診察,診察,シンサツ,,,シンサツ,シンサツ,診察
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4179,7 +4179,7 @@
 
 # newdoc id = dev-s174
 # sent_id = dev-s174
-# parallel_id = jagsdluw/dev174
+# parallel_id = jagsd/dev174
 # text = 10年W杯南アフリカ大会後の昨夏も獲得に動いたAマドリードが、ここに来て再び獲得に乗り出していることが判明。
 1	10年	10年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ジュウ;ネン,十;年,10;年,10;年,ジュー;ネン,;,;,ジュウ;ネン,ジュウネン,10年
 2	W杯南アフリカ大会後	W杯南アフリカ大会後	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダブリュー;ハイ;ミナミアフリカ;タイカイ;ゴ,Ｗ;杯;南アフリカ;大会;後,W;杯;南アフリカ;大会;後,W;杯;南アフリカ;大会;後,ダブリュー;ハイ;ミナミアフリカ;タイカイ;ゴ,;;;;,;;;;,ダブリュー;ハイ;ミナミアフリカ;タイカイ;ゴ,ダブリューハイミナミアフリカタイカイゴ,W杯南アフリカ大会後
@@ -4209,7 +4209,7 @@
 
 # newdoc id = dev-s175
 # sent_id = dev-s175
-# parallel_id = jagsdluw/dev175
+# parallel_id = jagsd/dev175
 # text = この選考について労働基準法違反に抵触する疑いがあるとして、厚生労働省が調査を開始した。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	選考	選考	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センコウ,選考,選考,選考,センコー,,,センコウ,センコウ,選考
@@ -4234,7 +4234,7 @@
 
 # newdoc id = dev-s176
 # sent_id = dev-s176
-# parallel_id = jagsdluw/dev176
+# parallel_id = jagsd/dev176
 # text = 広大で対象となる亡者も多いため政令指定地獄となっているが、亡者は地表に落ちるまで2000年落下し続けるため実際に服役する数はそれほどでもなく、仕事自体はまだヒマな方である。
 1	広大	広大	ADJ	形状詞-一般	_	8	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウダイ,広大,広大,広大,コーダイ,,,コウダイ,コウダイ,広大
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -4282,7 +4282,7 @@
 
 # newdoc id = dev-s177
 # sent_id = dev-s177
-# parallel_id = jagsdluw/dev177
+# parallel_id = jagsd/dev177
 # text = 内容は、下表の通り。
 1	内容	内容	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナイヨウ,内容,内容,内容,ナイヨー,,,ナイヨウ,ナイヨウ,内容
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4294,7 +4294,7 @@
 
 # newdoc id = dev-s178
 # sent_id = dev-s178
-# parallel_id = jagsdluw/dev178
+# parallel_id = jagsd/dev178
 # text = 冷戦中だったため、西側の状況は国家にとっても国民にとっても指標であったが、東ドイツは西ドイツの経済成長の速度に、端から追いついておらず、このことは国民を怒らせた。
 1	冷戦中	冷戦中	NOUN	名詞-普通名詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レイセン;チュウ,冷戦;中,冷戦;中,冷戦;中,レーセン;チュー,;,;,レイセン;チュウ,レイセンチュウ,冷戦中
 2	だっ	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だっ,だ,ダッ,,,ダ,ダ,だ
@@ -4343,7 +4343,7 @@
 
 # newdoc id = dev-s179
 # sent_id = dev-s179
-# parallel_id = jagsdluw/dev179
+# parallel_id = jagsd/dev179
 # text = ジェボムの俳優および歌手活動など、芸能活動全般を支援する見通しだ。
 1	ジェボム	ジェボム	PROPN	名詞-固有名詞-人名-一般	_	8	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェボム,ジェボム,ジェボム,ジェボム,ジェボム,,,ジェボム,ジェボム,ジェボム
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4361,7 +4361,7 @@
 
 # newdoc id = dev-s180
 # sent_id = dev-s180
-# parallel_id = jagsdluw/dev180
+# parallel_id = jagsd/dev180
 # text = 美声ではないのに演歌の心というか魂の叫びというか、とにかくこちらにズシーンと響いてくるような歌唱力の持ち主だった。
 1	美声	美声	NOUN	名詞-普通名詞-一般	_	29	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビセイ,美声,美声,美声,ビセー,,,ビセイ,ビセイ,美声
 2	ではない	ではない	AUX	助動詞-形容詞	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ;ハ;ナイ,だ;は;無い,で;は;ない,だ;は;ない,デ;ワ;ナイ,;;,;;,ダ;ハ;ナイ,デハナイ,ではない
@@ -4398,7 +4398,7 @@
 
 # newdoc id = dev-s181
 # sent_id = dev-s181
-# parallel_id = jagsdluw/dev181
+# parallel_id = jagsd/dev181
 # text = ネバダとは「雪に覆われた」という意味であり、地域の雪を冠した山々を指すものだった。
 1	ネバダ	ネバダ	PROPN	名詞-固有名詞-地名-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネバダ,ネバダ,ネバダ,ネバダ,ネバダ,,,ネバダ,ネバダ,ネバダ
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -4430,7 +4430,7 @@
 
 # newdoc id = dev-s182
 # sent_id = dev-s182
-# parallel_id = jagsdluw/dev182
+# parallel_id = jagsd/dev182
 # text = ホテル・コルテシア東京で挙式予定の客。
 1	ホテル・コルテシア東京	ホテル・コルテシア東京	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホテル;;コルテシア;トウキョウ,ホテル;・;コルテシア;トウキョウ,ホテル;・;コルテシア;東京,ホテル;・;コルテシア;東京,ホテル;;コルテシア;トーキョー,;;;,;;;,ホテル;;コルテシア;トウキョウ,ホテルコルテシアトウキョウ,ホテル・コルテシア東京
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -4441,7 +4441,7 @@
 
 # newdoc id = dev-s183
 # sent_id = dev-s183
-# parallel_id = jagsdluw/dev183
+# parallel_id = jagsd/dev183
 # text = サクラも動員されていたようだ。
 1	サクラ	桜	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクラ,桜,サクラ,サクラ,サクラ,,,サクラ,サクラ,桜
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4455,7 +4455,7 @@
 
 # newdoc id = dev-s184
 # sent_id = dev-s184
-# parallel_id = jagsdluw/dev184
+# parallel_id = jagsd/dev184
 # text = せまい待合室の受付で、症状を口頭で言わされました。
 1	せまい	狭い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セマイ,狭い,せまい,せまい,セマイ,,,セマイ,セマイ,狭い
 2	待合室	待ち合い室	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マチアイ;シツ,待ち合い;室,待合;室,待合;室,マチアイ;シツ,;,;,マチアイ;シツ,マチアイシツ,待ち合い室
@@ -4475,7 +4475,7 @@
 
 # newdoc id = dev-s185
 # sent_id = dev-s185
-# parallel_id = jagsdluw/dev185
+# parallel_id = jagsd/dev185
 # text = KGBの文書には、死因は「動脈硬化に伴う循環器疾患」と記録されている。
 1	KGB	KGB	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケージービー,ＫＧＢ,KGB,KGB,ケージービー,,,ケージービー,ケージービー,KGB
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4499,7 +4499,7 @@
 
 # newdoc id = dev-s186
 # sent_id = dev-s186
-# parallel_id = jagsdluw/dev186
+# parallel_id = jagsd/dev186
 # text = FBIがポールセンを追い始めた時、彼は逃亡者として地下に潜っていた。
 1	FBI	FBI	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エフビーアイ,ＦＢＩ,FBI,FBI,エフビーアイ,,,エフビーアイ,エフビーアイ,FBI
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4522,7 +4522,7 @@
 
 # newdoc id = dev-s187
 # sent_id = dev-s187
-# parallel_id = jagsdluw/dev187
+# parallel_id = jagsd/dev187
 # text = 再装填は人力である。
 1	再装填	再装填	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイ;ソウテン,再;装填,再;装填,再;装填,サイ;ソーテン,;,;,サイ;ソウテン,サイソウテン,再装填
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4532,7 +4532,7 @@
 
 # newdoc id = dev-s188
 # sent_id = dev-s188
-# parallel_id = jagsdluw/dev188
+# parallel_id = jagsd/dev188
 # text = スタッフの方やお店の雰囲気良かったです。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフ,スタッフ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4548,7 +4548,7 @@
 
 # newdoc id = dev-s189
 # sent_id = dev-s189
-# parallel_id = jagsdluw/dev189
+# parallel_id = jagsd/dev189
 # text = 現代でもイランやパキスタンではこのナスタアリーク体が使われているようです。
 1	現代	現代	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンダイ,現代,現代,現代,ゲンダイ,,,ゲンダイ,ゲンダイ,現代
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -4570,7 +4570,7 @@
 
 # newdoc id = dev-s190
 # sent_id = dev-s190
-# parallel_id = jagsdluw/dev190
+# parallel_id = jagsd/dev190
 # text = 市政委員会が火薬は植民地の財産であり、イギリス国王のものではないと主張して、火薬の返還を要求した。
 1	市政委員会	市政委員会	NOUN	名詞-普通名詞-一般	_	22	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シセイ;イイン;カイ,市政;委員;会,市政;委員;会,市政;委員;会,シセー;イイン;カイ,;;,;;,シセイ;イイン;カイ,シセイイインカイ,市政委員会
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4599,7 +4599,7 @@
 
 # newdoc id = dev-s191
 # sent_id = dev-s191
-# parallel_id = jagsdluw/dev191
+# parallel_id = jagsd/dev191
 # text = 薬の事全然わかりませんでしたが、丁寧に案内してもらい、買いたい物が買えました。
 1	薬	薬	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クスリ,薬,薬,薬,クスリ,,,クスリ,クスリ,薬
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4628,7 +4628,7 @@
 
 # newdoc id = dev-s192
 # sent_id = dev-s192
-# parallel_id = jagsdluw/dev192
+# parallel_id = jagsd/dev192
 # text = だから,日本が軍備をしちゃいかんというんだったら,もう自衛隊なんてやめてまえ。
 1	だから	だから	CCONJ	接続詞	_	19	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;カラ,だ;から,だ;から,だ;から,ダ;カラ,;,;,ダ;カラ,ダカラ,だから
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -4654,7 +4654,7 @@
 
 # newdoc id = dev-s193
 # sent_id = dev-s193
-# parallel_id = jagsdluw/dev193
+# parallel_id = jagsd/dev193
 # text = なお、町田修は「店長くん」として同社のキャラクターとなっている。
 1	なお	猶	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4674,7 +4674,7 @@
 
 # newdoc id = dev-s194
 # sent_id = dev-s194
-# parallel_id = jagsdluw/dev194
+# parallel_id = jagsd/dev194
 # text = NBAのコーチの中には試合中に大きな声や身振り手振りで選手に指示をする者も多いが、スコットは腕組みをしたまま寡黙に試合の行方を見守る。
 1	NBA	NBA	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エヌビーエー,ＮＢＡ,NBA,NBA,エヌビーエー,,,エヌビーエー,エヌビーエー,NBA
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4718,7 +4718,7 @@
 
 # newdoc id = dev-s195
 # sent_id = dev-s195
-# parallel_id = jagsdluw/dev195
+# parallel_id = jagsd/dev195
 # text = 設立は1965年。
 1	設立	設立	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セツリツ,設立,設立,設立,セツリツ,,,セツリツ,セツリツ,設立
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4727,7 +4727,7 @@
 
 # newdoc id = dev-s196
 # sent_id = dev-s196
-# parallel_id = jagsdluw/dev196
+# parallel_id = jagsd/dev196
 # text = 彼女の存在は、ゲーテのほかシラー、ヘルダーなど同時代のヴァイマルの文人たちに大きな影響を与えた。
 1	彼女	彼女	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カノジョ,彼女,彼女,彼女,カノジョ,,,カノジョ,カノジョ,彼女
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4756,7 +4756,7 @@
 
 # newdoc id = dev-s197
 # sent_id = dev-s197
-# parallel_id = jagsdluw/dev197
+# parallel_id = jagsd/dev197
 # text = 2500円のコースで、私はお肉・相方がお魚を選びました。
 1	2500円	2500円	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゴ;ゼロ;ゼロ;エン,二;五;ゼロ;ゼロ;円,2;5;0;0;円,2;5;0;0;円,ニ;ゴ;ゼロ;ゼロ;エン,;;;;,;;;;,ニ;ゴ;ゼロ;ゼロ;エン,ニゴゼロゼロエン,2500円
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4778,7 +4778,7 @@
 
 # newdoc id = dev-s198
 # sent_id = dev-s198
-# parallel_id = jagsdluw/dev198
+# parallel_id = jagsd/dev198
 # text = そのため人間界での舞台は里帰りのみとなる。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ため	為	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タメ,為,ため,ため,タメ,,,タメ,タメ,為
@@ -4795,14 +4795,14 @@
 
 # newdoc id = dev-s199
 # sent_id = dev-s199
-# parallel_id = jagsdluw/dev199
+# parallel_id = jagsd/dev199
 # text = ヴァイオリニスト。
 1	ヴァイオリニスト	バイオリニスト	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=バイオリニスト,バイオリニスト,ヴァイオリニスト,ヴァイオリニスト,バイオリニスト,,,バイオリニスト,バイオリニスト,バイオリニスト
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s200
 # sent_id = dev-s200
-# parallel_id = jagsdluw/dev200
+# parallel_id = jagsd/dev200
 # text = 他の軍団員と違ってシュララ軍団から足を洗いたいと思っており、登場目的はケロロ小隊に捕らえられた兄を救うことであった。
 1	他	他	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,他,他,ホカ,,,ホカ,ホカ,他
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4837,7 +4837,7 @@
 
 # newdoc id = dev-s201
 # sent_id = dev-s201
-# parallel_id = jagsdluw/dev201
+# parallel_id = jagsd/dev201
 # text = *1902年-ドイツ選手権がスタート。
 1	*	*	PUNCT	補助記号-一般	_	6	punct	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=,＊,*,*,,,,,,＊
 2	1902年	1902年	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;ゼロ;ニ;ネン,一;九;ゼロ;二;年,1;9;0;2;年,1;9;0;2;年,イチ;キュー;ゼロ;ニ;ネン,;;;;,;;;;,イチ;キュウ;ゼロ;ニ;ネン,イチキュウゼロニネン,1902年
@@ -4849,7 +4849,7 @@
 
 # newdoc id = dev-s202
 # sent_id = dev-s202
-# parallel_id = jagsdluw/dev202
+# parallel_id = jagsd/dev202
 # text = 週に3回は行ってます。
 1	週	週	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウ,週,週,週,シュー,,,シュウ,シュウ,週
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4862,7 +4862,7 @@
 
 # newdoc id = dev-s203
 # sent_id = dev-s203
-# parallel_id = jagsdluw/dev203
+# parallel_id = jagsd/dev203
 # text = ノンビリキング十三世の部屋。
 1	ノンビリキング	のんびりキング	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ノンビリ;キング,のんびり;キング,ノンビリ;キング,ノンビリ;キング,ノンビリ;キング,;,;,ノンビリ;キング,ノンビリキング,のんびりキング
 2	十三世	十三世	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウ;サン;セイ,十;三;世,十;三;世,十;三;世,ジュー;サン;セー,;;,;;,ジュウ;サン;セイ,ジュウサンセイ,十三世
@@ -4872,7 +4872,7 @@
 
 # newdoc id = dev-s204
 # sent_id = dev-s204
-# parallel_id = jagsdluw/dev204
+# parallel_id = jagsd/dev204
 # text = 現在、その名称はアトレティコの下部組織の名前として残っている。
 1	現在	現在	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4891,7 +4891,7 @@
 
 # newdoc id = dev-s205
 # sent_id = dev-s205
-# parallel_id = jagsdluw/dev205
+# parallel_id = jagsd/dev205
 # text = 特に六代目尾上梅幸を相方とした演目は名高い。
 1	特に	特に	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トクニ,特に,特に,特に,トクニ,,,トクニ,トクニ,特に
 2	六代目尾上梅幸	六代目尾上梅幸	PROPN	名詞-固有名詞-人名-一般	_	6	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ロク;ダイ;メ;オノエ;バイコウ,六;代;目;オノエ;バイコウ,六;代;目;尾上;梅幸,六;代;目;尾上;梅幸,ロク;ダイ;メ;オノエ;バイコー,;;;;,;;;;,ロク;ダイ;メ;オノエ;バイコウ,ロクダイメオノエバイコウ,六代目尾上梅幸
@@ -4907,7 +4907,7 @@
 
 # newdoc id = dev-s206
 # sent_id = dev-s206
-# parallel_id = jagsdluw/dev206
+# parallel_id = jagsd/dev206
 # text = 東日本大震災をきっかけに東京電力福島第1原発の危機的な状況が続いている。
 1	東日本大震災	東日本大震災	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒガシ;ニッポン;ダイ;シンサイ,東;日本;大;震災,東;日本;大;震災,東;日本;大;震災,ヒガシ;ニホン;ダイ;シンサイ,;;;,;;;,ヒガシ;ニホン;ダイ;シンサイ,ヒガシニホンダイシンサイ,東日本大震災
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4925,7 +4925,7 @@
 
 # newdoc id = dev-s207
 # sent_id = dev-s207
-# parallel_id = jagsdluw/dev207
+# parallel_id = jagsd/dev207
 # text = 何故か教員用の大型の三角定規を持っている事が多い。
 1	何故	何故	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナゼ,何故,何故,何故,ナゼ,,,ナゼ,ナゼ,何故
 2	か	か	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カ,か,か,か,カ,,,カ,カ,か
@@ -4944,7 +4944,7 @@
 
 # newdoc id = dev-s208
 # sent_id = dev-s208
-# parallel_id = jagsdluw/dev208
+# parallel_id = jagsd/dev208
 # text = 最初の2ヶ月間,自社のサービスを理解するためって事でユーザーサポートを担当しました。
 1	最初	最初	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイショ,最初,最初,最初,サイショ,,,サイショ,サイショ,最初
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4968,7 +4968,7 @@
 
 # newdoc id = dev-s209
 # sent_id = dev-s209
-# parallel_id = jagsdluw/dev209
+# parallel_id = jagsd/dev209
 # text = 2011年1月でレギュラー放送が終了し、今後は特番前の特別番組として放送される。
 1	2011年	2011年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;イチ;ネン,二;ゼロ;一;一;年,2;0;1;1;年,2;0;1;1;年,ニ;ゼロ;イチ;イチ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;イチ;ネン,ニゼロイチイチネン,2011年
 2	1月	1月	NUM	名詞-数詞	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ガツ,一;月,1;月,1;月,イチ;ガツ,;,;,イチ;ガツ,イチガツ,1月
@@ -4989,7 +4989,7 @@
 
 # newdoc id = dev-s210
 # sent_id = dev-s210
-# parallel_id = jagsdluw/dev210
+# parallel_id = jagsd/dev210
 # text = その後、他の音楽番組を担当し、TBSを退職。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -5007,7 +5007,7 @@
 
 # newdoc id = dev-s211
 # sent_id = dev-s211
-# parallel_id = jagsdluw/dev211
+# parallel_id = jagsd/dev211
 # text = これが無い場合、作業者は死に至る致命傷を負う場合もある。
 1	これ	此れ	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5029,7 +5029,7 @@
 
 # newdoc id = dev-s212
 # sent_id = dev-s212
-# parallel_id = jagsdluw/dev212
+# parallel_id = jagsd/dev212
 # text = SMEが、生産性の向上と革新を進め、経済の牽引役となることを目的としている。
 1	SME	SME	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エスエムイー,ＳＭＥ,SME,SME,エスエムイー,,,エスエムイー,エスエムイー,SME
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5057,7 +5057,7 @@
 
 # newdoc id = dev-s213
 # sent_id = dev-s213
-# parallel_id = jagsdluw/dev213
+# parallel_id = jagsd/dev213
 # text = 当時3回連続でオーダーミス。
 1	当時	当時	NOUN	名詞-普通名詞-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウジ,当時,当時,当時,トージ,,,トウジ,トウジ,当時
 2	3回連続	3回連続	NOUN	名詞-普通名詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;カイ;レンゾク,三;回;連続,3;回;連続,3;回;連続,サン;カイ;レンゾク,;;,;;,サン;カイ;レンゾク,サンカイレンゾク,3回連続
@@ -5067,7 +5067,7 @@
 
 # newdoc id = dev-s214
 # sent_id = dev-s214
-# parallel_id = jagsdluw/dev214
+# parallel_id = jagsd/dev214
 # text = また、香辛料を輸入するため、さかんにマカッサル王国とも交易をおこなった。
 1	また	又	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5089,7 +5089,7 @@
 
 # newdoc id = dev-s215
 # sent_id = dev-s215
-# parallel_id = jagsdluw/dev215
+# parallel_id = jagsd/dev215
 # text = 彼等の遺体は数日間晒されて、最終的にノグ山に埋葬された。
 1	彼等	彼等	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カレ;ラ,彼;等,彼;等,彼;等,カレ;ラ,;,;,カレ;ラ,カレラ,彼等
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5111,7 +5111,7 @@
 
 # newdoc id = dev-s216
 # sent_id = dev-s216
-# parallel_id = jagsdluw/dev216
+# parallel_id = jagsd/dev216
 # text = 伊勢丹時代にカリスマバイヤーとして名を馳せ、その後、様々な再建、ブランド創成、売り場プロデュースなどを手がけてきた藤巻幸夫氏。
 1	伊勢丹時代	伊勢丹時代	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イセタン;ジダイ,伊勢丹;時代,伊勢丹;時代,伊勢丹;時代,イセタン;ジダイ,;,;,イセタン;ジダイ,イセタンジダイ,伊勢丹時代
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -5141,7 +5141,7 @@
 
 # newdoc id = dev-s217
 # sent_id = dev-s217
-# parallel_id = jagsdluw/dev217
+# parallel_id = jagsd/dev217
 # text = ちなみにここには載せきれませんでしたが,ラッパを吹いている天使はコンクリート製。
 1	ちなみに	因みに	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チナミ;ニ,因み;に,ちなみ;に,ちなみ;に,チナミ;ニ,;,;,チナミ;ニ,チナミニ,因みに
 2	ここ	此処	PRON	代名詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
@@ -5165,7 +5165,7 @@
 
 # newdoc id = dev-s218
 # sent_id = dev-s218
-# parallel_id = jagsdluw/dev218
+# parallel_id = jagsd/dev218
 # text = 佐脇有紀裁判長は,吉田被告について“本件に果たした役割は主導的で積極的”とし,元警察官として“犯行の情状も悪い”としながらも,被告が素直に犯行を認め二度と犯罪を起こさないと反省していることや弁護士会に100万円を寄付したことなどを総合考慮し執行猶予付きの判決となったと述べた。
 1	佐脇有紀裁判長	佐脇有紀裁判長	PROPN	名詞-固有名詞-人名-一般	_	69	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サワキ;ユキ;サイバン;チョウ,サワキ;ユキ;裁判;長,佐脇;有紀;裁判;長,佐脇;有紀;裁判;長,サワキ;ユキ;サイバン;チョー,;;;,;;;,サワキ;ユキ;サイバン;チョウ,サワキユキサイバンチョウ,佐脇有紀裁判長
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5241,7 +5241,7 @@
 
 # newdoc id = dev-s219
 # sent_id = dev-s219
-# parallel_id = jagsdluw/dev219
+# parallel_id = jagsd/dev219
 # text = 髪は薄茶色で毛先が渦巻きカールになった髪型をしている。
 1	髪	髪	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カミ,髪,髪,髪,カミ,,,カミ,カミ,髪
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5262,7 +5262,7 @@
 
 # newdoc id = dev-s220
 # sent_id = dev-s220
-# parallel_id = jagsdluw/dev220
+# parallel_id = jagsd/dev220
 # text = 2月17日にグアムアプラ港に寄港し、グアム到着後は燃料と物資を補給して2月17日に出港。
 1	2月	2月	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ガツ,二;月,2;月,2;月,ニ;ガツ,;,;,ニ;ガツ,ニガツ,2月
 2	17日	17日	NUM	名詞-数詞	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;シチ;ニチ,一;七;日,1;7;日,1;7;日,イチ;シチ;ニチ,;;,;;,イチ;シチ;ニチ,イチシチニチ,17日
@@ -5288,7 +5288,7 @@
 
 # newdoc id = dev-s221
 # sent_id = dev-s221
-# parallel_id = jagsdluw/dev221
+# parallel_id = jagsd/dev221
 # text = 表題曲『港の五番町』の作詞は阿久悠、作曲は彩木雅夫である。
 1	表題曲	表題曲	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒョウダイ;キョク,表題;曲,表題;曲,表題;曲,ヒョーダイ;キョク,;,;,ヒョウダイ;キョク,ヒョウダイキョク,表題曲
 2	『	『	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
@@ -5309,7 +5309,7 @@
 
 # newdoc id = dev-s222
 # sent_id = dev-s222
-# parallel_id = jagsdluw/dev222
+# parallel_id = jagsd/dev222
 # text = 安くてうまいです。
 1	安く	安い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤスイ,安い,安く,安い,ヤスク,,,ヤスイ,ヤスイ,安い
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -5319,7 +5319,7 @@
 
 # newdoc id = dev-s223
 # sent_id = dev-s223
-# parallel_id = jagsdluw/dev223
+# parallel_id = jagsd/dev223
 # text = マイクスタンドは彼の背後から伸び、頭上を通って眼前に降ろす可動式のものを使用、必要に応じて都度、ドラム・テクがマイクスタンドを操作している。
 1	マイクスタンド	マイクスタンド	NOUN	名詞-普通名詞-一般	_	20	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マイク;スタンド,マイク;スタンド,マイク;スタンド,マイク;スタンド,マイク;スタンド,;,;,マイク;スタンド,マイクスタンド,マイクスタンド
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5358,7 +5358,7 @@
 
 # newdoc id = dev-s224
 # sent_id = dev-s224
-# parallel_id = jagsdluw/dev224
+# parallel_id = jagsd/dev224
 # text = 宗教法人格の取り消し云々は,結局のところ,その宗教の持つ教義そのものについて,善悪の判断を加えることになるだろう。
 1	宗教法人格	宗教法人格	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウキョウ;ホウジン;カク,宗教;法人;格,宗教;法人;格,宗教;法人;格,シューキョー;ホージン;カク,;;,;;,シュウキョウ;ホウジン;カク,シュウキョウホウジンカク,宗教法人格
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5389,7 +5389,7 @@
 
 # newdoc id = dev-s225
 # sent_id = dev-s225
-# parallel_id = jagsdluw/dev225
+# parallel_id = jagsd/dev225
 # text = 同氏はドジャースで2度ワールドシリーズを制覇。
 1	同氏	同氏	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウシ,同氏,同氏,同氏,ドーシ,,,ドウシ,ドウシ,同氏
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5403,7 +5403,7 @@
 
 # newdoc id = dev-s226
 # sent_id = dev-s226
-# parallel_id = jagsdluw/dev226
+# parallel_id = jagsd/dev226
 # text = 男性による、番組名・曲名等の簡単な英語ナビゲートがあったが、WEB上で情報が一切公開されておらず、氏名等は一切不明である。
 1	男性	男性	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダンセイ,男性,男性,男性,ダンセー,,,ダンセイ,ダンセイ,男性
 2	による	による	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル,に;因る,に;よる,に;よる,ニ;ヨル,;,;,ニ;ヨル,ニヨル,による
@@ -5437,7 +5437,7 @@
 
 # newdoc id = dev-s227
 # sent_id = dev-s227
-# parallel_id = jagsdluw/dev227
+# parallel_id = jagsd/dev227
 # text = そして回答の最後に,週刊誌の編集部に対して,こんな一文。
 1	そして	そして	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	回答	回答	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイトウ,回答,回答,回答,カイトー,,,カイトウ,カイトウ,回答
@@ -5456,7 +5456,7 @@
 
 # newdoc id = dev-s228
 # sent_id = dev-s228
-# parallel_id = jagsdluw/dev228
+# parallel_id = jagsd/dev228
 # text = 日本では江戸時代から昭和にかけて、主に農家以外で飼い猫の首輪の喉の部分に鈴を一つつけることが行われてきた。
 1	日本	日本	PROPN	名詞-固有名詞-地名-国	_	28	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニッポン,,,ニッポン,ニッポン,日本
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -5493,7 +5493,7 @@
 
 # newdoc id = dev-s229
 # sent_id = dev-s229
-# parallel_id = jagsdluw/dev229
+# parallel_id = jagsd/dev229
 # text = 既に高麗の太祖の時期から、貴族は王権に対する強力な挑戦者だった。
 1	既に	既に	ADV	副詞	_	15	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スデニ,既に,既に,既に,スデニ,,,スデニ,スデニ,既に
 2	高麗	高麗	PROPN	名詞-固有名詞-地名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウライ,コウライ,高麗,高麗,コーライ,,,コウライ,コウライ,高麗
@@ -5516,7 +5516,7 @@
 
 # newdoc id = dev-s230
 # sent_id = dev-s230
-# parallel_id = jagsdluw/dev230
+# parallel_id = jagsd/dev230
 # text = 1800年代は旧制高等学校の医学部薬学科として設置されたが、1900年代には旧制高等学校から医学専門学校が分離された、また私立の薬学専門学校も設置された。
 1	1800年代	1800年代	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;ゼロ;ゼロ;ネン;ダイ,一;八;ゼロ;ゼロ;年;代,1;8;0;0;年;代,1;8;0;0;年;代,イチ;ハチ;ゼロ;ゼロ;ネン;ダイ,;;;;;,;;;;;,イチ;ハチ;ゼロ;ゼロ;ネン;ダイ,イチハチゼロゼロネンダイ,1800年代
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5553,7 +5553,7 @@
 
 # newdoc id = dev-s231
 # sent_id = dev-s231
-# parallel_id = jagsdluw/dev231
+# parallel_id = jagsd/dev231
 # text = 店員の教育が残念な店。
 1	店員	店員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンイン,店員,店員,店員,テンイン,,,テンイン,テンイン,店員
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5566,7 +5566,7 @@
 
 # newdoc id = dev-s232
 # sent_id = dev-s232
-# parallel_id = jagsdluw/dev232
+# parallel_id = jagsd/dev232
 # text = 昭和が最も輝いていた昭和30年代中盤以降の日用雑貨、菓子のパッケージ、ビール瓶や飲料水の缶、そしてポスターにパネルなど。
 1	昭和	昭和	PROPN	名詞-固有名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウワ,昭和,昭和,昭和,ショーワ,,,ショウワ,ショウワ,昭和
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5597,7 +5597,7 @@
 
 # newdoc id = dev-s233
 # sent_id = dev-s233
-# parallel_id = jagsdluw/dev233
+# parallel_id = jagsd/dev233
 # text = 後藤の事が大好きになってしまった様々な作戦を使い嫌われようという企画。
 1	後藤	後藤	PROPN	名詞-固有名詞-人名-姓	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴトウ,ゴトウ,後藤,後藤,ゴトー,,,ゴトウ,ゴトウ,後藤
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5621,7 +5621,7 @@
 
 # newdoc id = dev-s234
 # sent_id = dev-s234
-# parallel_id = jagsdluw/dev234
+# parallel_id = jagsd/dev234
 # text = 大きさが全く違う海老とか調理側は何故平気なんだろ。
 1	大きさ	大きさ	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキイ;サ,大きい;さ,大き;さ,大きい;さ,オーキ;サ,;,;,オオキイ;サ,オオキサ,大きさ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5640,7 +5640,7 @@
 
 # newdoc id = dev-s235
 # sent_id = dev-s235
-# parallel_id = jagsdluw/dev235
+# parallel_id = jagsd/dev235
 # text = でも、リニューアルしたゲストハウス風のロビー?
 1	でも	でも	CCONJ	接続詞	_	7	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;モ,で;も,で;も,で;も,デ;モ,;,;,デ;モ,デモ,でも
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5653,7 +5653,7 @@
 
 # newdoc id = dev-s236
 # sent_id = dev-s236
-# parallel_id = jagsdluw/dev236
+# parallel_id = jagsd/dev236
 # text = 2008年に入り、楽天がイーバンク銀行と資本提携を行うこととなり、イーバンク銀行が新規に発行する第三者割当の優先株を楽天が引き受けることになり、同年9月30日付で社長を含む一部経営陣も楽天の役員から起用された。
 1	2008年	2008年	NUM	名詞-数詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ハチ;ネン,二;ゼロ;ゼロ;八;年,2;0;0;8;年,2;0;0;8;年,ニ;ゼロ;ゼロ;ハチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ハチ;ネン,ニゼロゼロハチネン,2008年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -5702,7 +5702,7 @@
 
 # newdoc id = dev-s237
 # sent_id = dev-s237
-# parallel_id = jagsdluw/dev237
+# parallel_id = jagsd/dev237
 # text = 導入にあたっては10回線以上299回線以下が条件であり2回線から、および300回線以上も導入できるソフトバンクモバイルオフィスと比べると条件を問われる。
 1	導入	導入	NOUN	名詞-普通名詞-一般	_	22	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウニュウ,導入,導入,導入,ドーニュー,,,ドウニュウ,ドウニュウ,導入
 2	にあたって	にあたって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;アタル;テ,に;当たる;て,に;あたっ;て,に;あたる;て,ニ;アタッ;テ,;;,;;,ニ;アタル;テ,ニアタッテ,にあたって
@@ -5731,7 +5731,7 @@
 
 # newdoc id = dev-s238
 # sent_id = dev-s238
-# parallel_id = jagsdluw/dev238
+# parallel_id = jagsd/dev238
 # text = 2007年からは、加藤ピンの仕事が多い。
 1	2007年	2007年	NUM	名詞-数詞	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;シチ;ネン,二;ゼロ;ゼロ;七;年,2;0;0;7;年,2;0;0;7;年,ニ;ゼロ;ゼロ;シチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;シチ;ネン,ニゼロゼロシチネン,2007年
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -5747,7 +5747,7 @@
 
 # newdoc id = dev-s239
 # sent_id = dev-s239
-# parallel_id = jagsdluw/dev239
+# parallel_id = jagsd/dev239
 # text = 突如、臆病な人格となって弱体化してしまう負の時間と呼ばれる一定の時間があるのが、この種族の最大の弱点。
 1	突如	突如	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トツジョ,突如,突如,突如,トツジョ,,,トツジョ,トツジョ,突如
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5783,7 +5783,7 @@
 
 # newdoc id = dev-s240
 # sent_id = dev-s240
-# parallel_id = jagsdluw/dev240
+# parallel_id = jagsd/dev240
 # text = 昨年の12月30日、日中は病棟当番だった鈴木は、夕方当直勤務に入った。
 1	昨年	昨年	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクネン,昨年,昨年,昨年,サクネン,,,サクネン,サクネン,昨年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5807,7 +5807,7 @@
 
 # newdoc id = dev-s241
 # sent_id = dev-s241
-# parallel_id = jagsdluw/dev241
+# parallel_id = jagsd/dev241
 # text = “創価学会”のラベルの記事には,しばしば“創価学会に人気の霊園”という広告が表示されています。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	創価学会	創価学会	PROPN	名詞-固有名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソウカ;ガッカイ,創価;学会,創価;学会,創価;学会,ソーカ;ガッカイ,;,;,ソウカ;ガッカイ,ソウカガッカイ,創価学会
@@ -5838,7 +5838,7 @@
 
 # newdoc id = dev-s242
 # sent_id = dev-s242
-# parallel_id = jagsdluw/dev242
+# parallel_id = jagsd/dev242
 # text = それでも小原は1963年4月に持っていた金は事件と無関係と言い張ったが、平塚らは「これだけ材料を突きつけられてまだ逃れられると思っているのか」と小原を追い詰め、それからほどなくして小原は金が吉展ちゃん事件と関係のあるものだと供述した。
 1	それでも	其れでも	CCONJ	接続詞	_	16	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ;デ;モ,其れ;で;も,それ;で;も,それ;で;も,ソレ;デ;モ,;;,;;,ソレ;デ;モ,ソレデモ,其れでも
 2	小原	小原	PROPN	名詞-固有名詞-人名-姓	_	16	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オバラ,オバラ,小原,小原,オバラ,,,オバラ,オバラ,小原
@@ -5906,7 +5906,7 @@
 
 # newdoc id = dev-s243
 # sent_id = dev-s243
-# parallel_id = jagsdluw/dev243
+# parallel_id = jagsd/dev243
 # text = 同基金では、ひとり親家庭の就業支援も新規に実施。
 1	同基金	同基金	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;キキン,同;基金,同;基金,同;基金,ドー;キキン,;,;,ドウ;キキン,ドウキキン,同基金
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -5923,7 +5923,7 @@
 
 # newdoc id = dev-s244
 # sent_id = dev-s244
-# parallel_id = jagsdluw/dev244
+# parallel_id = jagsd/dev244
 # text = でも、まずはハーフドリアではなく1人前のドリアをお試し下さい。
 1	でも	でも	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;モ,で;も,で;も,で;も,デ;モ,;,;,デ;モ,デモ,でも
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5940,7 +5940,7 @@
 
 # newdoc id = dev-s245
 # sent_id = dev-s245
-# parallel_id = jagsdluw/dev245
+# parallel_id = jagsd/dev245
 # text = 出場国は6カ国。
 1	出場国	出場国	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュツジョウ;コク,出場;国,出場;国,出場;国,シュツジョー;コク,;,;,シュツジョウ;コク,シュツジョウコク,出場国
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5949,7 +5949,7 @@
 
 # newdoc id = dev-s246
 # sent_id = dev-s246
-# parallel_id = jagsdluw/dev246
+# parallel_id = jagsd/dev246
 # text = 文字を取り扱う範囲は10FFFFまでである。
 1	文字	文字	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モジ,文字,文字,文字,モジ,,,モジ,モジ,文字
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -5963,7 +5963,7 @@
 
 # newdoc id = dev-s247
 # sent_id = dev-s247
-# parallel_id = jagsdluw/dev247
+# parallel_id = jagsd/dev247
 # text = 2010年11月28日のDDT・後楽園ホール大会で首を負傷し「後縦靱帯骨化症」と診断される。
 1	2010年	2010年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;ゼロ;ネン,二;ゼロ;一;ゼロ;年,2;0;1;0;年,2;0;1;0;年,ニ;ゼロ;イチ;ゼロ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;ゼロ;ネン,ニゼロイチゼロネン,2010年
 2	11月	11月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;イチ;ガツ,一;一;月,1;1;月,1;1;月,イチ;イチ;ガツ,;;,;;,イチ;イチ;ガツ,イチイチガツ,11月
@@ -5984,7 +5984,7 @@
 
 # newdoc id = dev-s248
 # sent_id = dev-s248
-# parallel_id = jagsdluw/dev248
+# parallel_id = jagsd/dev248
 # text = 郡内には自然湖が無いが、多くの河川がある。
 1	郡内	郡内	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=グンナイ,郡内,郡内,郡内,グンナイ,,,グンナイ,グンナイ,郡内
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6003,7 +6003,7 @@
 
 # newdoc id = dev-s249
 # sent_id = dev-s249
-# parallel_id = jagsdluw/dev249
+# parallel_id = jagsd/dev249
 # text = クラブの経営を支える大きな柱の一つである入場料収入も、2005年をピークに年々減少しております。
 1	クラブ	クラブ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クラブ,クラブ,クラブ,クラブ,クラブ,,,クラブ,クラブ,クラブ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6030,7 +6030,7 @@
 
 # newdoc id = dev-s250
 # sent_id = dev-s250
-# parallel_id = jagsdluw/dev250
+# parallel_id = jagsd/dev250
 # text = 福音書はヘンリー8世の命令による修道院の解散時にダラム大聖堂から持ち出され、17世紀初頭に英国議会の書記官、トーマス・ウォーカーからロバート・コットンの手に渡り、18世紀には大英博物館に納められ、更にそこからロンドンの大英図書館に移された。
 1	福音書	福音書	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フクイン;ショ,福音;書,福音;書,福音;書,フクイン;ショ,;,;,フクイン;ショ,フクインショ,福音書
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6084,7 +6084,7 @@
 
 # newdoc id = dev-s251
 # sent_id = dev-s251
-# parallel_id = jagsdluw/dev251
+# parallel_id = jagsd/dev251
 # text = 2011年の日本トンデモ本大賞は,ニコニコ生放送の投票だけでなく,会場の新宿ロフトプラスワンでの投票も影響するので,これだけで大川隆法氏の受賞が決まったわけではありません。
 1	2011年	2011年	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;イチ;ネン,二;ゼロ;一;一;年,2;0;1;1;年,2;0;1;1;年,ニ;ゼロ;イチ;イチ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;イチ;ネン,ニゼロイチイチネン,2011年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6121,7 +6121,7 @@
 
 # newdoc id = dev-s252
 # sent_id = dev-s252
-# parallel_id = jagsdluw/dev252
+# parallel_id = jagsd/dev252
 # text = 横浜横須賀道路と新湘南バイパスは、終日5割引。
 1	横浜横須賀道路	横浜横須賀道路	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨコハマ;ヨコスカ;ドウロ,ヨコハマ;ヨコスカ;道路,横浜;横須賀;道路,横浜;横須賀;道路,ヨコハマ;ヨコスカ;ドーロ,;;,;;,ヨコハマ;ヨコスカ;ドウロ,ヨコハマヨコスカドウロ,横浜横須賀道路
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -6134,7 +6134,7 @@
 
 # newdoc id = dev-s253
 # sent_id = dev-s253
-# parallel_id = jagsdluw/dev253
+# parallel_id = jagsd/dev253
 # text = 月のお社から脱走したシモーヌという名の女精霊使いを探している。
 1	月	肉月	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツキ,月,月,月,ツキ,,,ツキ,ニクヅキ,肉月
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6154,7 +6154,7 @@
 
 # newdoc id = dev-s254
 # sent_id = dev-s254
-# parallel_id = jagsdluw/dev254
+# parallel_id = jagsd/dev254
 # text = すべて私のせいでとんでもないご迷惑ばかりおかけし,この期に及んでも足をひっぱるばかりで,もう本当にお詫びの言葉もありません。
 1	すべて	全て	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スベテ,全て,すべて,すべて,スベテ,,,スベテ,スベテ,全て
 2	私	私	PRON	代名詞	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
@@ -6193,7 +6193,7 @@
 
 # newdoc id = dev-s255
 # sent_id = dev-s255
-# parallel_id = jagsdluw/dev255
+# parallel_id = jagsd/dev255
 # text = 現在は女優となり、最近はドラマで母親役が多い。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6212,7 +6212,7 @@
 
 # newdoc id = dev-s256
 # sent_id = dev-s256
-# parallel_id = jagsdluw/dev256
+# parallel_id = jagsd/dev256
 # text = 東京らしいシンプルな銭湯。
 1	東京らしい	東京らしい	ADJ	形容詞-一般-形容詞	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウキョウ;ラシイ,トウキョウ;らしい,東京;らしい,東京;らしい,トーキョー;ラシー,;,;,トウキョウ;ラシイ,トウキョウラシイ,東京らしい
 2	シンプル	シンプル	ADJ	形状詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンプル,シンプル,シンプル,シンプル,シンプル,,,シンプル,シンプル,シンプル
@@ -6222,7 +6222,7 @@
 
 # newdoc id = dev-s257
 # sent_id = dev-s257
-# parallel_id = jagsdluw/dev257
+# parallel_id = jagsd/dev257
 # text = ベンが処刑され、ウィラが地元のアイスクリーム屋で働いて生計を立てるようになった或る日、クリーサップの街にハリーが突然あらわれた。
 1	ベン	ベン	PROPN	名詞-固有名詞-人名-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベン,ベン,ベン,ベン,ベン,,,ベン,ベン,ベン
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6260,7 +6260,7 @@
 
 # newdoc id = dev-s258
 # sent_id = dev-s258
-# parallel_id = jagsdluw/dev258
+# parallel_id = jagsd/dev258
 # text = 徳島市の東部に位置し、吉野川下流デルタ地帯の一角をなす。
 1	徳島市	徳島市	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トクシマ;シ,トクシマ;市,徳島;市,徳島;市,トクシマ;シ,;,;,トクシマ;シ,トクシマシ,徳島市
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6277,7 +6277,7 @@
 
 # newdoc id = dev-s259
 # sent_id = dev-s259
-# parallel_id = jagsdluw/dev259
+# parallel_id = jagsd/dev259
 # text = 地元の農家の方が作った野菜のコーナーが好きです。
 1	地元	地元	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジモト,地元,地元,地元,ジモト,,,ジモト,ジモト,地元
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6297,7 +6297,7 @@
 
 # newdoc id = dev-s260
 # sent_id = dev-s260
-# parallel_id = jagsdluw/dev260
+# parallel_id = jagsd/dev260
 # text = ※GI昇格後の年度に限定。
 1	※	※	SYM	補助記号-一般	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=,※,※,※,,,,,,※
 2	GI昇格後	GI昇格後	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジーアイ;ショウカク;ゴ,ＧＩ;昇格;後,GI;昇格;後,GI;昇格;後,ジーアイ;ショーカク;ゴ,;;,;;,ジーアイ;ショウカク;ゴ,ジーアイショウカクゴ,GI昇格後
@@ -6309,7 +6309,7 @@
 
 # newdoc id = dev-s261
 # sent_id = dev-s261
-# parallel_id = jagsdluw/dev261
+# parallel_id = jagsd/dev261
 # text = 第3次以降の平成23年度補正予算案にNEMIC整備のための調査費計上を目指している。
 1	第3次以降	第3次以降	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;サン;ジ;イコウ,第;三;次;以降,第;3;次;以降,第;3;次;以降,ダイ;サン;ジ;イコー,;;;,;;;,ダイ;サン;ジ;イコウ,ダイサンジイコウ,第3次以降
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6327,7 +6327,7 @@
 
 # newdoc id = dev-s262
 # sent_id = dev-s262
-# parallel_id = jagsdluw/dev262
+# parallel_id = jagsd/dev262
 # text = 「ありがとうございます」とお礼を言い、笑顔で味わっていた。
 1	「	「	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	ありがとう	有り難い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アリガタイ,有り難い,ありがとう,ありがたい,アリガトー,,,アリガタイ,アリガタイ,有り難い
@@ -6348,7 +6348,7 @@
 
 # newdoc id = dev-s263
 # sent_id = dev-s263
-# parallel_id = jagsdluw/dev263
+# parallel_id = jagsd/dev263
 # text = 主な項目に関する最終案の内容は以下のとおり。
 1	主な	主な	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オモナ,主な,主な,主な,オモナ,,,オモナ,オモナ,主な
 2	項目	項目	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウモク,項目,項目,項目,コーモク,,,コウモク,コウモク,項目
@@ -6364,7 +6364,7 @@
 
 # newdoc id = dev-s264
 # sent_id = dev-s264
-# parallel_id = jagsdluw/dev264
+# parallel_id = jagsd/dev264
 # text = 先を歩いていたミニスカートの女性がNKプリントの前で自動車にはね飛ばされる。
 1	先	先	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サキ,先,先,先,サキ,,,サキ,サキ,先
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6387,7 +6387,7 @@
 
 # newdoc id = dev-s265
 # sent_id = dev-s265
-# parallel_id = jagsdluw/dev265
+# parallel_id = jagsd/dev265
 # text = 『ミューミューニャーニャー』はNHKの幼児向け番組『おかあさんといっしょ』の人形劇のコーナー。
 1	『	『	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
 2	ミューミューニャーニャー	みゅーみゅーにゃあにゃあ	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミューミュー;ニャアニャア,みゅーみゅー;にゃあにゃあ,ミューミュー;ニャーニャー,ミューミュー;ニャーニャー,ミューミュー;ニャーニャー,;,;,ミューミュー;ニャアニャア,ミューミューニャアニャア,みゅーみゅーにゃあにゃあ
@@ -6409,7 +6409,7 @@
 
 # newdoc id = dev-s266
 # sent_id = dev-s266
-# parallel_id = jagsdluw/dev266
+# parallel_id = jagsd/dev266
 # text = 同年はリザーブチームで6回プレーした。
 1	同年	同年	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウネン,同年,同年,同年,ドーネン,,,ドウネン,ドウネン,同年
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6422,7 +6422,7 @@
 
 # newdoc id = dev-s267
 # sent_id = dev-s267
-# parallel_id = jagsdluw/dev267
+# parallel_id = jagsd/dev267
 # text = 女性教会員が立候補した松戸市議選でも,足立教会の信者が大量動員されていた。
 1	女性教会員	女性教会員	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョセイ;キョウカイ;イン,女性;教会;員,女性;教会;員,女性;教会;員,ジョセー;キョーカイ;イン,;;,;;,ジョセイ;キョウカイ;イン,ジョセイキョウカイイン,女性教会員
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6444,7 +6444,7 @@
 
 # newdoc id = dev-s268
 # sent_id = dev-s268
-# parallel_id = jagsdluw/dev268
+# parallel_id = jagsd/dev268
 # text = 2000年のシドニーオリンピックではいずれも予選敗退だった。
 1	2000年	2000年	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ゼロ;ネン,二;ゼロ;ゼロ;ゼロ;年,2;0;0;0;年,2;0;0;0;年,ニ;ゼロ;ゼロ;ゼロ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ゼロ;ネン,ニゼロゼロゼロネン,2000年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6460,7 +6460,7 @@
 
 # newdoc id = dev-s269
 # sent_id = dev-s269
-# parallel_id = jagsdluw/dev269
+# parallel_id = jagsd/dev269
 # text = 東京の中でも新宿といういい立地でありながら、お料理の味やドレスの素敵さを考えるととても良心的な結婚式場という感じがしました。
 1	東京	東京	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウキョウ,トウキョウ,東京,東京,トーキョー,,,トウキョウ,トウキョウ,東京
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6498,7 +6498,7 @@
 
 # newdoc id = dev-s270
 # sent_id = dev-s270
-# parallel_id = jagsdluw/dev270
+# parallel_id = jagsd/dev270
 # text = 陳敦仁:統振株式有限会社理事長。
 1	陳敦仁	陳敦仁	PROPN	名詞-固有名詞-人名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チン;トンジン,チン;トンジン,陳;敦仁,陳;敦仁,チン;トンジン,;,;,チン;トンジン,チントンジン,陳敦仁
 2	:	:	SYM	補助記号-一般	_	1	dep	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,：,:,:,,,,,,：
@@ -6508,7 +6508,7 @@
 
 # newdoc id = dev-s271
 # sent_id = dev-s271
-# parallel_id = jagsdluw/dev271
+# parallel_id = jagsd/dev271
 # text = 水曜日と金曜日に図書室で貸し出しの作業をしている。
 1	水曜日	水曜日	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スイヨウ;ヒ,水曜;日,水曜;日,水曜;日,スイヨー;ビ,;,;,スイヨウ;ヒ,スイヨウビ,水曜日
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -6526,7 +6526,7 @@
 
 # newdoc id = dev-s272
 # sent_id = dev-s272
-# parallel_id = jagsdluw/dev272
+# parallel_id = jagsd/dev272
 # text = 本作の隠しキャラクターの1人。
 1	本作	本作	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンサク,本作,本作,本作,ホンサク,,,ホンサク,ホンサク,本作
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6537,7 +6537,7 @@
 
 # newdoc id = dev-s273
 # sent_id = dev-s273
-# parallel_id = jagsdluw/dev273
+# parallel_id = jagsd/dev273
 # text = セキュリティの点でも、安心して住めるよう、オートロックシステムをはじめ、防犯カメラ、ディンプルキー・鎌デッド錠、エレベータには防犯モニタが設置されています。
 1	セキュリティ	セキュリティ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セキュリティー,セキュリティー,セキュリティ,セキュリティ,セキュリティ,,,セキュリティ,セキュリティ,セキュリティ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6570,7 +6570,7 @@
 
 # newdoc id = dev-s274
 # sent_id = dev-s274
-# parallel_id = jagsdluw/dev274
+# parallel_id = jagsd/dev274
 # text = 超新星の所属事務所,株式会社maroo企画です。
 1	超新星	超新星	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウ;シンセイ,超;新星,超;新星,超;新星,チョー;シンセー,;,;,チョウ;シンセイ,チョウシンセイ,超新星
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6582,7 +6582,7 @@
 
 # newdoc id = dev-s275
 # sent_id = dev-s275
-# parallel_id = jagsdluw/dev275
+# parallel_id = jagsd/dev275
 # text = 2012年現在、外車だけでもランボルギーニ・ミウラP400SV、フェラーリ・F512M、ベンツ、BMWの4台を保有し、中でもランボルギーニ・ミウラは1971年生産の車体で41年が経過した時点でも走行可能と、極めて良好なコンディションである。
 1	2012年現在	2012年現在	ADV	副詞	_	17	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;ニ;ネン;ゲンザイ,二;ゼロ;一;二;年;現在,2;0;1;2;年;現在,2;0;1;2;年;現在,ニ;ゼロ;イチ;ニ;ネン;ゲンザイ,;;;;;,;;;;;,ニ;ゼロ;イチ;ニ;ネン;ゲンザイ,ニゼロイチニネンゲンザイ,2012年現在
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6630,7 +6630,7 @@
 
 # newdoc id = dev-s276
 # sent_id = dev-s276
-# parallel_id = jagsdluw/dev276
+# parallel_id = jagsd/dev276
 # text = 今後とも超新星を応援いただきますよう,よろしくお願いいたします。
 1	今後とも	今後共	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンゴ;トモ,今後;共,今後;とも,今後;とも,コンゴ;トモ,;,;,コンゴ;トモ,コンゴトモ,今後共
 2	超新星	超新星	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウ;シンセイ,超;新星,超;新星,超;新星,チョー;シンセー,;,;,チョウ;シンセイ,チョウシンセイ,超新星
@@ -6646,7 +6646,7 @@
 
 # newdoc id = dev-s277
 # sent_id = dev-s277
-# parallel_id = jagsdluw/dev277
+# parallel_id = jagsd/dev277
 # text = 山頂までの距離は、4.8kmである。
 1	山頂	山頂	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サンチョウ,山頂,山頂,山頂,サンチョー,,,サンチョウ,サンチョウ,山頂
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -6660,7 +6660,7 @@
 
 # newdoc id = dev-s278
 # sent_id = dev-s278
-# parallel_id = jagsdluw/dev278
+# parallel_id = jagsd/dev278
 # text = さっさと潰れろ!
 1	さっさと	さっさと	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サッサト,さっさと,さっさと,さっさと,サッサト,,,サッサト,サッサト,さっさと
 2	潰れろ	潰れる	VERB	動詞-一般-下一段-ラ行	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ツブレル,潰れる,潰れろ,潰れる,ツブレロ,,,ツブレル,ツブレル,潰れる
@@ -6668,7 +6668,7 @@
 
 # newdoc id = dev-s279
 # sent_id = dev-s279
-# parallel_id = jagsdluw/dev279
+# parallel_id = jagsd/dev279
 # text = 台湾守備混成第2旅団長を経て、日露戦争に歩兵第1旅団長として出征し、南山の戦いに参戦。
 1	台湾守備混成第2旅団長	台湾守備混成第2旅団長	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイワン;シュビ;コンセイ;ダイ;ニ;リョダン;チョウ,タイワン;守備;混成;第;二;旅団;長,台湾;守備;混成;第;2;旅団;長,台湾;守備;混成;第;2;旅団;長,タイワン;シュビ;コンセー;ダイ;ニ;リョダン;チョー,;;;;;;,;;;;;;,タイワン;シュビ;コンセイ;ダイ;ニ;リョダン;チョウ,タイワンシュビコンセイダイニリョダンチョウ,台湾守備混成第2旅団長
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6690,7 +6690,7 @@
 
 # newdoc id = dev-s280
 # sent_id = dev-s280
-# parallel_id = jagsdluw/dev280
+# parallel_id = jagsd/dev280
 # text = 主な内容は本格的な古典演奏から和楽器を使ったロックやポップスの紹介と、DJによる大学生活や舞台でのエピソードトーク。
 1	主な	主な	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オモナ,主な,主な,主な,オモナ,,,オモナ,オモナ,主な
 2	内容	内容	NOUN	名詞-普通名詞-一般	_	26	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナイヨウ,内容,内容,内容,ナイヨー,,,ナイヨウ,ナイヨウ,内容
@@ -6722,7 +6722,7 @@
 
 # newdoc id = dev-s281
 # sent_id = dev-s281
-# parallel_id = jagsdluw/dev281
+# parallel_id = jagsd/dev281
 # text = 連合は緒戦の勢いを失い、双方の首都をめぐりバージニア州で行われていた東部戦線は膠着状態に陥る一方、南軍の西部戦線にほころびが生じた。
 1	連合	連合	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レンゴウ,連合,連合,連合,レンゴー,,,レンゴウ,レンゴウ,連合
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6762,7 +6762,7 @@
 
 # newdoc id = dev-s282
 # sent_id = dev-s282
-# parallel_id = jagsdluw/dev282
+# parallel_id = jagsd/dev282
 # text = とりわけバグダードでは神学教授のガザーリーなどが活躍した。
 1	とりわけ	取り分け	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トリワケ,取り分け,とりわけ,とりわけ,トリワケ,,,トリワケ,トリワケ,取り分け
 2	バグダード	バグダード	PROPN	名詞-固有名詞-地名-一般	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バグダッド,バグダッド,バグダード,バグダード,バグダード,,,バグダード,バグダード,バグダード
@@ -6779,7 +6779,7 @@
 
 # newdoc id = dev-s283
 # sent_id = dev-s283
-# parallel_id = jagsdluw/dev283
+# parallel_id = jagsd/dev283
 # text = これにあたる語としてはملكがあり、字義としては「今まさに持っている」という意味合いになる。
 1	これ	此れ	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6808,7 +6808,7 @@
 
 # newdoc id = dev-s284
 # sent_id = dev-s284
-# parallel_id = jagsdluw/dev284
+# parallel_id = jagsd/dev284
 # text = 先日,坂本弁護士失踪事件直後のテレビ放送のVTRや波野村での反対集会の映像を観る機会があった。
 1	先日	先日	ADV	副詞	_	19	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センジツ,先日,先日,先日,センジツ,,,センジツ,センジツ,先日
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -6834,7 +6834,7 @@
 
 # newdoc id = dev-s285
 # sent_id = dev-s285
-# parallel_id = jagsdluw/dev285
+# parallel_id = jagsd/dev285
 # text = 一部を抜粋します。
 1	一部	一部	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチブ,一部,一部,一部,イチブ,,,イチブ,イチブ,一部
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6844,7 +6844,7 @@
 
 # newdoc id = dev-s286
 # sent_id = dev-s286
-# parallel_id = jagsdluw/dev286
+# parallel_id = jagsd/dev286
 # text = 調子に乗りやすく、危険な獣相手にピンチに陥ることも。
 1	調子	調子	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウシ,調子,調子,調子,チョーシ,,,チョウシ,チョウシ,調子
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6863,7 +6863,7 @@
 
 # newdoc id = dev-s287
 # sent_id = dev-s287
-# parallel_id = jagsdluw/dev287
+# parallel_id = jagsd/dev287
 # text = 白馬に入る入り口のスキー場でもあってとても奇麗でやることいっぱい!
 1	白馬	白馬	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハクバ,ハクバ,白馬,白馬,ハクバ,,,ハクバ,ハクバ,白馬
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6883,7 +6883,7 @@
 
 # newdoc id = dev-s288
 # sent_id = dev-s288
-# parallel_id = jagsdluw/dev288
+# parallel_id = jagsd/dev288
 # text = 普段は成績が悪く遅刻を繰り返す問題児で、第1話では喧嘩で相手を骨折させて自宅謹慎まで受けていたが、その反面、正義感が強く仲間からの信頼も厚い。
 1	普段	普段	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フダン,普段,普段,普段,フダン,,,フダン,フダン,普段
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6929,7 +6929,7 @@
 
 # newdoc id = dev-s289
 # sent_id = dev-s289
-# parallel_id = jagsdluw/dev289
+# parallel_id = jagsd/dev289
 # text = また、同ライブへ向け、両バンドのカップリング楽曲と映像を収録したCD&DVDパッケージ『Phoenix Rising』が10月12日にリリースされる。
 1	また	又	CCONJ	接続詞	_	23	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6959,7 +6959,7 @@
 
 # newdoc id = dev-s290
 # sent_id = dev-s290
-# parallel_id = jagsdluw/dev290
+# parallel_id = jagsd/dev290
 # text = 出演者も特有の風と降りしきる雨に悩ませられた。
 1	出演者	出演者	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュツエン;シャ,出演;者,出演;者,出演;者,シュツエン;シャ,;,;,シュツエン;シャ,シュツエンシャ,出演者
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -6978,7 +6978,7 @@
 
 # newdoc id = dev-s291
 # sent_id = dev-s291
-# parallel_id = jagsdluw/dev291
+# parallel_id = jagsd/dev291
 # text = コダールの完成型であるコダールiも『揺れるイントゥ・ザ・ブルー』でビルの倒壊に対してラムダ・ドライバを発動させオーバーヒートを起こしているが、検査の結果何の異常も見られなかったため、こちらはガウルンによるブラフと見られる。
 1	コダール	コダール	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コダール,コダール,コダール,コダール,コダール,,,コダール,コダール,コダール
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7030,7 +7030,7 @@
 
 # newdoc id = dev-s292
 # sent_id = dev-s292
-# parallel_id = jagsdluw/dev292
+# parallel_id = jagsd/dev292
 # text = 意識を取り戻した友作は階段から落ちた後、危篤状態だった時間と同じ57分間だけ他人の心の声が聞こえる能力を手に入れていた。
 1	意識	意識	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イシキ,意識,意識,意識,イシキ,,,イシキ,イシキ,意識
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7070,7 +7070,7 @@
 
 # newdoc id = dev-s293
 # sent_id = dev-s293
-# parallel_id = jagsdluw/dev293
+# parallel_id = jagsd/dev293
 # text = 全国霊感商法対策弁護士連絡会の渡辺博弁護士は2009年7月,統一日報の取材に“統一教会は民団や総連といった在日韓国人組織の活動にも入り込み,信者獲得を進めている”と語っている。
 1	全国霊感商法対策弁護士連絡会	全国霊感商法対策弁護士連絡会	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼンコク;レイカン;ショウホウ;タイサク;ベンゴ;シ;レンラク;カイ,全国;霊感;商法;対策;弁護;士;連絡;会,全国;霊感;商法;対策;弁護;士;連絡;会,全国;霊感;商法;対策;弁護;士;連絡;会,ゼンコク;レーカン;ショーホー;タイサク;ベンゴ;シ;レンラク;カイ,;;;;;;;,;;;;;;;,ゼンコク;レイカン;ショウホウ;タイサク;ベンゴ;シ;レンラク;カイ,ゼンコクレイカンショウホウタイサクベンゴシレンラクカイ,全国霊感商法対策弁護士連絡会
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7109,7 +7109,7 @@
 
 # newdoc id = dev-s294
 # sent_id = dev-s294
-# parallel_id = jagsdluw/dev294
+# parallel_id = jagsd/dev294
 # text = 編成番号は2両・3両単位で付番され、識別記号「HE」を冠し「HE-104」のように表す。
 1	編成番号	編成番号	NOUN	名詞-普通名詞-一般	_	20	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヘンセイ;バンゴウ,編成;番号,編成;番号,編成;番号,ヘンセー;バンゴー,;,;,ヘンセイ;バンゴウ,ヘンセイバンゴウ,編成番号
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7135,7 +7135,7 @@
 
 # newdoc id = dev-s295
 # sent_id = dev-s295
-# parallel_id = jagsdluw/dev295
+# parallel_id = jagsd/dev295
 # text = 信者にとってはありがたい存在なのであろうが,正直カリスマ性は感じられなかった。
 1	信者	信者	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンジャ,信者,信者,信者,シンジャ,,,シンジャ,シンジャ,信者
 2	にとって	にとって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;トル;テ,に;取る;て,に;とっ;て,に;とる;て,ニ;トッ;テ,;;,;;,ニ;トル;テ,ニトッテ,にとって
@@ -7157,7 +7157,7 @@
 
 # newdoc id = dev-s296
 # sent_id = dev-s296
-# parallel_id = jagsdluw/dev296
+# parallel_id = jagsd/dev296
 # text = 単に「属人主義」という積極的属人主義を指す場合が多い。
 1	単に	単に	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タンニ,単に,単に,単に,タンニ,,,タンニ,タンニ,単に
 2	「	「	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
@@ -7174,7 +7174,7 @@
 
 # newdoc id = dev-s297
 # sent_id = dev-s297
-# parallel_id = jagsdluw/dev297
+# parallel_id = jagsd/dev297
 # text = この特別代表は、現在知られているサイトは日本や韓国の北朝鮮支持者が運営していると明らかにしたという。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	特別代表	特別代表	NOUN	名詞-普通名詞-一般	_	22	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トクベツ;ダイヒョウ,特別;代表,特別;代表,特別;代表,トクベツ;ダイヒョー,;,;,トクベツ;ダイヒョウ,トクベツダイヒョウ,特別代表
@@ -7205,7 +7205,7 @@
 
 # newdoc id = dev-s298
 # sent_id = dev-s298
-# parallel_id = jagsdluw/dev298
+# parallel_id = jagsd/dev298
 # text = 幸福の科学の広報担当者によると,今回の広告掲載は“フライデー事件”以来,19年ぶりとのことです。
 1	幸福の科学	幸福の科学	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ノ;カガク,幸福;の;科学,幸福;の;科学,幸福;の;科学,コーフク;ノ;カガク,;;,;;,コウフク;ノ;カガク,コウフクノカガク,幸福の科学
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7230,7 +7230,7 @@
 
 # newdoc id = dev-s299
 # sent_id = dev-s299
-# parallel_id = jagsdluw/dev299
+# parallel_id = jagsd/dev299
 # text = 統一教会広報に問い合わせた。
 1	統一教会広報	統一教会広報	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウイツ;キョウカイ;コウホウ,統一;教会;広報,統一;教会;広報,統一;教会;広報,トーイツ;キョーカイ;コーホー,;;,;;,トウイツ;キョウカイ;コウホウ,トウイツキョウカイコウホウ,統一教会広報
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7240,7 +7240,7 @@
 
 # newdoc id = dev-s300
 # sent_id = dev-s300
-# parallel_id = jagsdluw/dev300
+# parallel_id = jagsd/dev300
 # text = PRACTICEモードはステージ3で終了だが、クリア時にベルを50個以上保持していればステージ4以降に進める。
 1	PRACTICEモード	PRACTICEモード	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=プラクティス;モード,プラクティス;モード,PRACTICE;モード,PRACTICE;モード,プラクティス;モード,;,;,プラクティス;モード,プラクティスモード,PRACTICEモード
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7267,7 +7267,7 @@
 
 # newdoc id = dev-s301
 # sent_id = dev-s301
-# parallel_id = jagsdluw/dev301
+# parallel_id = jagsd/dev301
 # text = 主人公の隣のアパートに引っ越してきた幼稚園の先生。
 1	主人公	主人公	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュジン;コウ,主人;公,主人;公,主人;公,シュジン;コー,;,;,シュジン;コウ,シュジンコウ,主人公
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7285,7 +7285,7 @@
 
 # newdoc id = dev-s302
 # sent_id = dev-s302
-# parallel_id = jagsdluw/dev302
+# parallel_id = jagsd/dev302
 # text = アンジェロの一人娘であるジェニファーは、命の危険から遠ざけるために、幼い頃に養女に出されていた。
 1	アンジェロ	アンジェロ	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アンジェロ,アンジェロ,アンジェロ,アンジェロ,アンジェロ,,,アンジェロ,アンジェロ,アンジェロ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7314,7 +7314,7 @@
 
 # newdoc id = dev-s303
 # sent_id = dev-s303
-# parallel_id = jagsdluw/dev303
+# parallel_id = jagsd/dev303
 # text = 桜井高校はランナー1.3塁から内野ゴロで先制します。
 1	桜井高校	桜井高校	PROPN	名詞-固有名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクライ;コウコウ,サクライ;高校,桜井;高校,桜井;高校,サクライ;コーコー,;,;,サクライ;コウコウ,サクライコウコウ,桜井高校
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7329,7 +7329,7 @@
 
 # newdoc id = dev-s304
 # sent_id = dev-s304
-# parallel_id = jagsdluw/dev304
+# parallel_id = jagsd/dev304
 # text = 5人以上だときついかもしれないけど、少人数の時にはまた使いたいです。
 1	5人以上	5人以上	NOUN	名詞-普通名詞-一般	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ;ニン;イジョウ,五;人;以上,5;人;以上,5;人;以上,ゴ;ニン;イジョー,;;,;;,ゴ;ニン;イジョウ,ゴニンイジョウ,5人以上
 2	だ	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダ,だ
@@ -7351,7 +7351,7 @@
 
 # newdoc id = dev-s305
 # sent_id = dev-s305
-# parallel_id = jagsdluw/dev305
+# parallel_id = jagsd/dev305
 # text = シーズン終了後球団社長のジョン・ショーは辞任し、12月22日にはジェイ・ジグムンドに代わってビリー・ディバニーがゼネラルマネージャーとなった。
 1	シーズン終了後	シーズン終了後	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シーズン;シュウリョウ;ゴ,シーズン;終了;後,シーズン;終了;後,シーズン;終了;後,シーズン;シューリョー;ゴ,;;,;;,シーズン;シュウリョウ;ゴ,シーズンシュウリョウゴ,シーズン終了後
 2	球団社長	球団社長	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウダン;シャチョウ,球団;社長,球団;社長,球団;社長,キューダン;シャチョー,;,;,キュウダン;シャチョウ,キュウダンシャチョウ,球団社長
@@ -7378,7 +7378,7 @@
 
 # newdoc id = dev-s306
 # sent_id = dev-s306
-# parallel_id = jagsdluw/dev306
+# parallel_id = jagsd/dev306
 # text = 1462年、アラゴン王フアン2世と、最初の妃であるナバラ女王ブランカ1世との間の王子カルラスが、ナバラ王位を巡って争うことになった。
 1	1462年	1462年	NUM	名詞-数詞	_	24	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ヨン;ロク;ニ;ネン,一;四;六;二;年,1;4;6;2;年,1;4;6;2;年,イチ;ヨン;ロク;ニ;ネン,;;;;,;;;;,イチ;ヨン;ロク;ニ;ネン,イチヨンロクニネン,1462年
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7410,7 +7410,7 @@
 
 # newdoc id = dev-s307
 # sent_id = dev-s307
-# parallel_id = jagsdluw/dev307
+# parallel_id = jagsd/dev307
 # text = 大部分が6車線で、品川埠頭の連絡道である。
 1	大部分	大部分	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;ブブン,大;部分,大;部分,大;部分,ダイ;ブブン,;,;,ダイ;ブブン,ダイブブン,大部分
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7425,7 +7425,7 @@
 
 # newdoc id = dev-s308
 # sent_id = dev-s308
-# parallel_id = jagsdluw/dev308
+# parallel_id = jagsd/dev308
 # text = 旅の途中で出会うモンスターを模した家具を、マイハウスに設置可能。
 1	旅	旅	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タビ,旅,旅,旅,タビ,,,タビ,タビ,旅
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7446,7 +7446,7 @@
 
 # newdoc id = dev-s309
 # sent_id = dev-s309
-# parallel_id = jagsdluw/dev309
+# parallel_id = jagsd/dev309
 # text = さらにその後、ビデオによる撮影が主流となるに従い、ビデオ機材を組み込んだ総合的なシステムとしてのスタジオが主流となった。
 1	さらに	更に	CCONJ	接続詞	_	27	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サラニ,更に,さらに,さらに,サラニ,,,サラニ,サラニ,更に
 2	その	其の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
@@ -7480,7 +7480,7 @@
 
 # newdoc id = dev-s310
 # sent_id = dev-s310
-# parallel_id = jagsdluw/dev310
+# parallel_id = jagsd/dev310
 # text = 外見は田舎の一般住宅のノリですが、津幡の店とは思えないクオリティーです。
 1	外見	外見	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガイケン,外見,外見,外見,ガイケン,,,ガイケン,ガイケン,外見
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7505,7 +7505,7 @@
 
 # newdoc id = dev-s311
 # sent_id = dev-s311
-# parallel_id = jagsdluw/dev311
+# parallel_id = jagsd/dev311
 # text = 九州大学大学院法学研究院准教授を経て、現在同教授。
 1	九州大学大学院	九州大学大学院	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウシュウ;ダイガク;ダイガク;イン,キュウシュウ;大学;大学;院,九州;大学;大学;院,九州;大学;大学;院,キューシュー;ダイガク;ダイガク;イン,;;;,;;;,キュウシュウ;ダイガク;ダイガク;イン,キュウシュウダイガクダイガクイン,九州大学大学院
 2	法学研究院	法学研究院	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ホウガク;ケンキュウ;イン,法学;研究;院,法学;研究;院,法学;研究;院,ホーガク;ケンキュー;イン,;;,;;,ホウガク;ケンキュウ;イン,ホウガクケンキュウイン,法学研究院
@@ -7520,7 +7520,7 @@
 
 # newdoc id = dev-s312
 # sent_id = dev-s312
-# parallel_id = jagsdluw/dev312
+# parallel_id = jagsd/dev312
 # text = 実に狡猾なやり口だ。
 1	実	実	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジツ,実,実,実,ジツ,,,ジツ,ジツ,実
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7532,7 +7532,7 @@
 
 # newdoc id = dev-s313
 # sent_id = dev-s313
-# parallel_id = jagsdluw/dev313
+# parallel_id = jagsd/dev313
 # text = 車両手配上の都合からホンダ車以外の他社の車両を使用する際には、車両の前部・後部に番組タイトルロゴ付きの板を被せていた。
 1	車両手配上	車両手配上	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シャリョウ;テハイ;ジョウ,車両;手配;上,車両;手配;上,車両;手配;上,シャリョー;テハイ;ジョー,;;,;;,シャリョウ;テハイ;ジョウ,シャリョウテハイジョウ,車両手配上
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7563,7 +7563,7 @@
 
 # newdoc id = dev-s314
 # sent_id = dev-s314
-# parallel_id = jagsdluw/dev314
+# parallel_id = jagsd/dev314
 # text = 日本向けには脱脂粉乳、雑穀類を食料として送った。
 1	日本向け	日本向け	NOUN	名詞-普通名詞-一般	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン;ムケ,日本;向け,日本;向け,日本;向け,ニッポン;ムケ,;,;,ニッポン;ムケ,ニッポンムケ,日本向け
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7580,7 +7580,7 @@
 
 # newdoc id = dev-s315
 # sent_id = dev-s315
-# parallel_id = jagsdluw/dev315
+# parallel_id = jagsd/dev315
 # text = 今後は高校野球などアマチュア野球の公式戦の他、プロ野球の二軍公式戦を誘致する方針である。
 1	今後	今後	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンゴ,今後,今後,今後,コンゴ,,,コンゴ,コンゴ,今後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7603,7 +7603,7 @@
 
 # newdoc id = dev-s316
 # sent_id = dev-s316
-# parallel_id = jagsdluw/dev316
+# parallel_id = jagsd/dev316
 # text = そもそも港市支配者は、外来商人と領域内の住民とを仲立ちすることこそが自らの拠って立つ基盤であった。
 1	そもそも	抑	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソモソモ,抑,そもそも,そもそも,ソモソモ,,,ソモソモ,ソモソモ,抑
 2	港市支配者	港市支配者	NOUN	名詞-普通名詞-一般	_	12	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウシ;シハイ;シャ,港市;支配;者,港市;支配;者,港市;支配;者,コーシ;シハイ;シャ,;;,;;,コウシ;シハイ;シャ,コウシシハイシャ,港市支配者
@@ -7632,7 +7632,7 @@
 
 # newdoc id = dev-s317
 # sent_id = dev-s317
-# parallel_id = jagsdluw/dev317
+# parallel_id = jagsd/dev317
 # text = そして現場へ着くと不思議な光に包まれる。
 1	そして	そして	CCONJ	接続詞	_	10	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	現場	現場	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンバ,現場,現場,現場,ゲンバ,,,ゲンバ,ゲンバ,現場
@@ -7649,7 +7649,7 @@
 
 # newdoc id = dev-s318
 # sent_id = dev-s318
-# parallel_id = jagsdluw/dev318
+# parallel_id = jagsd/dev318
 # text = 私はよく通ってますが、親切丁寧に対応してくださって安心です。
 1	私	私	PRON	代名詞	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7670,7 +7670,7 @@
 
 # newdoc id = dev-s319
 # sent_id = dev-s319
-# parallel_id = jagsdluw/dev319
+# parallel_id = jagsd/dev319
 # text = 大学在学中に、最初の文学賞を受賞する。
 1	大学在学中	大学在学中	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイガク;ザイガク;チュウ,大学;在学;中,大学;在学;中,大学;在学;中,ダイガク;ザイガク;チュー,;;,;;,ダイガク;ザイガク;チュウ,ダイガクザイガクチュウ,大学在学中
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7684,7 +7684,7 @@
 
 # newdoc id = dev-s320
 # sent_id = dev-s320
-# parallel_id = jagsdluw/dev320
+# parallel_id = jagsd/dev320
 # text = 私たちはビュッフェスタイルだったのですが、いろいろなプランでやってくれるみたいです。
 1	私たち	私達	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ;タチ,私;達,私;たち,私;たち,ワタシ;タチ,;,;,ワタシ;タチ,ワタシタチ,私達
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7706,7 +7706,7 @@
 
 # newdoc id = dev-s321
 # sent_id = dev-s321
-# parallel_id = jagsdluw/dev321
+# parallel_id = jagsd/dev321
 # text = 豚が美味しかったので、また行きます。
 1	豚	豚	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ブタ,豚,豚,豚,ブタ,,,ブタ,ブタ,豚
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7721,7 +7721,7 @@
 
 # newdoc id = dev-s322
 # sent_id = dev-s322
-# parallel_id = jagsdluw/dev322
+# parallel_id = jagsd/dev322
 # text = 同百貨店は「成長していく東京スカイツリーをリアルに体感してもらいたい」としている。
 1	同百貨店	同百貨店	NOUN	名詞-普通名詞-一般	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;ヒャッカ;テン,同;百貨;店,同;百貨;店,同;百貨;店,ドー;ヒャッカ;テン,;;,;;,ドウ;ヒャッカ;テン,ドウヒャッカテン,同百貨店
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7743,7 +7743,7 @@
 
 # newdoc id = dev-s323
 # sent_id = dev-s323
-# parallel_id = jagsdluw/dev323
+# parallel_id = jagsd/dev323
 # text = ウエイトが増え、トレードマークだった金髪のロングヘアもすっかり薄くなったことから、それまでの伊達男キャラクターを完全に払拭。
 1	ウエイト	ウエイト	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウエート,ウエート,ウエイト,ウエイト,ウエート,,,ウエイト,ウエイト,ウエイト
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7775,7 +7775,7 @@
 
 # newdoc id = dev-s324
 # sent_id = dev-s324
-# parallel_id = jagsdluw/dev324
+# parallel_id = jagsd/dev324
 # text = ヨーロッパで重要なロマネスク建築の一つで、ユネスコの世界遺産に登録されている。
 1	ヨーロッパ	ヨーロッパ	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨーロッパ,ヨーロッパ,ヨーロッパ,ヨーロッパ,ヨーロッパ,,,ヨーロッパ,ヨーロッパ,ヨーロッパ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -7797,7 +7797,7 @@
 
 # newdoc id = dev-s325
 # sent_id = dev-s325
-# parallel_id = jagsdluw/dev325
+# parallel_id = jagsd/dev325
 # text = 本当に健康な人は,身体だけでなく肌もきれいです。
 1	本当	本当	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホントウ,本当,本当,本当,ホント,,,ホント,ホントウ,本当
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7816,7 +7816,7 @@
 
 # newdoc id = dev-s326
 # sent_id = dev-s326
-# parallel_id = jagsdluw/dev326
+# parallel_id = jagsd/dev326
 # text = 2万人を収容可能。
 1	2万人	2万人	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;マン;ニン,二;万;人,2;万;人,2;万;人,ニ;マン;ニン,;;,;;,ニ;マン;ニン,ニマンニン,2万人
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7825,7 +7825,7 @@
 
 # newdoc id = dev-s327
 # sent_id = dev-s327
-# parallel_id = jagsdluw/dev327
+# parallel_id = jagsd/dev327
 # text = これでも関係がないと言えるのか?
 1	これ	此れ	PRON	代名詞	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -7841,7 +7841,7 @@
 
 # newdoc id = dev-s328
 # sent_id = dev-s328
-# parallel_id = jagsdluw/dev328
+# parallel_id = jagsd/dev328
 # text = お医者さんも、日大の大学病院で脳神経外科にて手術などの実績が多数あり、脳神経外科を経て同じく耳鼻科の教授にスカウトされ脳の近くの部位である耳鼻咽喉科にて実績を積んだ優秀な先生と聞いています。
 1	お医者さん	御医者さん	NOUN	名詞-普通名詞-一般	_	16	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;イシャ;サン,御;医者;さん,お;医者;さん,お;医者;さん,オ;イシャ;サン,;;,;;,オ;イシャ;サン,オイシャサン,御医者さん
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -7894,7 +7894,7 @@
 
 # newdoc id = dev-s329
 # sent_id = dev-s329
-# parallel_id = jagsdluw/dev329
+# parallel_id = jagsd/dev329
 # text = それに,病気を治す力も知識もない人間がさも病気を治せるかのように言っていただけなのであれば,そもそも10円だって払う筋合いはないでしょう。
 1	それ	其れ	PRON	代名詞	_	37	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7938,7 +7938,7 @@
 
 # newdoc id = dev-s330
 # sent_id = dev-s330
-# parallel_id = jagsdluw/dev330
+# parallel_id = jagsd/dev330
 # text = 若い脳細胞に与える傷は,一生消えないでしょう。
 1	若い	若い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワカイ,若い,若い,若い,ワカイ,,,ワカイ,ワカイ,若い
 2	脳細胞	脳細胞	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノウ;サイボウ,脳;細胞,脳;細胞,脳;細胞,ノー;サイボー,;,;,ノウ;サイボウ,ノウサイボウ,脳細胞
@@ -7955,7 +7955,7 @@
 
 # newdoc id = dev-s331
 # sent_id = dev-s331
-# parallel_id = jagsdluw/dev331
+# parallel_id = jagsd/dev331
 # text = 1225年にバーベンベルク家のオーストリア公レオポルト6世の娘マルガレーテと結婚、ハインリヒ8世とフリードリヒ4世を儲けたがいずれも若くして早世した。
 1	1225年	1225年	NUM	名詞-数詞	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ニ;ニ;ゴ;ネン,一;二;二;五;年,1;2;2;5;年,1;2;2;5;年,イチ;ニ;ニ;ゴ;ネン,;;;;,;;;;,イチ;ニ;ニ;ゴ;ネン,イチニニゴネン,1225年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7989,7 +7989,7 @@
 
 # newdoc id = dev-s332
 # sent_id = dev-s332
-# parallel_id = jagsdluw/dev332
+# parallel_id = jagsd/dev332
 # text = 午前中の西光寺と違って,かなり広大な境内だったため,門の外からはモニターも見えずスピーカーからの声も聞き取れません。
 1	午前中	午前中	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴゼン;チュウ,午前;中,午前;中,午前;中,ゴゼン;チュー,;,;,ゴゼン;チュウ,ゴゼンチュウ,午前中
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8027,7 +8027,7 @@
 
 # newdoc id = dev-s333
 # sent_id = dev-s333
-# parallel_id = jagsdluw/dev333
+# parallel_id = jagsd/dev333
 # text = 松濤本部では拉致問題対策委員長補佐を務めているようだ。
 1	松濤本部	松濤本部	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショートー;ホンブ,ショートー;本部,松濤;本部,松濤;本部,ショートー;ホンブ,;,;,ショートー;ホンブ,ショートーホンブ,松濤本部
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8042,7 +8042,7 @@
 
 # newdoc id = dev-s334
 # sent_id = dev-s334
-# parallel_id = jagsdluw/dev334
+# parallel_id = jagsd/dev334
 # text = この日は、被害者の会の14人と弁護士3人が市役所を訪れ、福地直樹弁護士が「真相究明と被害救済のため、必要な措置を講じて欲しい」と述べて要請書を提出。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	日	日	NOUN	名詞-普通名詞-一般	_	14	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ヒ,,,ヒ,ヒ,日
@@ -8085,7 +8085,7 @@
 
 # newdoc id = dev-s335
 # sent_id = dev-s335
-# parallel_id = jagsdluw/dev335
+# parallel_id = jagsd/dev335
 # text = 魔法使いへの直接干渉に特化した唯一の魔法大系。
 1	魔法使い	魔法使い	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マホウ;ツカイ,魔法;使い,魔法;使い,魔法;使い,マホー;ツカイ,;,;,マホウ;ツカイ,マホウツカイ,魔法使い
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -8101,7 +8101,7 @@
 
 # newdoc id = dev-s336
 # sent_id = dev-s336
-# parallel_id = jagsdluw/dev336
+# parallel_id = jagsd/dev336
 # text = しかし、国民各層にはその考え方が次第に浸透して行き、自由民権運動の気運が高まるきっかけとなった。
 1	しかし	然し	CCONJ	接続詞	_	21	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8129,7 +8129,7 @@
 
 # newdoc id = dev-s337
 # sent_id = dev-s337
-# parallel_id = jagsdluw/dev337
+# parallel_id = jagsd/dev337
 # text = また髪型も京風の引き鬢ではなく、江戸風の出し鬢であった。
 1	また	又	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	髪型	髪型	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カミガタ,髪型,髪型,髪型,カミガタ,,,カミガタ,カミガタ,髪型
@@ -8148,7 +8148,7 @@
 
 # newdoc id = dev-s338
 # sent_id = dev-s338
-# parallel_id = jagsdluw/dev338
+# parallel_id = jagsd/dev338
 # text = 1940年7月、オデッサ軍管区の第35狙撃軍団長となり、ベッサラビアの占領に参加した。
 1	1940年	1940年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;ヨン;ゼロ;ネン,一;九;四;ゼロ;年,1;9;4;0;年,1;9;4;0;年,イチ;キュー;ヨン;ゼロ;ネン,;;;;,;;;;,イチ;キュウ;ヨン;ゼロ;ネン,イチキュウヨンゼロネン,1940年
 2	7月	7月	NUM	名詞-数詞	_	14	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シチ;ガツ,七;月,7;月,7;月,シチ;ガツ,;,;,シチ;ガツ,シチガツ,7月
@@ -8169,7 +8169,7 @@
 
 # newdoc id = dev-s339
 # sent_id = dev-s339
-# parallel_id = jagsdluw/dev339
+# parallel_id = jagsd/dev339
 # text = スタンディングでわいわいも2Fテーブル席でまったりでも楽しめる泡なドリンク専門のスタンディングバー。
 1	スタンディング	スタンディング	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタンディング,スタンディング,スタンディング,スタンディング,スタンディング,,,スタンディング,スタンディング,スタンディング
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8190,7 +8190,7 @@
 
 # newdoc id = dev-s340
 # sent_id = dev-s340
-# parallel_id = jagsdluw/dev340
+# parallel_id = jagsd/dev340
 # text = ところが2ちゃんねるの幸福の科学統合スレッドでは,この“主催者発表数”に疑問の声が挙がりました。
 1	ところが	所が	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トコロ;ガ,所;が,ところ;が,ところ;が,トコロ;ガ,;,;,トコロ;ガ,トコロガ,所が
 2	2ちゃんねる	2ちゃんねる	PROPN	名詞-固有名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;チャンネル,二;チャンネル,2;ちゃんねる,2;ちゃんねる,ニ;チャンネル,;,;,ニ;チャンネル,ニチャンネル,2ちゃんねる
@@ -8215,7 +8215,7 @@
 
 # newdoc id = dev-s341
 # sent_id = dev-s341
-# parallel_id = jagsdluw/dev341
+# parallel_id = jagsd/dev341
 # text = 実験室を1カ所に集めたオープンラボ方式を採用した。
 1	実験室	実験室	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジッケン;シツ,実験;室,実験;室,実験;室,ジッケン;シツ,;,;,ジッケン;シツ,ジッケンシツ,実験室
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8231,7 +8231,7 @@
 
 # newdoc id = dev-s342
 # sent_id = dev-s342
-# parallel_id = jagsdluw/dev342
+# parallel_id = jagsd/dev342
 # text = JR東日本のクモハ123-1とは種車が同じで、番号も続番となっているが、外観は大きく異なる。
 1	JR東日本	JR東日本	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェーアール;ヒガシ;ニッポン,ＪＲ;東;日本,JR;東;日本,JR;東;日本,ジェーアール;ヒガシ;ニホン,;;,;;,ジェーアール;ヒガシ;ニホン,ジェーアールヒガシニホン,JR東日本
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8259,7 +8259,7 @@
 
 # newdoc id = dev-s343
 # sent_id = dev-s343
-# parallel_id = jagsdluw/dev343
+# parallel_id = jagsd/dev343
 # text = 十六日の卒業式が中止になった文教大学越谷校舎の四年生ら学生有志約二百人が越谷市内の駅やスーパーの前などに立ち、被災者救援のために募金を呼び掛けた。
 1	十六日	十六日	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウ;ロク;ニチ,十;六;日,十;六;日,十;六;日,ジュー;ロク;ニチ,;;,;;,ジュウ;ロク;ニチ,ジュウロクニチ,十六日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8298,14 +8298,14 @@
 
 # newdoc id = dev-s344
 # sent_id = dev-s344
-# parallel_id = jagsdluw/dev344
+# parallel_id = jagsd/dev344
 # text = 東京都生まれ。
 1	東京都生まれ	東京都生まれ	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=トウキョウ;ト;ウマレ,トウキョウ;都;生まれ,東京;都;生まれ,東京;都;生まれ,トーキョー;ト;ウマレ,;;,;;,トウキョウ;ト;ウマレ,トウキョウトウマレ,東京都生まれ
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s345
 # sent_id = dev-s345
-# parallel_id = jagsdluw/dev345
+# parallel_id = jagsd/dev345
 # text = 幸福の科学の教えを信じお布施をし,さらに今回のデモに参加したにもかかわらず,教団に守ってもらえないのでは,信者が気の毒です。
 1	幸福の科学	幸福の科学	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ノ;カガク,幸福;の;科学,幸福;の;科学,幸福;の;科学,コーフク;ノ;カガク,;;,;;,コウフク;ノ;カガク,コウフクノカガク,幸福の科学
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8341,7 +8341,7 @@
 
 # newdoc id = dev-s346
 # sent_id = dev-s346
-# parallel_id = jagsdluw/dev346
+# parallel_id = jagsd/dev346
 # text = 大阪駅から徒歩10分圏内のスパホテルで、一人旅行でも利用できるし友達とも利用したカプセルホテルです。
 1	大阪駅	大阪駅	PROPN	名詞-固有名詞-地名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオサカ;エキ,オオサカ;駅,大阪;駅,大阪;駅,オーサカ;エキ,;,;,オオサカ;エキ,オオサカエキ,大阪駅
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -8367,7 +8367,7 @@
 
 # newdoc id = dev-s347
 # sent_id = dev-s347
-# parallel_id = jagsdluw/dev347
+# parallel_id = jagsd/dev347
 # text = 今回、アメリカ側は6カ国協議の再開に必要な条件を示すための「予備的な米朝協議だ」としていて、北朝鮮の出方を慎重に見極める方針です。
 1	今回	今回	ADV	副詞	_	23	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンカイ,今回,今回,今回,コンカイ,,,コンカイ,コンカイ,今回
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8408,7 +8408,7 @@
 
 # newdoc id = dev-s348
 # sent_id = dev-s348
-# parallel_id = jagsdluw/dev348
+# parallel_id = jagsd/dev348
 # text = 1985年8月28日生。
 1	1985年	1985年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;ハチ;ゴ;ネン,一;九;八;五;年,1;9;8;5;年,1;9;8;5;年,イチ;キュー;ハチ;ゴ;ネン,;;;;,;;;;,イチ;キュウ;ハチ;ゴ;ネン,イチキュウハチゴネン,1985年
 2	8月	8月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ハチ;ガツ,八;月,8;月,8;月,ハチ;ガツ,;,;,ハチ;ガツ,ハチガツ,8月
@@ -8417,7 +8417,7 @@
 
 # newdoc id = dev-s349
 # sent_id = dev-s349
-# parallel_id = jagsdluw/dev349
+# parallel_id = jagsd/dev349
 # text = オハイオ州政府のコンピュータにSETI@homeをインストールして使用したために解雇された例がある。
 1	オハイオ州政府	オハイオ州政府	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オハイオ;シュウ;セイフ,オハイオ;州;政府,オハイオ;州;政府,オハイオ;州;政府,オハイオ;シュー;セーフ,;;,;;,オハイオ;シュウ;セイフ,オハイオシュウセイフ,オハイオ州政府
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8440,7 +8440,7 @@
 
 # newdoc id = dev-s350
 # sent_id = dev-s350
-# parallel_id = jagsdluw/dev350
+# parallel_id = jagsd/dev350
 # text = 大震災に対応した特措法の議論も行っており、しかるべく対応したい」と答えました。
 1	大震災	大震災	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;シンサイ,大;震災,大;震災,大;震災,ダイ;シンサイ,;,;,ダイ;シンサイ,ダイシンサイ,大震災
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8466,7 +8466,7 @@
 
 # newdoc id = dev-s351
 # sent_id = dev-s351
-# parallel_id = jagsdluw/dev351
+# parallel_id = jagsd/dev351
 # text = それに対し、ヨハンネスの要求は「奴隷500人、牛5万頭、馬1,000頭の貢物と、メネリクを上半身裸にした上で罪人の首枷をつけて謝罪させる」というものだった。
 1	それ	其れ	PRON	代名詞	_	38	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	に対し	に対し	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;タイスル,に;対する,に;対し,に;対する,ニ;タイシ,;,;,ニ;タイスル,ニタイシ,に対し
@@ -8512,7 +8512,7 @@
 
 # newdoc id = dev-s352
 # sent_id = dev-s352
-# parallel_id = jagsdluw/dev352
+# parallel_id = jagsd/dev352
 # text = 以来、約10カ月ぶりに横田が復活。
 1	以来	以来	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イライ,以来,以来,以来,イライ,,,イライ,イライ,以来
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8525,7 +8525,7 @@
 
 # newdoc id = dev-s353
 # sent_id = dev-s353
-# parallel_id = jagsdluw/dev353
+# parallel_id = jagsd/dev353
 # text = MTXの適応が無い患者に対する第二選択薬として用いられることが多い。
 1	MTX	MTX	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エムティーエックス,ＭＴＸ,MTX,MTX,エムティーエックス,,,エムティーエックス,エムティーエックス,MTX
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8545,7 +8545,7 @@
 
 # newdoc id = dev-s354
 # sent_id = dev-s354
-# parallel_id = jagsdluw/dev354
+# parallel_id = jagsd/dev354
 # text = 体力とボールパワーが高いが、素早さが低い。
 1	体力	体力	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイリョク,体力,体力,体力,タイリョク,,,タイリョク,タイリョク,体力
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -8561,7 +8561,7 @@
 
 # newdoc id = dev-s355
 # sent_id = dev-s355
-# parallel_id = jagsdluw/dev355
+# parallel_id = jagsd/dev355
 # text = しかし彼のホームレス支援活動が悪いことだとは思えません。
 1	しかし	然し	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	彼	彼	PRON	代名詞	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カレ,彼,彼,彼,カレ,,,カレ,カレ,彼
@@ -8580,7 +8580,7 @@
 
 # newdoc id = dev-s356
 # sent_id = dev-s356
-# parallel_id = jagsdluw/dev356
+# parallel_id = jagsd/dev356
 # text = その日はたまたまサービスで生肉を出して頂いたが、味、食感ともに大した事はなかった。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	日	日	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ヒ,,,ヒ,ヒ,日
@@ -8609,7 +8609,7 @@
 
 # newdoc id = dev-s357
 # sent_id = dev-s357
-# parallel_id = jagsdluw/dev357
+# parallel_id = jagsd/dev357
 # text = 1967年、アレクサンダーは連邦上院議員ハワード・ベイカーの議会補佐官として勤務した。
 1	1967年	1967年	NUM	名詞-数詞	_	9	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ロク;シチ;ネン,一;九;六;七;年,1;9;6;7;年,1;9;6;7;年,イチ;キュー;ロク;シチ;ネン,;;;;,;;;;,イチ;キュウ;ロク;シチ;ネン,イチキュウロクシチネン,1967年
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8625,7 +8625,7 @@
 
 # newdoc id = dev-s358
 # sent_id = dev-s358
-# parallel_id = jagsdluw/dev358
+# parallel_id = jagsd/dev358
 # text = 自然を愛するため、同様の性格を持つタイガトロンと共に行動することが多いが、「基地は性に合わない」と零すタイガトロンと違い、特に合わない素振りは見せていない。
 1	自然	自然	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シゼン,自然,自然,自然,シゼン,,,シゼン,シゼン,自然
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8673,14 +8673,14 @@
 
 # newdoc id = dev-s359
 # sent_id = dev-s359
-# parallel_id = jagsdluw/dev359
+# parallel_id = jagsd/dev359
 # text = 県指定重要文化財・くまもとアートポリス選定既存建造物。
 1	県指定重要文化財・くまもとアートポリス選定既存建造物	県指定重要文化財・くまもとアートポリス選定既存建造物	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ケン;シテイ;ジュウヨウ;ブンカ;ザイ;;クマモト;アート;ポリス;センテイ;キソン;ケンゾウ;ブツ,県;指定;重要;文化;財;・;クマモト;アート;ポリス;選定;既存;建造;物,県;指定;重要;文化;財;・;くまもと;アート;ポリス;選定;既存;建造;物,県;指定;重要;文化;財;・;くまもと;アート;ポリス;選定;既存;建造;物,ケン;シテー;ジューヨー;ブンカ;ザイ;;クマモト;アート;ポリス;センテー;キゾン;ケンゾー;ブツ,;;;;;;;;;;;;,;;;;;;;;;;;;,ケン;シテイ;ジュウヨウ;ブンカ;ザイ;;クマモト;アート;ポリス;センテイ;キゾン;ケンゾウ;ブツ,ケンシテイジュウヨウブンカザイクマモトアートポリスセンテイキソンケンゾウブツ,県指定重要文化財・くまもとアートポリス選定既存建造物
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s360
 # sent_id = dev-s360
-# parallel_id = jagsdluw/dev360
+# parallel_id = jagsd/dev360
 # text = 病院に行かず治療も受けずになくなっています。
 1	病院	病院	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビョウイン,病院,病院,病院,ビョーイン,,,ビョウイン,ビョウイン,病院
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8698,7 +8698,7 @@
 
 # newdoc id = dev-s361
 # sent_id = dev-s361
-# parallel_id = jagsdluw/dev361
+# parallel_id = jagsd/dev361
 # text = 同時上映は『・ふ・た・り・ぼ・っ・ち・』。
 1	同時上映	同時上映	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウジ;ジョウエイ,同時;上映,同時;上映,同時;上映,ドージ;ジョーエー,;,;,ドウジ;ジョウエイ,ドウジジョウエイ,同時上映
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8709,7 +8709,7 @@
 
 # newdoc id = dev-s362
 # sent_id = dev-s362
-# parallel_id = jagsdluw/dev362
+# parallel_id = jagsd/dev362
 # text = 飲んだ後に行きたくなる。
 1	飲ん	飲む	VERB	動詞-一般-五段-マ行	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノム,飲む,飲ん,飲む,ノン,,,ノム,ノム,飲む
 2	だ	だ	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,だ,だ,ダ,,,ダ,ダ,だ
@@ -8722,7 +8722,7 @@
 
 # newdoc id = dev-s363
 # sent_id = dev-s363
-# parallel_id = jagsdluw/dev363
+# parallel_id = jagsd/dev363
 # text = 官位は従四位上・参議。
 1	官位	官位	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンイ,官位,官位,官位,カンイ,,,カンイ,カンイ,官位
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8731,7 +8731,7 @@
 
 # newdoc id = dev-s364
 # sent_id = dev-s364
-# parallel_id = jagsdluw/dev364
+# parallel_id = jagsd/dev364
 # text = 日本に馴染み、短い間に日本語を覚えたセルギイは、日露戦争の結果、日本が獲得した樺太で没収された資産を信徒に返還するため、正教徒のスポークスマンとして活動した。
 1	日本	日本	PROPN	名詞-固有名詞-地名-国	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニッポン,,,ニッポン,ニッポン,日本
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8777,7 +8777,7 @@
 
 # newdoc id = dev-s365
 # sent_id = dev-s365
-# parallel_id = jagsdluw/dev365
+# parallel_id = jagsd/dev365
 # text = ちなみに、大阪市は現在の長居公園に1951年11月、大阪競馬場を利用して、市営の長居オートレース場も開設したが、爆音にかかる周辺環境問題や経営不振を理由に、わずか5ヶ月で廃止した。
 1	ちなみに	因みに	CCONJ	接続詞	_	38	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チナミ;ニ,因み;に,ちなみ;に,ちなみ;に,チナミ;ニ,;,;,チナミ;ニ,チナミニ,因みに
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8822,7 +8822,7 @@
 
 # newdoc id = dev-s366
 # sent_id = dev-s366
-# parallel_id = jagsdluw/dev366
+# parallel_id = jagsd/dev366
 # text = 幸福実現党では,唯一の国会議員であった大江康弘参議院議員も昨年末に離党しています。
 1	幸福実現党	幸福実現党	PROPN	名詞-固有名詞-一般	_	14	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ジツゲン;トウ,幸福;実現;党,幸福;実現;党,幸福;実現;党,コーフク;ジツゲン;トー,;;,;;,コウフク;ジツゲン;トウ,コウフクジツゲントウ,幸福実現党
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8844,7 +8844,7 @@
 
 # newdoc id = dev-s367
 # sent_id = dev-s367
-# parallel_id = jagsdluw/dev367
+# parallel_id = jagsd/dev367
 # text = この後結成した「アテナ&ロビケロッツ」「ガーディアンズ4」、また2009年6月にチャンプルユニットとして結成されたタンポポ#・プッチモニV・ZYX-α・続・美勇伝にも選抜参加したメンバーがいる。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	後	後	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アト,後,後,後,アト,,,アト,アト,後
@@ -8878,7 +8878,7 @@
 
 # newdoc id = dev-s368
 # sent_id = dev-s368
-# parallel_id = jagsdluw/dev368
+# parallel_id = jagsd/dev368
 # text = 玉子チリソースも気になった。
 1	玉子チリソース	卵チリソース	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タマゴ;チリ;ソース,卵;チリ;ソース,玉子;チリ;ソース,玉子;チリ;ソース,タマゴ;チリ;ソース,;;,;;,タマゴ;チリ;ソース,タマゴチリソース,卵チリソース
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -8890,7 +8890,7 @@
 
 # newdoc id = dev-s369
 # sent_id = dev-s369
-# parallel_id = jagsdluw/dev369
+# parallel_id = jagsd/dev369
 # text = その後、1948年8月25日の代議員選挙によって北朝鮮最高人民会議が設立され、9月3日には北朝鮮憲法が公式採択された。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -8919,7 +8919,7 @@
 
 # newdoc id = dev-s370
 # sent_id = dev-s370
-# parallel_id = jagsdluw/dev370
+# parallel_id = jagsd/dev370
 # text = 最後に穀物の珈琲とデザートまで付いてくるのです。
 1	最後	最後	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイゴ,最後,最後,最後,サイゴ,,,サイゴ,サイゴ,最後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8936,7 +8936,7 @@
 
 # newdoc id = dev-s371
 # sent_id = dev-s371
-# parallel_id = jagsdluw/dev371
+# parallel_id = jagsd/dev371
 # text = ディスクを取り外し可能なハードディスクのこと。
 1	ディスク	ディスク	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ディスク,ディスク,ディスク,ディスク,ディスク,,,ディスク,ディスク,ディスク
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8949,7 +8949,7 @@
 
 # newdoc id = dev-s372
 # sent_id = dev-s372
-# parallel_id = jagsdluw/dev372
+# parallel_id = jagsd/dev372
 # text = NPTLはRed Hat Enterprise Linuxのバージョン3から搭載され、現在ではGNU Cライブラリの一部となっている。
 1	NPTL	NPTL	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エヌピーティーエル,ＮＰＴＬ,NPTL,NPTL,エヌピーティーエル,,,エヌピーティーエル,エヌピーティーエル,NPTL
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8974,7 +8974,7 @@
 
 # newdoc id = dev-s373
 # sent_id = dev-s373
-# parallel_id = jagsdluw/dev373
+# parallel_id = jagsd/dev373
 # text = フェレット装甲車の設計と形状は前任のダイムラー偵察車との共通点が多いが、フェレット装甲車はダイムラー偵察車よりも戦闘区画が広く小さな機関銃付の砲塔を装備している。
 1	フェレット装甲車	フェレット装甲車	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フェレット;ソウコウ;シャ,フェレット;装甲;車,フェレット;装甲;車,フェレット;装甲;車,フェレット;ソーコー;シャ,;;,;;,フェレット;ソウコウ;シャ,フェレットソウコウシャ,フェレット装甲車
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9011,7 +9011,7 @@
 
 # newdoc id = dev-s374
 # sent_id = dev-s374
-# parallel_id = jagsdluw/dev374
+# parallel_id = jagsd/dev374
 # text = 作中では、皇一心や率いる集団の社会階級の明確な描写はされていない。
 1	作中	作中	NOUN	名詞-普通名詞-一般	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクチュウ,作中,作中,作中,サクチュー,,,サクチュウ,サクチュウ,作中
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9036,7 +9036,7 @@
 
 # newdoc id = dev-s375
 # sent_id = dev-s375
-# parallel_id = jagsdluw/dev375
+# parallel_id = jagsd/dev375
 # text = また“名進信徒会”の所在地についても“わかりません”。
 1	また	又	CCONJ	接続詞	_	10	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	“	“	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
@@ -9055,7 +9055,7 @@
 
 # newdoc id = dev-s376
 # sent_id = dev-s376
-# parallel_id = jagsdluw/dev376
+# parallel_id = jagsd/dev376
 # text = いつも飲み慣れている祖父が、突然、割ってあると言い出したのです。
 1	いつ	何時	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イツ,何時,いつ,いつ,イツ,,,イツ,イツ,何時
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -9076,7 +9076,7 @@
 
 # newdoc id = dev-s377
 # sent_id = dev-s377
-# parallel_id = jagsdluw/dev377
+# parallel_id = jagsd/dev377
 # text = ポール・ウェラーからセッションやオープニングアクトのオファーを受けるなど、高い評価を得ている。
 1	ポール・ウェラー	ポール・ウェラー	PROPN	名詞-固有名詞-人名-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ポール;;ウェラー,ポール;・;ウェラー,ポール;・;ウェラー,ポール;・;ウェラー,ポール;;ウェラー,;;,;;,ポール;;ウェラー,ポールウェラー,ポール・ウェラー
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -9098,7 +9098,7 @@
 
 # newdoc id = dev-s378
 # sent_id = dev-s378
-# parallel_id = jagsdluw/dev378
+# parallel_id = jagsd/dev378
 # text = しかし、憲法訴訟という類型自体が存在しないとしても、憲法判断の重要性から、憲法訴訟に特有の理論を考察する学問分野がある。
 1	しかし	然し	CCONJ	接続詞	_	25	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9129,7 +9129,7 @@
 
 # newdoc id = dev-s379
 # sent_id = dev-s379
-# parallel_id = jagsdluw/dev379
+# parallel_id = jagsd/dev379
 # text = 最も知られた蔵本モデルの形式は次のような支配方程式に従う。
 1	最も	最も	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モットモ,最も,最も,最も,モットモ,,,モットモ,モットモ,最も
 2	知ら	知る	VERB	動詞-一般-五段-ラ行	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シル,知る,知ら,知る,シラ,,,シル,シル,知る
@@ -9150,7 +9150,7 @@
 
 # newdoc id = dev-s380
 # sent_id = dev-s380
-# parallel_id = jagsdluw/dev380
+# parallel_id = jagsd/dev380
 # text = 彼に関する本を何冊も読みましたし,彼のプレゼンをYou Tubeで見ては興奮していました。
 1	彼	彼	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カレ,彼,彼,彼,カレ,,,カレ,カレ,彼
 2	に関する	に関する	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;カンスル,に;関する,に;関する,に;関する,ニ;カンスル,;,;,ニ;カンスル,ニカンスル,に関する
@@ -9180,7 +9180,7 @@
 
 # newdoc id = dev-s381
 # sent_id = dev-s381
-# parallel_id = jagsdluw/dev381
+# parallel_id = jagsd/dev381
 # text = アメリカの研究者や中国の臨床試験で,免疫システムの病気であるリューマチにも効果がすぐれているということも証明されました。
 1	アメリカ	アメリカ	PROPN	名詞-固有名詞-地名-国	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アメリカ,アメリカ,アメリカ,アメリカ,アメリカ,,,アメリカ,アメリカ,アメリカ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9213,7 +9213,7 @@
 
 # newdoc id = dev-s382
 # sent_id = dev-s382
-# parallel_id = jagsdluw/dev382
+# parallel_id = jagsd/dev382
 # text = 新宿の高速バスを利用するときは必ず足を運んでしまう。
 1	新宿	新宿	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンジュク,シンジュク,新宿,新宿,シンジュク,,,シンジュク,シンジュク,新宿
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9231,7 +9231,7 @@
 
 # newdoc id = dev-s383
 # sent_id = dev-s383
-# parallel_id = jagsdluw/dev383
+# parallel_id = jagsd/dev383
 # text = お店の雰囲気も活気がある感じが気に入っています。
 1	お店	御店	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセ,御;店,お;店,お;店,オ;ミセ,;,;,オ;ミセ,オミセ,御店
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9251,7 +9251,7 @@
 
 # newdoc id = dev-s384
 # sent_id = dev-s384
-# parallel_id = jagsdluw/dev384
+# parallel_id = jagsd/dev384
 # text = 1979年、DECを辞めて作家専業となり、フロリダ州オーランドに移住した。
 1	1979年	1979年	NUM	名詞-数詞	_	14	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ナナ;キュウ;ネン,一;九;七;九;年,1;9;7;9;年,1;9;7;9;年,イチ;キュー;ナナ;キュー;ネン,;;;;,;;;;,イチ;キュウ;ナナ;キュウ;ネン,イチキュウナナキュウネン,1979年
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9272,7 +9272,7 @@
 
 # newdoc id = dev-s385
 # sent_id = dev-s385
-# parallel_id = jagsdluw/dev385
+# parallel_id = jagsd/dev385
 # text = 板門店内および共同警備区域においては、韓国軍を中心とした国連軍と、北朝鮮軍の両軍が境界線を隔てて顔を合わせ警備についている。
 1	板門店内	板門店内	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハンモンテン;ナイ,ハンモンテン;内,板門店;内,板門店;内,ハンモンテン;ナイ,;,;,ハンモンテン;ナイ,ハンモンテンナイ,板門店内
 2	および	及び	CCONJ	接続詞	_	3	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オヨビ,及び,および,および,オヨビ,,,オヨビ,オヨビ,及び
@@ -9308,7 +9308,7 @@
 
 # newdoc id = dev-s386
 # sent_id = dev-s386
-# parallel_id = jagsdluw/dev386
+# parallel_id = jagsd/dev386
 # text = 以上の方面は、当駅は途中バス停である。
 1	以上	以上	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イジョウ,以上,以上,以上,イジョー,,,イジョウ,イジョウ,以上
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9323,7 +9323,7 @@
 
 # newdoc id = dev-s387
 # sent_id = dev-s387
-# parallel_id = jagsdluw/dev387
+# parallel_id = jagsd/dev387
 # text = 子どもが熱をだしとても親切に診ていただきました。
 1	子ども	子共	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コドモ,子供,子ども,子ども,コドモ,,,コドモ,コドモ,子共
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9341,7 +9341,7 @@
 
 # newdoc id = dev-s388
 # sent_id = dev-s388
-# parallel_id = jagsdluw/dev388
+# parallel_id = jagsd/dev388
 # text = そこで今月19日に開かれた“家系のおはなし”講演会に参加した。
 1	そこ	其処	PRON	代名詞	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソコ,其処,そこ,そこ,ソコ,,,ソコ,ソコ,其処
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9364,7 +9364,7 @@
 
 # newdoc id = dev-s389
 # sent_id = dev-s389
-# parallel_id = jagsdluw/dev389
+# parallel_id = jagsd/dev389
 # text = 当初は2008年4月1日から2011年3月31日までの3年間の契約で命名権が売却されたが、2010年12月-2011年1月にかけて実施された同ホールの命名権募集に穴吹興産1社しか応募がなかったため、同社との間で2011年4月1日から2016年3月31日の5年間の契約で命名権が売却された。
 1	当初	当初	NOUN	名詞-普通名詞-一般	_	18	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9438,7 +9438,7 @@
 
 # newdoc id = dev-s390
 # sent_id = dev-s390
-# parallel_id = jagsdluw/dev390
+# parallel_id = jagsd/dev390
 # text = 昔話を聞くと興奮して発砲する。
 1	昔話	昔話	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ムカシバナシ,昔話,昔話,昔話,ムカシバナシ,,,ムカシバナシ,ムカシバナシ,昔話
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -9451,7 +9451,7 @@
 
 # newdoc id = dev-s391
 # sent_id = dev-s391
-# parallel_id = jagsdluw/dev391
+# parallel_id = jagsd/dev391
 # text = 由来はヤコブから。
 1	由来	由来	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユライ,由来,由来,由来,ユライ,,,ユライ,ユライ,由来
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9461,7 +9461,7 @@
 
 # newdoc id = dev-s392
 # sent_id = dev-s392
-# parallel_id = jagsdluw/dev392
+# parallel_id = jagsd/dev392
 # text = ブルジョア教育を最も推進しているのは,日本共産党である。
 1	ブルジョア教育	ブルジョア教育	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ブルジョア;キョウイク,ブルジョア;教育,ブルジョア;教育,ブルジョア;教育,ブルジョア;キョーイク,;,;,ブルジョア;キョウイク,ブルジョアキョウイク,ブルジョア教育
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -9477,7 +9477,7 @@
 
 # newdoc id = dev-s393
 # sent_id = dev-s393
-# parallel_id = jagsdluw/dev393
+# parallel_id = jagsd/dev393
 # text = 部屋へ入るとドライヤーや鏡があり、明らかに宿泊用の部屋といった感じでした。
 1	部屋	部屋	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヘヤ,部屋,部屋,部屋,ヘヤ,,,ヘヤ,ヘヤ,部屋
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -9502,7 +9502,7 @@
 
 # newdoc id = dev-s394
 # sent_id = dev-s394
-# parallel_id = jagsdluw/dev394
+# parallel_id = jagsd/dev394
 # text = それに加えて,毎月の損失を50%以上軽減するための大規模な努力がなされました。
 1	それ	其れ	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9528,7 +9528,7 @@
 
 # newdoc id = dev-s395
 # sent_id = dev-s395
-# parallel_id = jagsdluw/dev395
+# parallel_id = jagsd/dev395
 # text = そのほかの主要任務としては「レーベンスボルン」と「アーネンエルベ」の実質的な運営があった。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ほか	他	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
@@ -9554,7 +9554,7 @@
 
 # newdoc id = dev-s396
 # sent_id = dev-s396
-# parallel_id = jagsdluw/dev396
+# parallel_id = jagsd/dev396
 # text = 警視庁や証券取引等監視委員会と合同で一斉捜索する見通し。
 1	警視庁	警視庁	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイシ;チョウ,警視;庁,警視;庁,警視;庁,ケーシ;チョー,;,;,ケイシ;チョウ,ケイシチョウ,警視庁
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -9568,7 +9568,7 @@
 
 # newdoc id = dev-s397
 # sent_id = dev-s397
-# parallel_id = jagsdluw/dev397
+# parallel_id = jagsd/dev397
 # text = 2005年にオランダのスパルタ・ロッテルダムへ移籍した。
 1	2005年	2005年	NUM	名詞-数詞	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ゴ;ネン,二;ゼロ;ゼロ;五;年,2;0;0;5;年,2;0;0;5;年,ニ;ゼロ;ゼロ;ゴ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ゴ;ネン,ニゼロゼロゴネン,2005年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9582,7 +9582,7 @@
 
 # newdoc id = dev-s398
 # sent_id = dev-s398
-# parallel_id = jagsdluw/dev398
+# parallel_id = jagsd/dev398
 # text = 2013年、栃木SCのシニアアドバイザーに就任。
 1	2013年	2013年	NUM	名詞-数詞	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;サン;ネン,二;ゼロ;一;三;年,2;0;1;3;年,2;0;1;3;年,ニ;ゼロ;イチ;サン;ネン,;;;;,;;;;,ニ;ゼロ;イチ;サン;ネン,ニゼロイチサンネン,2013年
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9595,7 +9595,7 @@
 
 # newdoc id = dev-s399
 # sent_id = dev-s399
-# parallel_id = jagsdluw/dev399
+# parallel_id = jagsd/dev399
 # text = 元々は、済美女子高等学校であったが、2004年4月から男女共学部普通科を設置し、名称が済美高等学校となった。
 1	元々	元々	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モトモト,元々,元々,元々,モトモト,,,モトモト,モトモト,元々
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9623,7 +9623,7 @@
 
 # newdoc id = dev-s400
 # sent_id = dev-s400
-# parallel_id = jagsdluw/dev400
+# parallel_id = jagsd/dev400
 # text = ハーダーは第二次世界大戦の戦功で6個の従軍星章を受章した。
 1	ハーダー	ハーダー	PROPN	名詞-固有名詞-人名-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハーダー,ハーダー,ハーダー,ハーダー,ハーダー,,,ハーダー,ハーダー,ハーダー
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9641,7 +9641,7 @@
 
 # newdoc id = dev-s401
 # sent_id = dev-s401
-# parallel_id = jagsdluw/dev401
+# parallel_id = jagsd/dev401
 # text = かつては、塩山-丹波-奥多摩駅という形で山梨交通との相互乗り入れを行っていたが、利用客の減少などにより、1972年で廃止になっている。
 1	かつて	嘗て	ADV	副詞	_	13	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カツテ,嘗て,かつて,かつて,カツテ,,,カツテ,カツテ,嘗て
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9676,7 +9676,7 @@
 
 # newdoc id = dev-s402
 # sent_id = dev-s402
-# parallel_id = jagsdluw/dev402
+# parallel_id = jagsd/dev402
 # text = 所属事務所は米朝事務所。
 1	所属事務所	所属事務所	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショゾク;ジム;ショ,所属;事務;所,所属;事務;所,所属;事務;所,ショゾク;ジム;ショ,;;,;;,ショゾク;ジム;ショ,ショゾクジムショ,所属事務所
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9685,7 +9685,7 @@
 
 # newdoc id = dev-s403
 # sent_id = dev-s403
-# parallel_id = jagsdluw/dev403
+# parallel_id = jagsd/dev403
 # text = 狭いお店だけど、パンだけじゃなく結構変わったかりんとうなんかも売ってました。
 1	狭い	狭い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セマイ,狭い,狭い,狭い,セマイ,,,セマイ,セマイ,狭い
 2	お店	御店	NOUN	名詞-普通名詞-一般	_	16	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセ,御;店,お;店,お;店,オ;ミセ,;,;,オ;ミセ,オミセ,御店
@@ -9710,7 +9710,7 @@
 
 # newdoc id = dev-s404
 # sent_id = dev-s404
-# parallel_id = jagsdluw/dev404
+# parallel_id = jagsd/dev404
 # text = 拉致監禁強制改宗は犯罪だ!
 1	拉致監禁強制改宗	拉致監禁強制改宗	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ラチ;カンキン;キョウセイ;カイシュウ,拉致;監禁;強制;改宗,拉致;監禁;強制;改宗,拉致;監禁;強制;改宗,ラチ;カンキン;キョーセー;カイシュー,;;;,;;;,ラチ;カンキン;キョウセイ;カイシュウ,ラチカンキンキョウセイカイシュウ,拉致監禁強制改宗
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9720,7 +9720,7 @@
 
 # newdoc id = dev-s405
 # sent_id = dev-s405
-# parallel_id = jagsdluw/dev405
+# parallel_id = jagsd/dev405
 # text = 京成本線町屋駅-千住大橋駅の間に存在していた。
 1	京成本線町屋駅-千住大橋駅	京成本線町家駅-千住大橋駅	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイセイ;ホンセン;マチヤ;エキ;;センジュ;オオハシ;エキ,京成;本線;町家;駅;-;センジュ;大橋;駅,京成;本線;町屋;駅;-;千住;大橋;駅,京成;本線;町屋;駅;-;千住;大橋;駅,ケーセー;ホンセン;マチヤ;エキ;;センジュ;オーハシ;エキ,;;;;;;;,;;;;;;;,ケイセイ;ホンセン;マチヤ;エキ;;センジュ;オオハシ;エキ,ケイセイホンセンマチヤエキセンジュオオハシエキ,京成本線町家駅-千住大橋駅
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9733,7 +9733,7 @@
 
 # newdoc id = dev-s406
 # sent_id = dev-s406
-# parallel_id = jagsdluw/dev406
+# parallel_id = jagsd/dev406
 # text = 製品生産者たちはまだ自らのウェブサイトで広告するという手段を持っておらず、宣伝には「AOL Key words」を利用していた。
 1	製品生産者たち	製品生産者達	NOUN	名詞-普通名詞-一般	_	12	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイヒン;セイサン;シャ;タチ,製品;生産;者;達,製品;生産;者;たち,製品;生産;者;たち,セーヒン;セーサン;シャ;タチ,;;;,;;;,セイヒン;セイサン;シャ;タチ,セイヒンセイサンシャタチ,製品生産者達
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9764,7 +9764,7 @@
 
 # newdoc id = dev-s407
 # sent_id = dev-s407
-# parallel_id = jagsdluw/dev407
+# parallel_id = jagsd/dev407
 # text = 1819年から1821年までの間にヴィルヘルムス運河が造られ、特にハイルブロンナー製紙によって発展した工業地域の立地に寄与した。
 1	1819年	1819年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;イチ;キュウ;ネン,一;八;一;九;年,1;8;1;9;年,1;8;1;9;年,イチ;ハチ;イチ;キュー;ネン,;;;;,;;;;,イチ;ハチ;イチ;キュウ;ネン,イチハチイチキュウネン,1819年
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -9793,7 +9793,7 @@
 
 # newdoc id = dev-s408
 # sent_id = dev-s408
-# parallel_id = jagsdluw/dev408
+# parallel_id = jagsd/dev408
 # text = 教団内では“科学技術省次官”の地位にありました。
 1	教団内	教団内	NOUN	名詞-普通名詞-一般	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウダン;ナイ,教団;内,教団;内,教団;内,キョーダン;ナイ,;,;,キョウダン;ナイ,キョウダンナイ,教団内
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9811,7 +9811,7 @@
 
 # newdoc id = dev-s409
 # sent_id = dev-s409
-# parallel_id = jagsdluw/dev409
+# parallel_id = jagsd/dev409
 # text = 強い香りを持つ植物である。
 1	強い	強い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツヨイ,強い,強い,強い,ツヨイ,,,ツヨイ,ツヨイ,強い
 2	香り	香り	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カオリ,香り,香り,香り,カオリ,,,カオリ,カオリ,香り
@@ -9823,7 +9823,7 @@
 
 # newdoc id = dev-s410
 # sent_id = dev-s410
-# parallel_id = jagsdluw/dev410
+# parallel_id = jagsd/dev410
 # text = 女性も大丈夫です。
 1	女性	女性	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョセイ,女性,女性,女性,ジョセー,,,ジョセイ,ジョセイ,女性
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -9833,7 +9833,7 @@
 
 # newdoc id = dev-s411
 # sent_id = dev-s411
-# parallel_id = jagsdluw/dev411
+# parallel_id = jagsd/dev411
 # text = 従来予想は微増の19億円。
 1	従来予想	従来予想	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウライ;ヨソウ,従来;予想,従来;予想,従来;予想,ジューライ;ヨソー,;,;,ジュウライ;ヨソウ,ジュウライヨソウ,従来予想
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9844,7 +9844,7 @@
 
 # newdoc id = dev-s412
 # sent_id = dev-s412
-# parallel_id = jagsdluw/dev412
+# parallel_id = jagsd/dev412
 # text = この方は,本紙<沖縄知事選めぐり大江議員と幸福実現党が対立>登場された方です。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	方	方	NOUN	名詞-普通名詞-一般	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カタ,方,方,方,カタ,,,カタ,カタ,方
@@ -9869,7 +9869,7 @@
 
 # newdoc id = dev-s413
 # sent_id = dev-s413
-# parallel_id = jagsdluw/dev413
+# parallel_id = jagsd/dev413
 # text = 1708年にカルロが死ぬと、マントヴァ公位は廃位され、ゴンザーガ家は永久にマントヴァを失い、以後ハプスブルク家支配となった。
 1	1708年	1708年	NUM	名詞-数詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ナナ;ゼロ;ハチ;ネン,一;七;ゼロ;八;年,1;7;0;8;年,1;7;0;8;年,イチ;ナナ;ゼロ;ハチ;ネン,;;;;,;;;;,イチ;ナナ;ゼロ;ハチ;ネン,イチナナゼロハチネン,1708年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9900,7 +9900,7 @@
 
 # newdoc id = dev-s414
 # sent_id = dev-s414
-# parallel_id = jagsdluw/dev414
+# parallel_id = jagsd/dev414
 # text = ちょっとした遊具もあるので小さな子どもさんもいいと思います。
 1	ちょっとし	一寸する	VERB	動詞-一般-サ行変格	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョット;スル,一寸;為る,ちょっと;し,ちょっと;する,チョット;シ,;,;,チョット;スル,チョットスル,一寸する
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -9919,7 +9919,7 @@
 
 # newdoc id = dev-s415
 # sent_id = dev-s415
-# parallel_id = jagsdluw/dev415
+# parallel_id = jagsd/dev415
 # text = SEXが強すぎるのかも知れない。
 1	SEX	SEX	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セックス,セックス,SEX,SEX,セックス,,,セックス,セックス,SEX
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9930,7 +9930,7 @@
 
 # newdoc id = dev-s416
 # sent_id = dev-s416
-# parallel_id = jagsdluw/dev416
+# parallel_id = jagsd/dev416
 # text = 所属事務所はBreath。
 1	所属事務所	所属事務所	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショゾク;ジム;ショ,所属;事務;所,所属;事務;所,所属;事務;所,ショゾク;ジム;ショ,;;,;;,ショゾク;ジム;ショ,ショゾクジムショ,所属事務所
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9939,7 +9939,7 @@
 
 # newdoc id = dev-s417
 # sent_id = dev-s417
-# parallel_id = jagsdluw/dev417
+# parallel_id = jagsd/dev417
 # text = 紳助さんは、先月23日の引退記者会見で、十数年前にあったトラブルを解決してくれたのが、暴力団関係者だったことを明らかにした。
 1	紳助さん	紳助さん	PROPN	名詞-固有名詞-人名-名	_	29	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンスケ;サン,シンスケ;さん,紳助;さん,紳助;さん,シンスケ;サン,;,;,シンスケ;サン,シンスケサン,紳助さん
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9975,7 +9975,7 @@
 
 # newdoc id = dev-s418
 # sent_id = dev-s418
-# parallel_id = jagsdluw/dev418
+# parallel_id = jagsd/dev418
 # text = 自分の身は自分で守ろう!
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9988,7 +9988,7 @@
 
 # newdoc id = dev-s419
 # sent_id = dev-s419
-# parallel_id = jagsdluw/dev419
+# parallel_id = jagsd/dev419
 # text = 清代は湖北省が置かれ、そのまま現代の行政区分になっている。
 1	清代	清代	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンダイ,清代,清代,清代,シンダイ,,,シンダイ,シンダイ,清代
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10009,7 +10009,7 @@
 
 # newdoc id = dev-s420
 # sent_id = dev-s420
-# parallel_id = jagsdluw/dev420
+# parallel_id = jagsd/dev420
 # text = 戦死後に彼の妻から譲られる「ナイトシールド」は、彼の形見でもある。
 1	戦死後	戦死後	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センシ;ゴ,戦死;後,戦死;後,戦死;後,センシ;ゴ,;,;,センシ;ゴ,センシゴ,戦死後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -10032,7 +10032,7 @@
 
 # newdoc id = dev-s421
 # sent_id = dev-s421
-# parallel_id = jagsdluw/dev421
+# parallel_id = jagsd/dev421
 # text = 建造物も仏像も中国明朝時代を偲ばせています。
 1	建造物	建造物	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケンゾウ;ブツ,建造;物,建造;物,建造;物,ケンゾー;ブツ,;,;,ケンゾウ;ブツ,ケンゾウブツ,建造物
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -10048,7 +10048,7 @@
 
 # newdoc id = dev-s422
 # sent_id = dev-s422
-# parallel_id = jagsdluw/dev422
+# parallel_id = jagsd/dev422
 # text = これからは花こうさんをずっと利用したいと思っています。
 1	これ	此れ	PRON	代名詞	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -10066,7 +10066,7 @@
 
 # newdoc id = dev-s423
 # sent_id = dev-s423
-# parallel_id = jagsdluw/dev423
+# parallel_id = jagsd/dev423
 # text = また、この番組は公開録音スタイルがとられており、当初は改装前の第3スタジオでギャラリーも5~6人だったが、その後常時10人以上集まるように更にギャラリーの数が増えたため広い第1スタジオに移って収録するようになった。
 1	また	又	CCONJ	接続詞	_	48	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10121,7 +10121,7 @@
 
 # newdoc id = dev-s424
 # sent_id = dev-s424
-# parallel_id = jagsdluw/dev424
+# parallel_id = jagsd/dev424
 # text = 同コーナーの放送開始と終了時には、この定点カメラの映像とは別に部屋全体を映す別の固定カメラの映像を使用している。
 1	同コーナー	同コーナー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;コーナー,同;コーナー,同;コーナー,同;コーナー,ドー;コーナー,;,;,ドウ;コーナー,ドウコーナー,同コーナー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10154,7 +10154,7 @@
 
 # newdoc id = dev-s425
 # sent_id = dev-s425
-# parallel_id = jagsdluw/dev425
+# parallel_id = jagsd/dev425
 # text = この曲は、1964年のテレビドラマ版の主題歌であると誤解されやすいが、ドラマで使用されたのはシンプルなインストルメンタルBGM曲のみで、青山和子が歌うこのレコード企画とは全く別のプロジェクトである。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	曲	曲	NOUN	名詞-普通名詞-一般	_	12	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョク,曲,曲,曲,キョク,,,キョク,キョク,曲
@@ -10199,7 +10199,7 @@
 
 # newdoc id = dev-s426
 # sent_id = dev-s426
-# parallel_id = jagsdluw/dev426
+# parallel_id = jagsd/dev426
 # text = ローズクランズはイウカでは縮小されたミシシッピ軍を率い、コリンスではテネシー軍からの2個師団の支援を受けた。
 1	ローズクランズ	ローズクランズ	PROPN	名詞-固有名詞-人名-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ローズクランズ,ローズクランズ,ローズクランズ,ローズクランズ,ローズクランズ,,,ローズクランズ,ローズクランズ,ローズクランズ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10229,7 +10229,7 @@
 
 # newdoc id = dev-s427
 # sent_id = dev-s427
-# parallel_id = jagsdluw/dev427
+# parallel_id = jagsd/dev427
 # text = バニラアイスが大好物。
 1	バニラアイス	バニラアイス	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バニラ;アイス,バニラ;アイス,バニラ;アイス,バニラ;アイス,バニラ;アイス,;,;,バニラ;アイス,バニラアイス,バニラアイス
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -10238,7 +10238,7 @@
 
 # newdoc id = dev-s428
 # sent_id = dev-s428
-# parallel_id = jagsdluw/dev428
+# parallel_id = jagsd/dev428
 # text = インターネットにおける個人の報道活動の意義と実状を全く無視した,あまりに時代錯誤な最高裁の判決を,本紙は強く非難します。
 1	インターネット	インターネット	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=インターネット,インターネット,インターネット,インターネット,インターネット,,,インターネット,インターネット,インターネット
 2	における	における	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;オク;リ,に;於く;り,に;おけ;る,に;おく;り,ニ;オケ;ル,;;,;;,ニ;オク;リ,ニオケル,における
@@ -10272,7 +10272,7 @@
 
 # newdoc id = dev-s429
 # sent_id = dev-s429
-# parallel_id = jagsdluw/dev429
+# parallel_id = jagsd/dev429
 # text = しかし、正恩氏は軍大将として登場し、活動を部隊視察から始めた。
 1	しかし	然し	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10292,7 +10292,7 @@
 
 # newdoc id = dev-s430
 # sent_id = dev-s430
-# parallel_id = jagsdluw/dev430
+# parallel_id = jagsd/dev430
 # text = その3分の2近くが統一教会関係者のようでした。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	3分の2近く	3分の2近く	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ブン;ノ;ニ;チカク,三;分;の;二;近く,3;分;の;2;近く,3;分;の;2;近く,サン;ブン;ノ;ニ;チカク,;;;;,;;;;,サン;ブン;ノ;ニ;チカク,サンブンノニチカク,3分の2近く
@@ -10306,7 +10306,7 @@
 
 # newdoc id = dev-s431
 # sent_id = dev-s431
-# parallel_id = jagsdluw/dev431
+# parallel_id = jagsd/dev431
 # text = 状況によっては統一教会擁護の論陣を張ろうと思っています。
 1	状況	状況	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョウキョウ,状況,状況,状況,ジョーキョー,,,ジョウキョウ,ジョウキョウ,状況
 2	によって	によって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;テ,に;因る;て,に;よっ;て,に;よる;て,ニ;ヨッ;テ,;;,;;,ニ;ヨル;テ,ニヨッテ,によって
@@ -10324,7 +10324,7 @@
 
 # newdoc id = dev-s432
 # sent_id = dev-s432
-# parallel_id = jagsdluw/dev432
+# parallel_id = jagsd/dev432
 # text = 治療はステロイドの内服が中心だという。
 1	治療	治療	NOUN	名詞-普通名詞-一般	_	7	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チリョウ,治療,治療,治療,チリョー,,,チリョウ,チリョウ,治療
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10340,7 +10340,7 @@
 
 # newdoc id = dev-s433
 # sent_id = dev-s433
-# parallel_id = jagsdluw/dev433
+# parallel_id = jagsd/dev433
 # text = 彼女は、ロサンゼルスでのより高いステータスを得られる仕事のオファーを受け入れたのだった。
 1	彼女	彼女	PRON	代名詞	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カノジョ,彼女,彼女,彼女,カノジョ,,,カノジョ,カノジョ,彼女
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10366,7 +10366,7 @@
 
 # newdoc id = dev-s434
 # sent_id = dev-s434
-# parallel_id = jagsdluw/dev434
+# parallel_id = jagsd/dev434
 # text = 「唯識三十頌」では上述の八識説を唱え、部分的に深層心理学的傾向や生物学的傾向を示した。
 1	「	「	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	唯識	唯識	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ユイシキ,唯識,唯識,唯識,ユイシキ,,,ユイシキ,ユイシキ,唯識
@@ -10392,7 +10392,7 @@
 
 # newdoc id = dev-s435
 # sent_id = dev-s435
-# parallel_id = jagsdluw/dev435
+# parallel_id = jagsd/dev435
 # text = 1928年10月から1929年11月にかけて初代駐トルコ大使である小幡酉吉の帰朝にともない臨時代理大使を務め、この間に参事官へと昇格した。
 1	1928年	1928年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;ニ;ハチ;ネン,一;九;二;八;年,1;9;2;8;年,1;9;2;8;年,イチ;キュー;ニ;ハチ;ネン,;;;;,;;;;,イチ;キュウ;ニ;ハチ;ネン,イチキュウニハチネン,1928年
 2	10月	10月	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウ;ガツ,十;月,10;月,10;月,ジュー;ガツ,;,;,ジュウ;ガツ,ジュウガツ,10月
@@ -10425,7 +10425,7 @@
 
 # newdoc id = dev-s436
 # sent_id = dev-s436
-# parallel_id = jagsdluw/dev436
+# parallel_id = jagsd/dev436
 # text = 彼女たちは「負け犬」を自称しながら、その実オタクを恋愛対象にしようとせずヒエラルキーの下位におき、自己の精神的安寧を得ているに過ぎず、そのオタクを否定する価値観も「恋愛資本主義」に洗脳されているに過ぎないと主張した。
 1	彼女たち	彼女達	PRON	代名詞	_	49	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カノジョ;タチ,彼女;達,彼女;たち,彼女;たち,カノジョ;タチ,;,;,カノジョ;タチ,カノジョタチ,彼女達
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10481,7 +10481,7 @@
 
 # newdoc id = dev-s437
 # sent_id = dev-s437
-# parallel_id = jagsdluw/dev437
+# parallel_id = jagsd/dev437
 # text = 民主党公約があてにならないのはまだある。
 1	民主党公約	民主党公約	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミンシュ;トウ;コウヤク,民主;党;公約,民主;党;公約,民主;党;公約,ミンシュ;トー;コーヤク,;;,;;,ミンシュ;トウ;コウヤク,ミンシュトウコウヤク,民主党公約
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -10497,7 +10497,7 @@
 
 # newdoc id = dev-s438
 # sent_id = dev-s438
-# parallel_id = jagsdluw/dev438
+# parallel_id = jagsd/dev438
 # text = だが、最後は仲間達の願いを受けて復活したメビウスのメビュームシュートとウルトラ兄弟の合体光線を受けて再び消滅した。
 1	だが	だが	CCONJ	接続詞	_	24	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;ガ,だ;が,だ;が,だ;が,ダ;ガ,;,;,ダ;ガ,ダガ,だが
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10528,7 +10528,7 @@
 
 # newdoc id = dev-s439
 # sent_id = dev-s439
-# parallel_id = jagsdluw/dev439
+# parallel_id = jagsd/dev439
 # text = しかしプラセボ効果は,患者を騙すからこそ生まれる効果です。
 1	しかし	然し	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	プラセボ効果	プラセボ効果	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=プラシーボ;コウカ,プラシーボ;効果,プラセボ;効果,プラセボ;効果,プラセボ;コーカ,;,;,プラセボ;コウカ,プラセボコウカ,プラセボ効果
@@ -10546,7 +10546,7 @@
 
 # newdoc id = dev-s440
 # sent_id = dev-s440
-# parallel_id = jagsdluw/dev440
+# parallel_id = jagsd/dev440
 # text = 遊学館は県予選会後に3年の亀樋哲生、吉田圭佑の両選手ら主力3人が故障して欠場した。
 1	遊学館	遊学館	PROPN	名詞-固有名詞-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユウガク;カン,遊学;館,遊学;館,遊学;館,ユーガク;カン,;,;,ユウガク;カン,ユウガクカン,遊学館
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10570,7 +10570,7 @@
 
 # newdoc id = dev-s441
 # sent_id = dev-s441
-# parallel_id = jagsdluw/dev441
+# parallel_id = jagsd/dev441
 # text = 属品として負紐付きの収容嚢が存在し、行軍時などには狙撃眼鏡を銃から外しこれに収容した。
 1	属品	属品	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゾクヒン,属品,属品,属品,ゾクヒン,,,ゾクヒン,ゾクヒン,属品
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -10597,7 +10597,7 @@
 
 # newdoc id = dev-s442
 # sent_id = dev-s442
-# parallel_id = jagsdluw/dev442
+# parallel_id = jagsd/dev442
 # text = 宇高航路においては、初の車載客船でもあった。
 1	宇高航路	宇高航路	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウコウ;コウロ,宇高;航路,宇高;航路,宇高;航路,ウコー;コーロ,;,;,ウコウ;コウロ,ウコウコウロ,宇高航路
 2	において	において	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;オク;テ,に;於く;て,に;おい;て,に;おく;て,ニ;オイ;テ,;;,;;,ニ;オク;テ,ニオイテ,において
@@ -10612,7 +10612,7 @@
 
 # newdoc id = dev-s443
 # sent_id = dev-s443
-# parallel_id = jagsdluw/dev443
+# parallel_id = jagsd/dev443
 # text = 車の販売、板金、塗装等を行っています。
 1	車	車	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クルマ,車,車,車,クルマ,,,クルマ,クルマ,車
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10629,7 +10629,7 @@
 
 # newdoc id = dev-s444
 # sent_id = dev-s444
-# parallel_id = jagsdluw/dev444
+# parallel_id = jagsd/dev444
 # text = 柱の円周は、大人5人が手を伸ばして抱えても届かないくらいの大きさである。
 1	柱	柱	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハシラ,柱,柱,柱,ハシラ,,,ハシラ,ハシラ,柱
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10656,7 +10656,7 @@
 
 # newdoc id = dev-s445
 # sent_id = dev-s445
-# parallel_id = jagsdluw/dev445
+# parallel_id = jagsd/dev445
 # text = 有名な先生方が講師として来られています。
 1	有名	有名	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユウメイ,有名,有名,有名,ユーメー,,,ユウメイ,ユウメイ,有名
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -10672,7 +10672,7 @@
 
 # newdoc id = dev-s446
 # sent_id = dev-s446
-# parallel_id = jagsdluw/dev446
+# parallel_id = jagsd/dev446
 # text = 悲観的になるとは,階級的意識がないことであるが,本来敵であるものを味方と思った時,その失望が悲観的にさせる。
 1	悲観的	悲観的	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒカン;テキ,悲観;的,悲観;的,悲観;的,ヒカン;テキ,;,;,ヒカン;テキ,ヒカンテキ,悲観的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -10709,7 +10709,7 @@
 
 # newdoc id = dev-s447
 # sent_id = dev-s447
-# parallel_id = jagsdluw/dev447
+# parallel_id = jagsd/dev447
 # text = 好物はマシュマロ。
 1	好物	好物	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウブツ,好物,好物,好物,コーブツ,,,コウブツ,コウブツ,好物
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10718,7 +10718,7 @@
 
 # newdoc id = dev-s448
 # sent_id = dev-s448
-# parallel_id = jagsdluw/dev448
+# parallel_id = jagsd/dev448
 # text = 私は,幸福の施設しか知らなくて恐縮ですが,安心して過ごせる所だと思う。
 1	私	私	PRON	代名詞	_	21	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10745,7 +10745,7 @@
 
 # newdoc id = dev-s449
 # sent_id = dev-s449
-# parallel_id = jagsdluw/dev449
+# parallel_id = jagsd/dev449
 # text = こじんまりした、アットホームな良い雰囲気で食事が出来ます。
 1	こじんまりし	小ぢんまりする	VERB	動詞-一般-サ行変格	_	7	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コヂンマリ;スル,小ぢんまり;為る,こじんまり;し,こじんまり;する,コジンマリ;シ,;,;,コヂンマリ;スル,コヂンマリスル,小ぢんまりする
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -10763,7 +10763,7 @@
 
 # newdoc id = dev-s450
 # sent_id = dev-s450
-# parallel_id = jagsdluw/dev450
+# parallel_id = jagsd/dev450
 # text = クアラルンプールで開催されるマラソンはこのほか「KLマラソン」など、複数の大会がある。
 1	クアラルンプール	クアラルンプール	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クアラルンプール,クアラ・ルンプール,クアラルンプール,クアラルンプール,クアラルンプール,,,クアラルンプール,クアラルンプール,クアラルンプール
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -10787,7 +10787,7 @@
 
 # newdoc id = dev-s451
 # sent_id = dev-s451
-# parallel_id = jagsdluw/dev451
+# parallel_id = jagsd/dev451
 # text = SF作品などで、宇宙船の航行が著しく困難な空間に「サルガッソ」の名が冠されることがある。
 1	SF作品	SF作品	NOUN	名詞-普通名詞-一般	_	20	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エスエフ;サクヒン,ＳＦ;作品,SF;作品,SF;作品,エスエフ;サクヒン,;,;,エスエフ;サクヒン,エスエフサクヒン,SF作品
 2	など	など	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナド,など,など,など,ナド,,,ナド,ナド,など
@@ -10815,7 +10815,7 @@
 
 # newdoc id = dev-s452
 # sent_id = dev-s452
-# parallel_id = jagsdluw/dev452
+# parallel_id = jagsd/dev452
 # text = 英語の公用語化云々よりも、まずは国際感覚を身につける社員教育の方が優先すべきだろう。
 1	英語	英語	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エイゴ,英語,英語,英語,エーゴ,,,エイゴ,エイゴ,英語
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10841,7 +10841,7 @@
 
 # newdoc id = dev-s453
 # sent_id = dev-s453
-# parallel_id = jagsdluw/dev453
+# parallel_id = jagsd/dev453
 # text = 本作より昔の話である『ドラゴンクエストIII』の時代では魔物に滅ぼされておらず活気のある町として存在していた。
 1	本作	本作	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンサク,本作,本作,本作,ホンサク,,,ホンサク,ホンサク,本作
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -10874,7 +10874,7 @@
 
 # newdoc id = dev-s454
 # sent_id = dev-s454
-# parallel_id = jagsdluw/dev454
+# parallel_id = jagsd/dev454
 # text = 2009年11月28日、サードアルバム、『HellChose Me 』のレコーディングを終える。
 1	2009年	2009年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;キュウ;ネン,二;ゼロ;ゼロ;九;年,2;0;0;9;年,2;0;0;9;年,ニ;ゼロ;ゼロ;キュー;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;キュウ;ネン,ニゼロゼロキュウネン,2009年
 2	11月	11月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;イチ;ガツ,一;一;月,1;1;月,1;1;月,イチ;イチ;ガツ,;;,;;,イチ;イチ;ガツ,イチイチガツ,11月
@@ -10893,7 +10893,7 @@
 
 # newdoc id = dev-s455
 # sent_id = dev-s455
-# parallel_id = jagsdluw/dev455
+# parallel_id = jagsd/dev455
 # text = 今年7月から、宝塚歌劇の専門チャンネル「タカラヅカ・スカイ・ステージ」の案内役スカイ・フェアリーズを務めている。
 1	今年	今年	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=コトシ,今年,今年,今年,コトシ,,,コトシ,コトシ,今年
 2	7月	7月	NUM	名詞-数詞	_	15	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シチ;ガツ,七;月,7;月,7;月,シチ;ガツ,;,;,シチ;ガツ,シチガツ,7月
@@ -10915,7 +10915,7 @@
 
 # newdoc id = dev-s456
 # sent_id = dev-s456
-# parallel_id = jagsdluw/dev456
+# parallel_id = jagsd/dev456
 # text = 取締機によって撮影されると、数日から遅くとも30日以内に警察から当該車両の所有者に出頭通知が送付される。
 1	取締機	取り締まり機	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トリシマリ;キ,取り締まり;機,取締;機,取締;機,トリシマリ;キ,;,;,トリシマリ;キ,トリシマリキ,取り締まり機
 2	によって	によって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;テ,に;因る;て,に;よっ;て,に;よる;て,ニ;ヨッ;テ,;;,;;,ニ;ヨル;テ,ニヨッテ,によって
@@ -10943,7 +10943,7 @@
 
 # newdoc id = dev-s457
 # sent_id = dev-s457
-# parallel_id = jagsdluw/dev457
+# parallel_id = jagsd/dev457
 # text = 享年84。
 1	享年	享年	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=キョウネン,享年,享年,享年,キョーネン,,,キョウネン,キョウネン,享年
 2	84	84	NUM	名詞-数詞	_	0	root	_	BunsetuBILabel=I|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ハチ;ヨン,八;四,8;4,8;4,ハチ;ヨン,;,;,ハチ;ヨン,ハチヨン,84
@@ -10951,7 +10951,7 @@
 
 # newdoc id = dev-s458
 # sent_id = dev-s458
-# parallel_id = jagsdluw/dev458
+# parallel_id = jagsd/dev458
 # text = 当初は熊田の傍若無人ぶりにブーイングの嵐だった観衆も、「まともに戦うのなら」という条件付きで熊田応援に回り、場内は熊田コールと仲本コールに二分された。
 1	当初	当初	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10994,7 +10994,7 @@
 
 # newdoc id = dev-s459
 # sent_id = dev-s459
-# parallel_id = jagsdluw/dev459
+# parallel_id = jagsd/dev459
 # text = 脳梗塞の症状で入院していた60歳代の男性が、食事で出されたおかゆを喉に詰まらせた。
 1	脳梗塞	脳梗塞	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノウ;コウソク,脳;梗塞,脳;梗塞,脳;梗塞,ノー;コーソク,;,;,ノウ;コウソク,ノウコウソク,脳梗塞
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11024,7 +11024,7 @@
 
 # newdoc id = dev-s460
 # sent_id = dev-s460
-# parallel_id = jagsdluw/dev460
+# parallel_id = jagsd/dev460
 # text = 幼いゆえか、大人っぽさに憧れている。
 1	幼い	幼い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オサナイ,幼い,幼い,幼い,オサナイ,,,オサナイ,オサナイ,幼い
 2	ゆえ	故	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユエ,故,ゆえ,ゆえ,ユエ,,,ユエ,ユエ,故
@@ -11038,7 +11038,7 @@
 
 # newdoc id = dev-s461
 # sent_id = dev-s461
-# parallel_id = jagsdluw/dev461
+# parallel_id = jagsd/dev461
 # text = ネタ番組のように、3段オチを考えるコーナーではない。
 1	ネタ番組	ねた番組	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネタ;バングミ,ねた;番組,ネタ;番組,ネタ;番組,ネタ;バングミ,;,;,ネタ;バングミ,ネタバングミ,ねた番組
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11054,7 +11054,7 @@
 
 # newdoc id = dev-s462
 # sent_id = dev-s462
-# parallel_id = jagsdluw/dev462
+# parallel_id = jagsd/dev462
 # text = バター珈琲の味が好きな方にはお薦めだが、外連味の無い、王道の珈琲を求める方には向かない。
 1	バター珈琲	バターコーヒー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バター;コーヒー,バター;コーヒー,バター;珈琲,バター;珈琲,バター;コーヒー,;,;,バター;コーヒー,バターコーヒー,バターコーヒー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11087,7 +11087,7 @@
 
 # newdoc id = dev-s463
 # sent_id = dev-s463
-# parallel_id = jagsdluw/dev463
+# parallel_id = jagsd/dev463
 # text = 対称性を評価するパターン、生え際を評価するパターン、鼻や口の大きさを評価するパターンなどがある。
 1	対称性	対称性	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイショウ;セイ,対称;性,対称;性,対称;性,タイショー;セー,;,;,タイショウ;セイ,タイショウセイ,対称性
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -11114,7 +11114,7 @@
 
 # newdoc id = dev-s465
 # sent_id = dev-s465
-# parallel_id = jagsdluw/dev465
+# parallel_id = jagsd/dev465
 # text = ハムスターの診察をしてくれる病院は少なくとても助かりました。
 1	ハムスター	ハムスター	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハムスター,ハムスター,ハムスター,ハムスター,ハムスター,,,ハムスター,ハムスター,ハムスター
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11133,7 +11133,7 @@
 
 # newdoc id = dev-s466
 # sent_id = dev-s466
-# parallel_id = jagsdluw/dev466
+# parallel_id = jagsd/dev466
 # text = 休養を挟んで京成杯オータムハンデキャップに出走したが、5着に敗れた。
 1	休養	休養	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウヨウ,休養,休養,休養,キューヨー,,,キュウヨウ,キュウヨウ,休養
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -11153,7 +11153,7 @@
 
 # newdoc id = dev-s467
 # sent_id = dev-s467
-# parallel_id = jagsdluw/dev467
+# parallel_id = jagsd/dev467
 # text = ファイブブラックの個人武器。
 1	ファイブブラック	ファイブブラック	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ファイブ;ブラック,ファイブ;ブラック,ファイブ;ブラック,ファイブ;ブラック,ファイブ;ブラック,;,;,ファイブ;ブラック,ファイブブラック,ファイブブラック
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11162,7 +11162,7 @@
 
 # newdoc id = dev-s468
 # sent_id = dev-s468
-# parallel_id = jagsdluw/dev468
+# parallel_id = jagsd/dev468
 # text = 朝まで飲み会コースというのがあり、4品で1500円くらいのようですよ。
 1	朝	朝	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アサ,朝,朝,朝,アサ,,,アサ,アサ,朝
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -11184,7 +11184,7 @@
 
 # newdoc id = dev-s469
 # sent_id = dev-s469
-# parallel_id = jagsdluw/dev469
+# parallel_id = jagsd/dev469
 # text = 同国の国営テレビは、ムバラク氏が公金横領や反体制デモ参加者殺害などの疑いで検察当局の聴取を受けている最中に心臓発作で倒れ、入院先で集中治療を受けていると報じた。
 1	同国	同国	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウコク,同国,同国,同国,ドーコク,,,ドウコク,ドウコク,同国
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11225,7 +11225,7 @@
 
 # newdoc id = dev-s470
 # sent_id = dev-s470
-# parallel_id = jagsdluw/dev470
+# parallel_id = jagsd/dev470
 # text = 通称・但馬、和泉、又左衛門。
 1	通称	通称	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツウショウ,通称,通称,通称,ツーショー,,,ツウショウ,ツウショウ,通称
 2	・	・	SYM	補助記号-一般	_	1	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,,・
@@ -11238,7 +11238,7 @@
 
 # newdoc id = dev-s471
 # sent_id = dev-s471
-# parallel_id = jagsdluw/dev471
+# parallel_id = jagsd/dev471
 # text = 真っ黒のタレだけど美味しいよ。
 1	真っ黒	真っ黒	ADJ	形状詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マックロ,真っ黒,真っ黒,真っ黒,マックロ,,,マックロ,マックロ,真っ黒
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11251,7 +11251,7 @@
 
 # newdoc id = dev-s472
 # sent_id = dev-s472
-# parallel_id = jagsdluw/dev472
+# parallel_id = jagsd/dev472
 # text = かつて虐めにあっていた大和の中学時代の同級生。
 1	かつて	嘗て	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カツテ,嘗て,かつて,かつて,カツテ,,,カツテ,カツテ,嘗て
 2	虐め	苛め	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イジメ,苛め,虐め,虐め,イジメ,,,イジメ,イジメ,苛め
@@ -11268,7 +11268,7 @@
 
 # newdoc id = dev-s473
 # sent_id = dev-s473
-# parallel_id = jagsdluw/dev473
+# parallel_id = jagsd/dev473
 # text = すると店内がかわいくて気に入りパ—マとカットをしてもらいました。
 1	すると	すると	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スル;ト,為る;と,する;と,する;と,スル;ト,;,;,スル;ト,スルト,すると
 2	店内	店内	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンナイ,店内,店内,店内,テンナイ,,,テンナイ,テンナイ,店内
@@ -11290,7 +11290,7 @@
 
 # newdoc id = dev-s474
 # sent_id = dev-s474
-# parallel_id = jagsdluw/dev474
+# parallel_id = jagsd/dev474
 # text = 2010年10月17日にインディアナ州で前立腺がんで亡くなった。
 1	2010年	2010年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;ゼロ;ネン,二;ゼロ;一;ゼロ;年,2;0;1;0;年,2;0;1;0;年,ニ;ゼロ;イチ;ゼロ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;ゼロ;ネン,ニゼロイチゼロネン,2010年
 2	10月	10月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ジュウ;ガツ,十;月,10;月,10;月,ジュー;ガツ,;,;,ジュウ;ガツ,ジュウガツ,10月
@@ -11306,7 +11306,7 @@
 
 # newdoc id = dev-s475
 # sent_id = dev-s475
-# parallel_id = jagsdluw/dev475
+# parallel_id = jagsd/dev475
 # text = 劉裕の異母弟にあたる。
 1	劉裕	劉裕	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リュウユウ,リュウユウ,劉裕,劉裕,リューユー,,,リュウユウ,リュウユウ,劉裕
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11317,7 +11317,7 @@
 
 # newdoc id = dev-s476
 # sent_id = dev-s476
-# parallel_id = jagsdluw/dev476
+# parallel_id = jagsd/dev476
 # text = 看護師不足が問題となる中、高梁市が看護師を目指す学生を対象にした看護師養成奨学金制度をつくり、4月から奨学生の募集を始める。
 1	看護師不足	看護師不足	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンゴ;シ;フソク,看護;師;不足,看護;師;不足,看護;師;不足,カンゴ;シ;ブソク,;;,;;,カンゴ;シ;フソク,カンゴシブソク,看護師不足
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -11352,7 +11352,7 @@
 
 # newdoc id = dev-s477
 # sent_id = dev-s477
-# parallel_id = jagsdluw/dev477
+# parallel_id = jagsd/dev477
 # text = 1821年から1867年までの長きに亘ってモスクワ府主教位にあった。
 1	1821年	1821年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;ニ;イチ;ネン,一;八;二;一;年,1;8;2;1;年,1;8;2;1;年,イチ;ハチ;ニ;イチ;ネン,;;;;,;;;;,イチ;ハチ;ニ;イチ;ネン,イチハチニイチネン,1821年
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -11369,7 +11369,7 @@
 
 # newdoc id = dev-s478
 # sent_id = dev-s478
-# parallel_id = jagsdluw/dev478
+# parallel_id = jagsd/dev478
 # text = でも重症じゃないので絶対に治ると信じて治療に専念し、きれいな女性になりたいとの想いを込め、決断しました。
 1	でも	でも	CCONJ	接続詞	_	27	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;モ,で;も,で;も,で;も,デ;モ,;,;,デ;モ,デモ,でも
 2	重症	重症	NOUN	名詞-普通名詞-一般	_	7	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウショウ,重症,重症,重症,ジューショー,,,ジュウショウ,ジュウショウ,重症
@@ -11404,7 +11404,7 @@
 
 # newdoc id = dev-s479
 # sent_id = dev-s479
-# parallel_id = jagsdluw/dev479
+# parallel_id = jagsd/dev479
 # text = この風景を学生が見たら大喜びをするに違いない。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	風景	風景	NOUN	名詞-普通名詞-一般	_	6	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フウケイ,風景,風景,風景,フーケー,,,フウケイ,フウケイ,風景
@@ -11421,7 +11421,7 @@
 
 # newdoc id = dev-s480
 # sent_id = dev-s480
-# parallel_id = jagsdluw/dev480
+# parallel_id = jagsd/dev480
 # text = 現在の書店「丸善」だ。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11434,7 +11434,7 @@
 
 # newdoc id = dev-s481
 # sent_id = dev-s481
-# parallel_id = jagsdluw/dev481
+# parallel_id = jagsd/dev481
 # text = ここの居酒屋のメニューで目を引いたのは、やっぱりコラーゲン鍋でしょ!
 1	ここ	此処	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11456,7 +11456,7 @@
 
 # newdoc id = dev-s482
 # sent_id = dev-s482
-# parallel_id = jagsdluw/dev482
+# parallel_id = jagsd/dev482
 # text = 大きな一つ目に小さな胴体、細い手足、とんがり帽子という異形だが何処かコミカルにも見える姿をとる。
 1	大きな	大きな	ADJ	連体詞	_	3	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキナ,大きな,大きな,大きな,オーキナ,,,オオキナ,オオキナ,大きな
 2	一つ	一つ	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ヒト;ツ,一;つ,一;つ,一;つ,ヒト;ツ,;,;,ヒト;ツ,ヒトツ,一つ
@@ -11486,7 +11486,7 @@
 
 # newdoc id = dev-s483
 # sent_id = dev-s483
-# parallel_id = jagsdluw/dev483
+# parallel_id = jagsd/dev483
 # text = ここから、単なる文字列よりも高機能なクラスなどをロープと呼ぶことがある。
 1	ここ	此処	PRON	代名詞	_	15	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -11508,7 +11508,7 @@
 
 # newdoc id = dev-s484
 # sent_id = dev-s484
-# parallel_id = jagsdluw/dev484
+# parallel_id = jagsd/dev484
 # text = 柔道人生は終わるまで安心できない。
 1	柔道人生	柔道人生	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウドウ;ジンセイ,柔道;人生,柔道;人生,柔道;人生,ジュードー;ジンセー,;,;,ジュウドウ;ジンセイ,ジュウドウジンセイ,柔道人生
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11520,7 +11520,7 @@
 
 # newdoc id = dev-s485
 # sent_id = dev-s485
-# parallel_id = jagsdluw/dev485
+# parallel_id = jagsd/dev485
 # text = 雪に足をとられないようにするために足裏に取り付けられるミニスキー。
 1	雪	雪	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユキ,雪,雪,雪,ユキ,,,ユキ,ユキ,雪
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11542,7 +11542,7 @@
 
 # newdoc id = dev-s486
 # sent_id = dev-s486
-# parallel_id = jagsdluw/dev486
+# parallel_id = jagsd/dev486
 # text = 作品にはオペラ、バレエ、映画音楽、劇場音楽があり、リトアニア・ソビエト社会主義共和国の国歌も作曲している。
 1	作品	作品	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクヒン,作品,作品,作品,サクヒン,,,サクヒン,サクヒン,作品
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11567,14 +11567,14 @@
 
 # newdoc id = dev-s487
 # sent_id = dev-s487
-# parallel_id = jagsdluw/dev487
+# parallel_id = jagsd/dev487
 # text = 静岡県出身。
 1	静岡県出身	静岡県出身	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=シズオカ;ケン;シュッシン,シズオカ;県;出身,静岡;県;出身,静岡;県;出身,シズオカ;ケン;シュッシン,;;,;;,シズオカ;ケン;シュッシン,シズオカケンシュッシン,静岡県出身
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s488
 # sent_id = dev-s488
-# parallel_id = jagsdluw/dev488
+# parallel_id = jagsd/dev488
 # text = あと、びっくりなのが、玄関前にペンギンが3羽。
 1	あと	後	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アト,後,あと,あと,アト,,,アト,アト,後
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -11592,7 +11592,7 @@
 
 # newdoc id = dev-s489
 # sent_id = dev-s489
-# parallel_id = jagsdluw/dev489
+# parallel_id = jagsd/dev489
 # text = 鉄郎の同僚でドーテーズの初期メンバー。
 1	鉄郎	鉄郎	PROPN	名詞-固有名詞-人名-名	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テツオ,テツオ,鉄郎,鉄郎,テツオ,,,テツオ,テツオ,鉄郎
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11605,7 +11605,7 @@
 
 # newdoc id = dev-s490
 # sent_id = dev-s490
-# parallel_id = jagsdluw/dev490
+# parallel_id = jagsd/dev490
 # text = X線新星の特徴である、数ヶ月かけて暗くなる性質と一致している。
 1	X線新星	X線新星	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エックス;セン;シンセイ,Ｘ;線;新星,X;線;新星,X;線;新星,エックス;セン;シンセー,;;,;;,エックス;セン;シンセイ,エックスセンシンセイ,X線新星
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11625,7 +11625,7 @@
 
 # newdoc id = dev-s491
 # sent_id = dev-s491
-# parallel_id = jagsdluw/dev491
+# parallel_id = jagsd/dev491
 # text = 地区予選で敗者復活戦に回った雪辱を果たせるか。
 1	地区予選	地区予選	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チク;ヨセン,地区;予選,地区;予選,地区;予選,チク;ヨセン,;,;,チク;ヨセン,チクヨセン,地区予選
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11641,7 +11641,7 @@
 
 # newdoc id = dev-s492
 # sent_id = dev-s492
-# parallel_id = jagsdluw/dev492
+# parallel_id = jagsd/dev492
 # text = ノルウェーの劇作家ヘンリック・イプセンの劇詩『ペール・ギュント』の登場人物に因んで命名された。
 1	ノルウェー	ノルウェー	PROPN	名詞-固有名詞-地名-国	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノルウェー,ノルウェー,ノルウェー,ノルウェー,ノルウェー,,,ノルウェー,ノルウェー,ノルウェー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11663,7 +11663,7 @@
 
 # newdoc id = dev-s493
 # sent_id = dev-s493
-# parallel_id = jagsdluw/dev493
+# parallel_id = jagsd/dev493
 # text = 3月20日に発売開始。
 1	3月	3月	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=サン;ガツ,三;月,3;月,3;月,サン;ガツ,;,;,サン;ガツ,サンガツ,3月
 2	20日	20日	NUM	名詞-数詞	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハツ;カ,二十;日,20;日,20;日,ハツ;カ,;,;,ハツ;カ,ハツカ,20日
@@ -11673,7 +11673,7 @@
 
 # newdoc id = dev-s494
 # sent_id = dev-s494
-# parallel_id = jagsdluw/dev494
+# parallel_id = jagsd/dev494
 # text = 今上大岡に住んでいて、毎週行っています。
 1	今	今	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イマ,今,今,今,イマ,,,イマ,イマ,今
 2	上大岡	上大岡	PROPN	名詞-固有名詞-地名-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カミオオオカ,カミオオオカ,上大岡,上大岡,カミオーオカ,,,カミオオオカ,カミオオオカ,上大岡
@@ -11690,7 +11690,7 @@
 
 # newdoc id = dev-s495
 # sent_id = dev-s495
-# parallel_id = jagsdluw/dev495
+# parallel_id = jagsd/dev495
 # text = 千月学園に通いつつ弥勒院をサポートする有能な助手ではあるが、謎も多い不思議な少女。
 1	千月学園	千月学園	PROPN	名詞-固有名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センゲツ;ガクエン,千月;学園,千月;学園,千月;学園,センゲツ;ガクエン,;,;,センゲツ;ガクエン,センゲツガクエン,千月学園
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11717,7 +11717,7 @@
 
 # newdoc id = dev-s496
 # sent_id = dev-s496
-# parallel_id = jagsdluw/dev496
+# parallel_id = jagsd/dev496
 # text = 旧松山藩領東部に当たる西条6万8600石は、伊勢国神戸藩主一柳直盛に与えられたが、加増のうえ転封することとなった直盛は、采地に赴く途中の大坂で没した。
 1	旧松山藩領東部	旧松山藩領東部	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウ;マツヤマ;ハンリョウ;トウブ,旧;マツヤマ;藩領;東部,旧;松山;藩領;東部,旧;松山;藩領;東部,キュー;マツヤマ;ハンリョー;トーブ,;;;,;;;,キュウ;マツヤマ;ハンリョウ;トウブ,キュウマツヤマハンリョウトウブ,旧松山藩領東部
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11755,7 +11755,7 @@
 
 # newdoc id = dev-s497
 # sent_id = dev-s497
-# parallel_id = jagsdluw/dev497
+# parallel_id = jagsd/dev497
 # text = 霊芝には毛細血管の血液循環を促進する働きがあります。
 1	霊芝	霊芝	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レイシ,霊芝,霊芝,霊芝,レーシ,,,レイシ,レイシ,霊芝
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11773,7 +11773,7 @@
 
 # newdoc id = dev-s498
 # sent_id = dev-s498
-# parallel_id = jagsdluw/dev498
+# parallel_id = jagsd/dev498
 # text = 『第2次OG』でコウタと共に帰還し、海上でヒリュウ改を襲撃したイグニスを撃破後に鋼龍戦隊に合流。
 1	『	『	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
 2	第2次OG	第2次OG	PROPN	名詞-固有名詞-一般	_	9	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;ニ;ジ;オー;ジー,第;二;次;Ｏ;Ｇ,第;2;次;O;G,第;2;次;O;G,ダイ;ニ;ジ;オー;ジー,;;;;,;;;;,ダイ;ニ;ジ;オー;ジー,ダイニジオージー,第2次OG
@@ -11802,7 +11802,7 @@
 
 # newdoc id = dev-s499
 # sent_id = dev-s499
-# parallel_id = jagsdluw/dev499
+# parallel_id = jagsd/dev499
 # text = 2位の天草本渡クラブと3位の菊池クラブは10月に宮崎県で行われる九州大会に出場する。
 1	2位	2位	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;イ,二;位,2;位,2;位,ニ;イ,;,;,ニ;イ,ニイ,2位
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11825,7 +11825,7 @@
 
 # newdoc id = dev-s500
 # sent_id = dev-s500
-# parallel_id = jagsdluw/dev500
+# parallel_id = jagsd/dev500
 # text = 財務相のヘルムート・シュミットに連邦首相の座を譲った。
 1	財務相	財務相	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ザイム;ショウ,財務;相,財務;相,財務;相,ザイム;ショー,;,;,ザイム;ショウ,ザイムショウ,財務相
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11841,7 +11841,7 @@
 
 # newdoc id = dev-s501
 # sent_id = dev-s501
-# parallel_id = jagsdluw/dev501
+# parallel_id = jagsd/dev501
 # text = 2008年4月6日午前11時に子供が生まれるとします。
 1	2008年	2008年	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ハチ;ネン,二;ゼロ;ゼロ;八;年,2;0;0;8;年,2;0;0;8;年,ニ;ゼロ;ゼロ;ハチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ハチ;ネン,ニゼロゼロハチネン,2008年
 2	4月	4月	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=シ;ガツ,四;月,4;月,4;月,シ;ガツ,;,;,シ;ガツ,シガツ,4月
@@ -11859,7 +11859,7 @@
 
 # newdoc id = dev-s502
 # sent_id = dev-s502
-# parallel_id = jagsdluw/dev502
+# parallel_id = jagsd/dev502
 # text = スターフェリーやヨーマティフェリーが創業すると、非常に重要であることを証明することになった。
 1	スターフェリー	スターフェリー	PROPN	名詞-固有名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スター;フェリー,スター;フェリー,スター;フェリー,スター;フェリー,スター;フェリー,;,;,スター;フェリー,スターフェリー,スターフェリー
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -11881,7 +11881,7 @@
 
 # newdoc id = dev-s503
 # sent_id = dev-s503
-# parallel_id = jagsdluw/dev503
+# parallel_id = jagsd/dev503
 # text = 横柄な女医の婆さんといい加減な受付。
 1	横柄	横柄	ADJ	形状詞-一般	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オウヘイ,横柄,横柄,横柄,オーヘー,,,オウヘイ,オウヘイ,横柄
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -11896,7 +11896,7 @@
 
 # newdoc id = dev-s504
 # sent_id = dev-s504
-# parallel_id = jagsdluw/dev504
+# parallel_id = jagsd/dev504
 # text = この荻野氏,自らクラシカルホメオパシー京都という団体を主宰し,ホメオパシー講座を開催しています。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	荻野氏	荻野氏	PROPN	名詞-固有名詞-人名-姓	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オギノ;シ,オギノ;氏,荻野;氏,荻野;氏,オギノ;シ,;,;,オギノ;シ,オギノシ,荻野氏
@@ -11917,7 +11917,7 @@
 
 # newdoc id = dev-s505
 # sent_id = dev-s505
-# parallel_id = jagsdluw/dev505
+# parallel_id = jagsd/dev505
 # text = メソポタミア南部は文字による記録が残される最初期からシュメール語とセム語のバイリンガル地帯であった。
 1	メソポタミア南部	メソポタミア南部	NOUN	名詞-普通名詞-一般	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メソポタミア;ナンブ,メソポタミア;南部,メソポタミア;南部,メソポタミア;南部,メソポタミア;ナンブ,;,;,メソポタミア;ナンブ,メソポタミアナンブ,メソポタミア南部
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11940,7 +11940,7 @@
 
 # newdoc id = dev-s506
 # sent_id = dev-s506
-# parallel_id = jagsdluw/dev506
+# parallel_id = jagsd/dev506
 # text = また日本語学者の寺村秀夫も自著では「名容詞」という用語を用いている。
 1	また	又	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	日本語学者	日本語学者	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン;ゴ;ガク;シャ,日本;語;学;者,日本;語;学;者,日本;語;学;者,ニホン;ゴ;ガク;シャ,;;;,;;;,ニホン;ゴ;ガク;シャ,ニホンゴガクシャ,日本語学者
@@ -11962,7 +11962,7 @@
 
 # newdoc id = dev-s507
 # sent_id = dev-s507
-# parallel_id = jagsdluw/dev507
+# parallel_id = jagsd/dev507
 # text = お風呂大きくはないけれどお湯はきれい。
 1	お風呂	御風呂	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=オ;フロ,御;風呂,お;風呂,お;風呂,オ;フロ,;,;,オ;フロ,オフロ,御風呂
 2	大きく	大きい	ADJ	形容詞-一般-形容詞	_	4	advcl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキイ,大きい,大きく,大きい,オーキク,,,オオキイ,オオキイ,大きい
@@ -11976,14 +11976,14 @@
 
 # newdoc id = dev-s508
 # sent_id = dev-s508
-# parallel_id = jagsdluw/dev508
+# parallel_id = jagsd/dev508
 # text = 新生闇軍団頭領。
 1	新生闇軍団頭領	新生闇軍団頭領	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=シンセイ;ヤミ;グンダン;トウリョウ,新生;闇;軍団;頭領,新生;闇;軍団;頭領,新生;闇;軍団;頭領,シンセー;ヤミ;グンダン;トーリョー,;;;,;;;,シンセイ;ヤミ;グンダン;トウリョウ,シンセイヤミグンダントウリョウ,新生闇軍団頭領
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s509
 # sent_id = dev-s509
-# parallel_id = jagsdluw/dev509
+# parallel_id = jagsd/dev509
 # text = 当初の説明と実際の施設の状態が違うという点も,川島町の住民の証言とよく似ています。
 1	当初	当初	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12014,7 +12014,7 @@
 
 # newdoc id = dev-s510
 # sent_id = dev-s510
-# parallel_id = jagsdluw/dev510
+# parallel_id = jagsd/dev510
 # text = それでいてこの対応である。
 1	それ	其れ	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -12027,7 +12027,7 @@
 
 # newdoc id = dev-s511
 # sent_id = dev-s511
-# parallel_id = jagsdluw/dev511
+# parallel_id = jagsd/dev511
 # text = 児童生徒が犠牲になる事態も多く、同市にある京田幼児園では園舎が倒壊し園児3名が圧死、園児14名と保育士1名が生き埋めとなった。
 1	児童生徒	児童生徒	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジドウ;セイト,児童;生徒,児童;生徒,児童;生徒,ジドー;セート,;,;,ジドウ;セイト,ジドウセイト,児童生徒
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が

--- a/ja_gsdluw-ud-dev.conllu
+++ b/ja_gsdluw-ud-dev.conllu
@@ -1,5 +1,6 @@
 # newdoc id = dev-s1
 # sent_id = dev-s1
+# parallel_id = jagsdluw/dev1
 # text = ただし、50周年ソングに変更後は、EDも歌つきのものが使われた。
 1	ただし	但し	CCONJ	接続詞	_	14	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -21,6 +22,7 @@
 
 # newdoc id = dev-s2
 # sent_id = dev-s2
+# parallel_id = jagsdluw/dev2
 # text = 私は初めてだったんだけど思っていたよりも魚は新鮮でした。
 1	私	私	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -43,6 +45,7 @@
 
 # newdoc id = dev-s4
 # sent_id = dev-s4
+# parallel_id = jagsdluw/dev4
 # text = セントラル・リーグ審判員の水落朋大は実兄。
 1	セントラル・リーグ審判員	セントラル・リーグ審判員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セントラル;;リーグ;シンパン;イン,セントラル;・;リーグ;審判;員,セントラル;・;リーグ;審判;員,セントラル;・;リーグ;審判;員,セントラル;;リーグ;シンパン;イン,;;;;,;;;;,セントラル;;リーグ;シンパン;イン,セントラルリーグシンパンイン,セントラル・リーグ審判員
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -53,6 +56,7 @@
 
 # newdoc id = dev-s5
 # sent_id = dev-s5
+# parallel_id = jagsdluw/dev5
 # text = 多彩なライブアクトとともに、祝日前の渋谷の夜を盛り上げてくれそうだ。
 1	多彩	多彩	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タサイ,多彩,多彩,多彩,タサイ,,,タサイ,タサイ,多彩
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -75,6 +79,7 @@
 
 # newdoc id = dev-s6
 # sent_id = dev-s6
+# parallel_id = jagsdluw/dev6
 # text = 今作品では大会でのパラメータUPが非常に大きく、ALL999への育成は回復アイテムを投与しつつ、冬眠、復活を繰り返し大会に連続して出すという方法が取られた。
 1	今作品	今作品	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コン;サクヒン,今;作品,今;作品,今;作品,コン;サクヒン,;,;,コン;サクヒン,コンサクヒン,今作品
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -118,6 +123,7 @@
 
 # newdoc id = dev-s7
 # sent_id = dev-s7
+# parallel_id = jagsdluw/dev7
 # text = ゲーム入力のレスポンスをよくするためには、これを1秒間に通常30回以上行う必要があり、実際に得られたデータの回数と値はゲームコントローラ内の抵抗や回路上のノイズやCPUスピード、ゲームコントローラ全体の容量からくるRC回路・時定数に依存する。
 1	ゲーム入力	ゲーム入力	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲーム;ニュウリョク,ゲーム;入力,ゲーム;入力,ゲーム;入力,ゲーム;ニューリョク,;,;,ゲーム;ニュウリョク,ゲームニュウリョク,ゲーム入力
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -172,6 +178,7 @@
 
 # newdoc id = dev-s8
 # sent_id = dev-s8
+# parallel_id = jagsdluw/dev8
 # text = 姉と同じ先生だったので、話やすかったです。
 1	姉	姉	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アネ,姉,姉,姉,アネ,,,アネ,アネ,姉
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -188,6 +195,7 @@
 
 # newdoc id = dev-s9
 # sent_id = dev-s9
+# parallel_id = jagsdluw/dev9
 # text = 同僚教師のすみれと彩はそんな夕子と意気投合し、問題を解決するため行動を共にする。
 1	同僚教師	同僚教師	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウリョウ;キョウシ,同僚;教師,同僚;教師,同僚;教師,ドーリョー;キョーシ,;,;,ドウリョウ;キョウシ,ドウリョウキョウシ,同僚教師
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -213,6 +221,7 @@
 
 # newdoc id = dev-s10
 # sent_id = dev-s10
+# parallel_id = jagsdluw/dev10
 # text = ほかの複数の信者も女性宅近くで付きまとい行為をしていたとみられ,統一教会の組織的な関与の有無を慎重に調べている。
 1	ほか	他	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -247,6 +256,7 @@
 
 # newdoc id = dev-s11
 # sent_id = dev-s11
+# parallel_id = jagsdluw/dev11
 # text = 背中に背負ったブースターを使って空中飛行を行う。
 1	背中	背中	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セナカ,背中,背中,背中,セナカ,,,セナカ,セナカ,背中
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -263,6 +273,7 @@
 
 # newdoc id = dev-s12
 # sent_id = dev-s12
+# parallel_id = jagsdluw/dev12
 # text = また、最新版のウェブブラウザを利用していても、OSやコンポーネント側にセキュリティホールが存在すれば、そこを突かれる可能性がある。
 1	また	又	CCONJ	接続詞	_	27	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -295,6 +306,7 @@
 
 # newdoc id = dev-s13
 # sent_id = dev-s13
+# parallel_id = jagsdluw/dev13
 # text = しかも、熱々の料理はとても美味しかったです。
 1	しかも	然も	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカモ,然も,しかも,しかも,シカモ,,,シカモ,シカモ,然も
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -310,6 +322,7 @@
 
 # newdoc id = dev-s14
 # sent_id = dev-s14
+# parallel_id = jagsdluw/dev14
 # text = 取り調べ段階では黙秘を貫き“全ては裁判官の前で話す”としていた被告は,犯行を認めたものの教祖への逮捕状発布の経緯に関し“捜査当局の不手際,失態”と元同僚らを非難,法廷は一時元警視の独壇場となった。
 1	取り調べ段階	取り調べ段階	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トリシラベ;ダンカイ,取り調べ;段階,取り調べ;段階,取り調べ;段階,トリシラベ;ダンカイ,;,;,トリシラベ;ダンカイ,トリシラベダンカイ,取り調べ段階
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -371,6 +384,7 @@
 
 # newdoc id = dev-s15
 # sent_id = dev-s15
+# parallel_id = jagsdluw/dev15
 # text = 今回、日本のメディアもこのテストに参加することができたので、最新バージョンの出来具合をレポートしていきたい。
 1	今回	今回	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンカイ,今回,今回,今回,コンカイ,,,コンカイ,コンカイ,今回
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -397,6 +411,7 @@
 
 # newdoc id = dev-s16
 # sent_id = dev-s16
+# parallel_id = jagsdluw/dev16
 # text = 大正期から、ノンフィクション、推理小説などを訳した。
 1	大正期	大正期	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイショウ;キ,大正;期,大正;期,大正;期,タイショー;キ,;,;,タイショウ;キ,タイショウキ,大正期
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -412,6 +427,7 @@
 
 # newdoc id = dev-s17
 # sent_id = dev-s17
+# parallel_id = jagsdluw/dev17
 # text = 市内のユダヤ人は1942年までにその全員が逃亡するか、強制収容所に送致されるかのいずれかであった。
 1	市内	市内	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シナイ,市内,市内,市内,シナイ,,,シナイ,シナイ,市内
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -440,6 +456,7 @@
 
 # newdoc id = dev-s18
 # sent_id = dev-s18
+# parallel_id = jagsdluw/dev18
 # text = ほとんどは浅海生だが、水深数百mほどの深海まで生息するものもいる。
 1	ほとんど	殆ど	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホトンド,殆ど,ほとんど,ほとんど,ホトンド,,,ホトンド,ホトンド,殆ど
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -461,6 +478,7 @@
 
 # newdoc id = dev-s19
 # sent_id = dev-s19
+# parallel_id = jagsdluw/dev19
 # text = 価格に見合う満足感を感じます。
 1	価格	価格	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カカク,価格,価格,価格,カカク,,,カカク,カカク,価格
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -473,6 +491,7 @@
 
 # newdoc id = dev-s20
 # sent_id = dev-s20
+# parallel_id = jagsdluw/dev20
 # text = 一方B国では輸出により小麦の量が減るので、小麦の価格は上がる。
 1	一方	一方	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	B国	B国	NOUN	名詞-普通名詞-一般	_	18	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビー;コク,Ｂ;国,B;国,B;国,ビー;コク,;,;,ビー;コク,ビーコク,B国
@@ -496,6 +515,7 @@
 
 # newdoc id = dev-s21
 # sent_id = dev-s21
+# parallel_id = jagsdluw/dev21
 # text = インターナショナル・マネジメント・グループをはじめとする投資家によって所有しているが、中でも元テニス選手ピート・サンプラスとアンドレ・アガシも投資されている。
 1	インターナショナル・マネジメント・グループ	インターナショナル・マネジメント・グループ	PROPN	名詞-固有名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=インターナショナル;;マネージメント;;グループ,インターナショナル;・;マネージメント;・;グループ,インターナショナル;・;マネジメント;・;グループ,インターナショナル;・;マネジメント;・;グループ,インターナショナル;;マネジメント;;グループ,;;;;,;;;;,インターナショナル;;マネジメント;;グループ,インターナショナルマネージメントグループ,インターナショナル・マネージメント・グループ
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -523,6 +543,7 @@
 
 # newdoc id = dev-s22
 # sent_id = dev-s22
+# parallel_id = jagsdluw/dev22
 # text = 聖書に当てはめた場合、最も分かりやすいのがノアの方舟伝説である。
 1	聖書	聖書	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイショ,聖書,聖書,聖書,セーショ,,,セイショ,セイショ,聖書
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -543,6 +564,7 @@
 
 # newdoc id = dev-s23
 # sent_id = dev-s23
+# parallel_id = jagsdluw/dev23
 # text = 海は油膜を貼って青白く光っており、無数の漂着物が流れている。
 1	海	海	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウミ,海,海,海,ウミ,,,ウミ,ウミ,海
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -564,6 +586,7 @@
 
 # newdoc id = dev-s24
 # sent_id = dev-s24
+# parallel_id = jagsdluw/dev24
 # text = 一つに,書籍や講演会,施設,HPなどで教祖と幹部の本音,生活,人間性などの真実の情報を手に入れることです。
 1	一つ	一つ	NUM	名詞-数詞	_	31	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒト;ツ,一;つ,一;つ,一;つ,ヒト;ツ,;,;,ヒト;ツ,ヒトツ,一つ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -601,6 +624,7 @@
 
 # newdoc id = dev-s25
 # sent_id = dev-s25
+# parallel_id = jagsdluw/dev25
 # text = 麺棒は直径2~3cm、長さ1m程度のものが一般的という。
 1	麺棒	麺棒	NOUN	名詞-普通名詞-一般	_	13	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メンボウ,麺棒,麺棒,麺棒,メンボー,,,メンボウ,メンボウ,麺棒
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -619,6 +643,7 @@
 
 # newdoc id = dev-s26
 # sent_id = dev-s26
+# parallel_id = jagsdluw/dev26
 # text = グレたのは、母を亡くし父が仕事で忙しい事が原因らしい。
 1	グレ	ぐれる	VERB	動詞-一般-下一段-ラ行	_	16	csubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=グレル,ぐれる,グレ,グレる,グレ,,,グレル,グレル,ぐれる
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -641,6 +666,7 @@
 
 # newdoc id = dev-s27
 # sent_id = dev-s27
+# parallel_id = jagsdluw/dev27
 # text = スタッフさんも親切に接してくれたので、緊張せずに居心地が良かったです。
 1	スタッフさん	スタッフさん	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタッフ;サン,スタッフ;さん,スタッフ;さん,スタッフ;さん,スタッフ;サン,;,;,スタッフ;サン,スタッフサン,スタッフさん
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -663,12 +689,14 @@
 
 # newdoc id = dev-s28
 # sent_id = dev-s28
+# parallel_id = jagsdluw/dev28
 # text = 元広島県議会議員。
 1	元広島県議会議員	元広島県議会議員	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=モト;ヒロシマ;ケン;ギカイ;ギイン,元;ヒロシマ;県;議会;議員,元;広島;県;議会;議員,元;広島;県;議会;議員,モト;ヒロシマ;ケン;ギカイ;ギイン,;;;;,;;;;,モト;ヒロシマ;ケン;ギカイ;ギイン,モトヒロシマケンギカイギイン,元広島県議会議員
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s29
 # sent_id = dev-s29
+# parallel_id = jagsdluw/dev29
 # text = 地域別では「高台」を選んだのは田老66・0%、仙台39・6%と地域差が大きかった。
 1	地域別	地域別	NOUN	名詞-普通名詞-一般	_	20	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チイキ;ベツ,地域;別,地域;別,地域;別,チイキ;ベツ,;,;,チイキ;ベツ,チイキベツ,地域別
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -695,6 +723,7 @@
 
 # newdoc id = dev-s30
 # sent_id = dev-s30
+# parallel_id = jagsdluw/dev30
 # text = 演芸では,昨年の後夜祭で大受けをとった米粒写経が登場。
 1	演芸	演芸	NOUN	名詞-普通名詞-一般	_	15	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エンゲイ,演芸,演芸,演芸,エンゲー,,,エンゲイ,エンゲイ,演芸
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -715,6 +744,7 @@
 
 # newdoc id = dev-s31
 # sent_id = dev-s31
+# parallel_id = jagsdluw/dev31
 # text = ロングヘアーの色黒の女性。
 1	ロングヘアー	ロングヘアー	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ロング;ヘア,ロング;ヘア,ロング;ヘアー,ロング;ヘアー,ロング;ヘアー,;,;,ロング;ヘアー,ロングヘアー,ロングヘアー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -725,6 +755,7 @@
 
 # newdoc id = dev-s33
 # sent_id = dev-s33
+# parallel_id = jagsdluw/dev33
 # text = ここ数年,統一教会の関連会社による霊感商法で信者の逮捕者が続出しています。
 1	ここ	此処	PRON	代名詞	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
 2	数年	数年	NUM	名詞-数詞	_	14	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スウ;ネン,数;年,数;年,数;年,スー;ネン,;,;,スウ;ネン,スウネン,数年
@@ -746,6 +777,7 @@
 
 # newdoc id = dev-s34
 # sent_id = dev-s34
+# parallel_id = jagsdluw/dev34
 # text = やはり、個室って隔たりがあるのでプライベートな話やビジネスの大事な話もお食事やお酒を飲みながらできるというのがとても大きなメリットであることが分かりました。
 1	やはり	矢張り	ADV	副詞	_	35	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤハリ,矢張り,やはり,やはり,ヤハリ,,,ヤハリ,ヤハリ,矢張り
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -788,6 +820,7 @@
 
 # newdoc id = dev-s35
 # sent_id = dev-s35
+# parallel_id = jagsdluw/dev35
 # text = 精神科へ通院する人の中には、病院へ通院したり予約時間までの間待ち続けるだけでも消耗する人もいます。
 1	精神科	精神科	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイシン;カ,精神;科,精神;科,精神;科,セーシン;カ,;,;,セイシン;カ,セイシンカ,精神科
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -819,6 +852,7 @@
 
 # newdoc id = dev-s36
 # sent_id = dev-s36
+# parallel_id = jagsdluw/dev36
 # text = また、前年16本だったホームランは19本まで増えた。
 1	また	又	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -836,6 +870,7 @@
 
 # newdoc id = dev-s37
 # sent_id = dev-s37
+# parallel_id = jagsdluw/dev37
 # text = 久しぶりにうまいコーヒーが飲めました。
 1	久しぶり	久し振り	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒサシイ;ブリ,久しい;振り,久し;ぶり,久しい;ぶり,ヒサシ;ブリ,;,;,ヒサシイ;ブリ,ヒサシブリ,久し振り
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -849,6 +884,7 @@
 
 # newdoc id = dev-s38
 # sent_id = dev-s38
+# parallel_id = jagsdluw/dev38
 # text = これはほとんどのユーザーには問題なかったが、一部のゲームではコピープロテクト用の未フォーマット領域やディスクにたくさんのデータを詰め込む方法として拡張トラックを使用しており、カスタムフォーマットユーティリティでは80トラックのディスクに86のトラックを作るフォーマットが容量拡張の手段として一般的に選べた。
 1	これ	此れ	PRON	代名詞	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -911,6 +947,7 @@
 
 # newdoc id = dev-s39
 # sent_id = dev-s39
+# parallel_id = jagsdluw/dev39
 # text = 現在は空き名跡となっている。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -922,6 +959,7 @@
 
 # newdoc id = dev-s40
 # sent_id = dev-s40
+# parallel_id = jagsdluw/dev40
 # text = 元文3年の一門家新設時は加治木家と垂水家がこの家格とされたが、同年に成立した重富家も加わり、重富家の前身、越前島津家が室町幕府の直勤だったため、一門家筆頭とされた。
 1	元文	元文	PROPN	名詞-固有名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ゲンブン,元文,元文,元文,ゲンブン,,,ゲンブン,ゲンブン,元文
 2	3年	3年	NUM	名詞-数詞	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ネン,三;年,3;年,3;年,サン;ネン,;,;,サン;ネン,サンネン,3年
@@ -970,6 +1008,7 @@
 
 # newdoc id = dev-s41
 # sent_id = dev-s41
+# parallel_id = jagsdluw/dev41
 # text = 色の指定にtealと指定すると、16進数表記で#008080と表現される色が発色される。
 1	色	色	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イロ,色,色,色,イロ,,,イロ,イロ,色
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -994,6 +1033,7 @@
 
 # newdoc id = dev-s42
 # sent_id = dev-s42
+# parallel_id = jagsdluw/dev42
 # text = 晩年は霧ケ峰牧場で余生を過ごしたといわれている。
 1	晩年	晩年	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バンネン,晩年,晩年,晩年,バンネン,,,バンネン,バンネン,晩年
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1011,6 +1051,7 @@
 
 # newdoc id = dev-s43
 # sent_id = dev-s43
+# parallel_id = jagsdluw/dev43
 # text = 以上の操作を再帰的に繰り返すと以下のような決定木が出力される。
 1	以上	以上	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イジョウ,以上,以上,以上,イジョー,,,イジョウ,イジョウ,以上
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1032,6 +1073,7 @@
 
 # newdoc id = dev-s44
 # sent_id = dev-s44
+# parallel_id = jagsdluw/dev44
 # text = どこにするか迷ってる方がいたら、ぜひともここをオススメします。
 1	どこ	何処	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドコ,何処,どこ,どこ,ドコ,,,ドコ,ドコ,何処
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1053,6 +1095,7 @@
 
 # newdoc id = dev-s45
 # sent_id = dev-s45
+# parallel_id = jagsdluw/dev45
 # text = これはおそらくタバコを普及させたウォルター・ローリー卿が伝説の黄金の都市エル・ドラードを求めてガイアナのオリノコ川を遡った1580年の遠征の栄誉を称えたものと見られている。
 1	これ	此れ	PRON	代名詞	_	36	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1096,6 +1139,7 @@
 
 # newdoc id = dev-s46
 # sent_id = dev-s46
+# parallel_id = jagsdluw/dev46
 # text = 16日の東京株式市場も主力輸出株はさえない。
 1	16日	16日	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ロク;ニチ,一;六;日,1;6;日,1;6;日,イチ;ロク;ニチ,;;,;;,イチ;ロク;ニチ,イチロクニチ,16日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1109,6 +1153,7 @@
 
 # newdoc id = dev-s47
 # sent_id = dev-s47
+# parallel_id = jagsdluw/dev47
 # text = これらが順に収縮することで食物を胃に送り出すような動きをする。
 1	これら	此れ等	PRON	代名詞	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ;ラ,此れ;等,これ;ら,これ;ら,コレ;ラ,;,;,コレ;ラ,コレラ,此れ等
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1131,6 +1176,7 @@
 
 # newdoc id = dev-s48
 # sent_id = dev-s48
+# parallel_id = jagsdluw/dev48
 # text = 実際廃止された区間の復旧再開も京義・東海線とともに検討され、1991年にすでに用地買取や設計などが済まされていたが、地形的理由で見送られてきた。
 1	実際	実際	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジッサイ,実際,実際,実際,ジッサイ,,,ジッサイ,ジッサイ,実際
 2	廃止さ	廃止する	VERB	動詞-一般-サ行変格	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハイシ;スル,廃止;為る,廃止;さ,廃止;する,ハイシ;サ,;,;,ハイシ;スル,ハイシスル,廃止する
@@ -1171,6 +1217,7 @@
 
 # newdoc id = dev-s49
 # sent_id = dev-s49
+# parallel_id = jagsdluw/dev49
 # text = 蔵前国技館跡地は東京都に売却し、その売却益が両国国技館建設の資金となった。
 1	蔵前国技館跡地	蔵前国技館跡地	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クラマエ;コクギ;カン;アトチ,クラマエ;国技;館;跡地,蔵前;国技;館;跡地,蔵前;国技;館;跡地,クラマエ;コクギ;カン;アトチ,;;;,;;;,クラマエ;コクギ;カン;アトチ,クラマエコクギカンアトチ,蔵前国技館跡地
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1191,6 +1238,7 @@
 
 # newdoc id = dev-s50
 # sent_id = dev-s50
+# parallel_id = jagsdluw/dev50
 # text = ヴィクトル・ユゴーなどフランス・ロマン派を専門とした。
 1	ヴィクトル・ユゴー	ヴィクトル・ユゴー	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビクトル;;ユーゴー,ビクトル;・;ユーゴー,ヴィクトル;・;ユゴー,ヴィクトル;・;ユゴー,ビクトル;;ユゴー,;;,;;,ビクトル;;ユゴー,ビクトルユゴー,ヴィクトル・ユゴー
 2	など	など	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナド,など,など,など,ナド,,,ナド,ナド,など
@@ -1204,6 +1252,7 @@
 
 # newdoc id = dev-s51
 # sent_id = dev-s51
+# parallel_id = jagsdluw/dev51
 # text = イーアスの中にある映画館なので、駐車場が広いのもGood。
 1	イーアス	イーアス	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イーアス,イーアス,イーアス,イーアス,イーアス,,,イーアス,イーアス,イーアス
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1224,6 +1273,7 @@
 
 # newdoc id = dev-s52
 # sent_id = dev-s52
+# parallel_id = jagsdluw/dev52
 # text = 府中や国立の辺りの土地が得意とのことで、色々と紹介してもらうことができました。
 1	府中	府中	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フチュウ,フチュウ,府中,府中,フチュー,,,フチュウ,フチュウ,府中
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -1250,6 +1300,7 @@
 
 # newdoc id = dev-s53
 # sent_id = dev-s53
+# parallel_id = jagsdluw/dev53
 # text = 日本貝類学会役員、東京貝類同好会名誉会長を務めた貝類収集家としても知られた。
 1	日本貝類学会役員	日本介類学会役員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン;カイルイ;ガッカイ;ヤクイン,日本;介類;学会;役員,日本;貝類;学会;役員,日本;貝類;学会;役員,ニッポン;カイルイ;ガッカイ;ヤクイン,;;;,;;;,ニッポン;カイルイ;ガッカイ;ヤクイン,ニッポンカイルイガッカイヤクイン,日本介類学会役員
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1268,6 +1319,7 @@
 
 # newdoc id = dev-s54
 # sent_id = dev-s54
+# parallel_id = jagsdluw/dev54
 # text = 富士通は、産業機械だけでなく、社会インフラや物流業界などに対してM2Mサービスを提供する。
 1	富士通	富士通	PROPN	名詞-固有名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フジツウ,富士通,富士通,富士通,フジツー,,,フジツウ,フジツウ,富士通
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1287,6 +1339,7 @@
 
 # newdoc id = dev-s55
 # sent_id = dev-s55
+# parallel_id = jagsdluw/dev55
 # text = 第一次世界大戦終結後、ヴェルサイユ条約によって大砲の保有を禁止されたドイツから戦争賠償としてベルギーが残存砲を接収して装備した。
 1	第一次世界大戦終結後	第一次世界大戦終結後	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;イチ;ジ;セカイ;タイセン;シュウケツ;ゴ,第;一;次;世界;大戦;終結;後,第;一;次;世界;大戦;終結;後,第;一;次;世界;大戦;終結;後,ダイ;イチ;ジ;セカイ;タイセン;シューケツ;ゴ,;;;;;;,;;;;;;,ダイ;イチ;ジ;セカイ;タイセン;シュウケツ;ゴ,ダイイチジセカイタイセンシュウケツゴ,第一次世界大戦終結後
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1315,6 +1368,7 @@
 
 # newdoc id = dev-s56
 # sent_id = dev-s56
+# parallel_id = jagsdluw/dev56
 # text = やはり、おすすめは焼き物ですね。
 1	やはり	矢張り	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤハリ,矢張り,やはり,やはり,ヤハリ,,,ヤハリ,ヤハリ,矢張り
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1327,6 +1381,7 @@
 
 # newdoc id = dev-s57
 # sent_id = dev-s57
+# parallel_id = jagsdluw/dev57
 # text = いなべ市藤原町坂本-同市藤原町下野尻を以下の路線バスが通過する。
 1	いなべ市	いなべ市	PROPN	名詞-固有名詞-地名-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イナベ;シ,イナベ;市,いなべ;市,いなべ;市,イナベ;シ,;,;,イナベ;シ,イナベシ,いなべ市
 2	藤原町	藤原町	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フジワラ;チョウ,フジワラ;町,藤原;町,藤原;町,フジワラ;チョー,;,;,フジワラ;チョウ,フジワラチョウ,藤原町
@@ -1345,6 +1400,7 @@
 
 # newdoc id = dev-s58
 # sent_id = dev-s58
+# parallel_id = jagsdluw/dev58
 # text = ロイツェは沖縄戦終結後の7月10日に慶良間を離れてグアム、真珠湾を経由してサンフランシスコに到着し、8月3日からハンターズ・ポイント海軍造船所で修理が開始されたが、終戦により修理は停止された。
 1	ロイツェ	ロイツェ	PROPN	名詞-固有名詞-人名-一般	_	20	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ロイツェ,ロイツェ,ロイツェ,ロイツェ,ロイツェ,,,ロイツェ,ロイツェ,ロイツェ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1390,6 +1446,7 @@
 
 # newdoc id = dev-s59
 # sent_id = dev-s59
+# parallel_id = jagsdluw/dev59
 # text = その際,国会議員に対して請願を行う予定と見られています。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	際	際	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイ,際,際,際,サイ,,,サイ,サイ,際
@@ -1409,6 +1466,7 @@
 
 # newdoc id = dev-s60
 # sent_id = dev-s60
+# parallel_id = jagsdluw/dev60
 # text = かつては、農業が圧倒的で、バーデン=ヴュルテンベルク州内で最も脆弱な経済基盤の郡であったが、近年は構造変化を成し遂げている。
 1	かつて	嘗て	ADV	副詞	_	16	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カツテ,嘗て,かつて,かつて,カツテ,,,カツテ,カツテ,嘗て
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1440,6 +1498,7 @@
 
 # newdoc id = dev-s61
 # sent_id = dev-s61
+# parallel_id = jagsdluw/dev61
 # text = 人を人として思わないような,尋常ではないこの現実をみなさんにお伝えしたいのです。
 1	人	人	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒト,人,人,人,ヒト,,,ヒト,ヒト,人
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -1464,6 +1523,7 @@
 
 # newdoc id = dev-s62
 # sent_id = dev-s62
+# parallel_id = jagsdluw/dev62
 # text = ハンマーはやめて!
 1	ハンマー	ハンマー	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハンマー,ハンマー,ハンマー,ハンマー,ハンマー,,,ハンマー,ハンマー,ハンマー
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1473,6 +1533,7 @@
 
 # newdoc id = dev-s63
 # sent_id = dev-s63
+# parallel_id = jagsdluw/dev63
 # text = 大きな拍手が巻き起こりました。
 1	大きな	大きな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキナ,大きな,大きな,大きな,オーキナ,,,オオキナ,オオキナ,大きな
 2	拍手	拍手	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハクシュ,拍手,拍手,拍手,ハクシュ,,,ハクシュ,ハクシュ,拍手
@@ -1484,6 +1545,7 @@
 
 # newdoc id = dev-s64
 # sent_id = dev-s64
+# parallel_id = jagsdluw/dev64
 # text = リミテッド・シリーズの『マーベル1602』で、「スティーブン・ストレンジ卿」は専属医師兼魔術師としてエリザベス1世に仕えた。
 1	リミテッド・シリーズ	リミテッド・シリーズ	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リミテッド;;シリーズ,リミテッド;・;シリーズ,リミテッド;・;シリーズ,リミテッド;・;シリーズ,リミテッド;;シリーズ,;;,;;,リミテッド;;シリーズ,リミテッドシリーズ,リミテッド・シリーズ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1508,6 +1570,7 @@
 
 # newdoc id = dev-s65
 # sent_id = dev-s65
+# parallel_id = jagsdluw/dev65
 # text = 果肉は橙色で、肉質はやや硬いが多汁である。
 1	果肉	果肉	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カニク,果肉,果肉,果肉,カニク,,,カニク,カニク,果肉
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1525,6 +1588,7 @@
 
 # newdoc id = dev-s66
 # sent_id = dev-s66
+# parallel_id = jagsdluw/dev66
 # text = 戸籍上は女性として生まれたが、幼い頃から「自分は男性である」との性自認を持っていた。
 1	戸籍上	戸籍上	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コセキ;ジョウ,戸籍;上,戸籍;上,戸籍;上,コセキ;ジョー,;,;,コセキ;ジョウ,コセキジョウ,戸籍上
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1554,6 +1618,7 @@
 
 # newdoc id = dev-s67
 # sent_id = dev-s67
+# parallel_id = jagsdluw/dev67
 # text = 中日新聞社が後援している。
 1	中日新聞社	中日新聞社	PROPN	名詞-固有名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウニチ;シンブン;シャ,中日;新聞;社,中日;新聞;社,中日;新聞;社,チューニチ;シンブン;シャ,;;,;;,チュウニチ;シンブン;シャ,チュウニチシンブンシャ,中日新聞社
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1563,6 +1628,7 @@
 
 # newdoc id = dev-s68
 # sent_id = dev-s68
+# parallel_id = jagsdluw/dev68
 # text = カラフルで色合いがいいデザインがあったので気に入りました。
 1	カラフル	カラフル	ADJ	形状詞-一般	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カラフル,カラフル,カラフル,カラフル,カラフル,,,カラフル,カラフル,カラフル
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -1583,6 +1649,7 @@
 
 # newdoc id = dev-s69
 # sent_id = dev-s69
+# parallel_id = jagsdluw/dev69
 # text = クルマにまつわるエピソードをTwitterで投稿する同キャンペーン。
 1	クルマ	車	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クルマ,車,クルマ,クルマ,クルマ,,,クルマ,クルマ,車
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1597,6 +1664,7 @@
 
 # newdoc id = dev-s70
 # sent_id = dev-s70
+# parallel_id = jagsdluw/dev70
 # text = ビッグ・モーラが破壊されたときには、彼らの策略のために、既にかつての威光はなくなっていた。
 1	ビッグ・モーラ	ビッグ・モーラ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビッグ;;モーラ,ビッグ;・;モーラ,ビッグ;・;モーラ,ビッグ;・;モーラ,ビッグ;;モーラ,;;,;;,ビッグ;;モーラ,ビッグモーラ,ビッグ・モーラ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1626,6 +1694,7 @@
 
 # newdoc id = dev-s71
 # sent_id = dev-s71
+# parallel_id = jagsdluw/dev71
 # text = 北朝鮮についてはホームでの対戦もすんなりとはいかない。
 1	北朝鮮	北朝鮮	PROPN	名詞-固有名詞-地名-国	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キタチョウセン,北朝鮮,北朝鮮,北朝鮮,キタチョーセン,,,キタチョウセン,キタチョウセン,北朝鮮
 2	について	について	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ツク;テ,に;つく;て,に;つい;て,に;つく;て,ニ;ツイ;テ,;;,;;,ニ;ツク;テ,ニツイテ,について
@@ -1644,6 +1713,7 @@
 
 # newdoc id = dev-s72
 # sent_id = dev-s72
+# parallel_id = jagsdluw/dev72
 # text = 定期的にイベントしてるらしくて要チェックです。
 1	定期的	定期的	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テイキ;テキ,定期;的,定期;的,定期;的,テーキ;テキ,;,;,テイキ;テキ,テイキテキ,定期的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -1657,6 +1727,7 @@
 
 # newdoc id = dev-s73
 # sent_id = dev-s73
+# parallel_id = jagsdluw/dev73
 # text = 中日の次期監督に決まっている高木守道氏からラブコールを送られている福留に、巨人も再び手を伸ばすことになるかどうか。
 1	中日	中日	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウニチ,中日,中日,中日,チューニチ,,,チュウニチ,チュウニチ,中日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1688,6 +1759,7 @@
 
 # newdoc id = dev-s74
 # sent_id = dev-s74
+# parallel_id = jagsdluw/dev74
 # text = 施設は大阪市が所有し、指定管理者は財団法人大阪市スポーツ・みどり振興協会である。
 1	施設	施設	NOUN	名詞-普通名詞-一般	_	5	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シセツ,施設,施設,施設,シセツ,,,シセツ,シセツ,施設
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1703,6 +1775,7 @@
 
 # newdoc id = dev-s75
 # sent_id = dev-s75
+# parallel_id = jagsdluw/dev75
 # text = 私は住民に事実を伝えるのが仕事ですから。
 1	私	私	PRON	代名詞	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1720,6 +1793,7 @@
 
 # newdoc id = dev-s76
 # sent_id = dev-s76
+# parallel_id = jagsdluw/dev76
 # text = ヨーロッパ各国の航空機メーカのコンソーシアムであるエアバス社は、政治的な理由によりヨーロッパ各地に部品工場を保有しており、最終組み立てのため機体部品の輸送が課題であった。
 1	ヨーロッパ各国	ヨーロッパ各国	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨーロッパ;カッコク,ヨーロッパ;各国,ヨーロッパ;各国,ヨーロッパ;各国,ヨーロッパ;カッコク,;,;,ヨーロッパ;カッコク,ヨーロッパカッコク,ヨーロッパ各国
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1755,6 +1829,7 @@
 
 # newdoc id = dev-s77
 # sent_id = dev-s77
+# parallel_id = jagsdluw/dev77
 # text = 途中でジュールが亡くなったため兄エドモンが完成。
 1	途中	途中	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トチュウ,途中,途中,途中,トチュー,,,トチュウ,トチュウ,途中
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -1770,6 +1845,7 @@
 
 # newdoc id = dev-s78
 # sent_id = dev-s78
+# parallel_id = jagsdluw/dev78
 # text = 同社の不燃木材は浅野木材工業の浅野成昭が開発し、2001年に日本で初めて国土交通省から不燃材料の認定を受けた。
 1	同社	同社	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウシャ,同社,同社,同社,ドーシャ,,,ドウシャ,ドウシャ,同社
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1798,6 +1874,7 @@
 
 # newdoc id = dev-s79
 # sent_id = dev-s79
+# parallel_id = jagsdluw/dev79
 # text = 堀田は仙台藩伊達家を「家元」と宇和島藩伊達家を「家別レ」とするといった調停案を示した。
 1	堀田	堀田	PROPN	名詞-固有名詞-人名-姓	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホッタ,ホッタ,堀田,堀田,ホッタ,,,ホッタ,ホッタ,堀田
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1823,6 +1900,7 @@
 
 # newdoc id = dev-s80
 # sent_id = dev-s80
+# parallel_id = jagsdluw/dev80
 # text = ホームページが出来たみたいです。
 1	ホームページ	ホームページ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホーム;ページ,ホーム;ページ,ホーム;ページ,ホーム;ページ,ホーム;ページ,;,;,ホーム;ページ,ホームページ,ホームページ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1834,6 +1912,7 @@
 
 # newdoc id = dev-s81
 # sent_id = dev-s81
+# parallel_id = jagsdluw/dev81
 # text = また、10月には販売網の強化と顧客へのサービスの充実を図るため、神奈川県藤沢市に営業所を開設。
 1	また	又	CCONJ	接続詞	_	25	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1864,6 +1943,7 @@
 
 # newdoc id = dev-s82
 # sent_id = dev-s82
+# parallel_id = jagsdluw/dev82
 # text = JBS日本福祉放送は社会福祉法人“視覚障害者文化振興協会”が運営する視覚障害者専用放送だ。
 1	JBS日本福祉放送	JBS日本福祉放送	PROPN	名詞-固有名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェービーエス;ニッポン;フクシ;ホウソウ,ＪＢＳ;日本;福祉;放送,JBS;日本;福祉;放送,JBS;日本;福祉;放送,ジェービーエス;ニッポン;フクシ;ホーソー,;;;,;;;,ジェービーエス;ニッポン;フクシ;ホウソウ,ジェービーエスニッポンフクシホウソウ,JBS日本福祉放送
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1879,6 +1959,7 @@
 
 # newdoc id = dev-s83
 # sent_id = dev-s83
+# parallel_id = jagsdluw/dev83
 # text = 1986年より開発はフェイズ2に移行し機体の改修作業が行われた。
 1	1986年	1986年	NUM	名詞-数詞	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ハチ;ロク;ネン,一;九;八;六;年,1;9;8;6;年,1;9;8;6;年,イチ;キュー;ハチ;ロク;ネン,;;;;,;;;;,イチ;キュウ;ハチ;ロク;ネン,イチキュウハチロクネン,1986年
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -1898,6 +1979,7 @@
 
 # newdoc id = dev-s84
 # sent_id = dev-s84
+# parallel_id = jagsdluw/dev84
 # text = 米議会内でもビンラディンが殺害されたことを確認するうえでも公表すべきだとの声が高まっていた。
 1	米議会内	米議会内	NOUN	名詞-普通名詞-一般	_	21	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベイ;ギカイ;ナイ,米;議会;内,米;議会;内,米;議会;内,ベー;ギカイ;ナイ,;;,;;,ベイ;ギカイ;ナイ,ベイギカイナイ,米議会内
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -1926,6 +2008,7 @@
 
 # newdoc id = dev-s85
 # sent_id = dev-s85
+# parallel_id = jagsdluw/dev85
 # text = ただし、個別の作品に関する話題はエロゲー作品別板で扱う。
 1	ただし	但し	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1942,6 +2025,7 @@
 
 # newdoc id = dev-s86
 # sent_id = dev-s86
+# parallel_id = jagsdluw/dev86
 # text = そのような活動を止めるどころか,顕進氏は,自分は創始者と協力しており,真の御父母様の遺されたものを維持しようとしているのだという錯覚を,積極的に助長してきています。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	よう	様	NOUN	形状詞-助動詞語幹	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=ヨウ,様,よう,よう,ヨー,,,ヨウ,ヨウ,様
@@ -1990,6 +2074,7 @@
 
 # newdoc id = dev-s87
 # sent_id = dev-s87
+# parallel_id = jagsdluw/dev87
 # text = 私はクートラ医師の所有するストリックランドの果物絵を見て恐ろしさを感じていた。
 1	私	私	PRON	代名詞	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2011,6 +2096,7 @@
 
 # newdoc id = dev-s88
 # sent_id = dev-s88
+# parallel_id = jagsdluw/dev88
 # text = その保健室の養護教諭が,生徒からバカにされていた様子がうかがえます。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	保健室	保健室	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホケン;シツ,保健;室,保健;室,保健;室,ホケン;シツ,;,;,ホケン;シツ,ホケンシツ,保健室
@@ -2034,6 +2120,7 @@
 
 # newdoc id = dev-s89
 # sent_id = dev-s89
+# parallel_id = jagsdluw/dev89
 # text = 今回が初のツアー競技挑戦だ。
 1	今回	今回	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンカイ,今回,今回,今回,コンカイ,,,コンカイ,コンカイ,今回
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -2045,6 +2132,7 @@
 
 # newdoc id = dev-s90
 # sent_id = dev-s90
+# parallel_id = jagsdluw/dev90
 # text = やはり、日常的に利用されることが多い業者だけあって、非常に慣れた感じはあります。
 1	やはり	矢張り	ADV	副詞	_	21	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤハリ,矢張り,やはり,やはり,ヤハリ,,,ヤハリ,ヤハリ,矢張り
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2072,6 +2160,7 @@
 
 # newdoc id = dev-s91
 # sent_id = dev-s91
+# parallel_id = jagsdluw/dev91
 # text = 流出したものとされる資料群の中に,“日本における国産テロリストの脅威について”というタイトルのPDFファイルがありました。
 1	流出し	流出する	VERB	動詞-一般-サ行変格	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リュウシュツ;スル,流出;為る,流出;し,流出;する,リューシュツ;シ,;,;,リュウシュツ;スル,リュウシュツスル,流出する
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -2104,6 +2193,7 @@
 
 # newdoc id = dev-s92
 # sent_id = dev-s92
+# parallel_id = jagsdluw/dev92
 # text = しかしながら、中心部の温度は、約5,000°Cである。
 1	しかしながら	然しながら	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ;ナガラ,然し;ながら,しかし;ながら,しかし;ながら,シカシ;ナガラ,;,;,シカシ;ナガラ,シカシナガラ,然しながら
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2118,6 +2208,7 @@
 
 # newdoc id = dev-s93
 # sent_id = dev-s93
+# parallel_id = jagsdluw/dev93
 # text = 歯のかみ合わせを考えて治療をしてくれる歯科なので、満足のいく治療をしてもらえます。
 1	歯	歯	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハ,歯,歯,歯,ハ,,,ハ,ハ,歯
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2145,6 +2236,7 @@
 
 # newdoc id = dev-s94
 # sent_id = dev-s94
+# parallel_id = jagsdluw/dev94
 # text = そして、寛永期以降の蝦夷地幕領化の中で「松前稼」と呼ばれた、蝦夷地への労働力移動が可能であり、飢餓期の困窮を一時的に回避することができた。
 1	そして	そして	CCONJ	接続詞	_	31	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2183,6 +2275,7 @@
 
 # newdoc id = dev-s95
 # sent_id = dev-s95
+# parallel_id = jagsdluw/dev95
 # text = 建設中や計画中のラインがさらに8つあるという。
 1	建設中	建設中	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケンセツ;チュウ,建設;中,建設;中,建設;中,ケンセツ;チュー,;,;,ケンセツ;チュウ,ケンセツチュウ,建設中
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -2199,6 +2292,7 @@
 
 # newdoc id = dev-s96
 # sent_id = dev-s96
+# parallel_id = jagsdluw/dev96
 # text = ぬーとぴあのシェアメイトは、優太を除きなんと全員女性。
 1	ぬーとぴあ	ぬーとぴあ	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヌートピア,ぬーとぴあ,ぬーとぴあ,ぬーとぴあ,ヌートピア,,,ヌートピア,ヌートピア,ぬーとぴあ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2214,6 +2308,7 @@
 
 # newdoc id = dev-s97
 # sent_id = dev-s97
+# parallel_id = jagsdluw/dev97
 # text = 体育科2年2組所属の少年。
 1	体育科	体育科	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=タイイク;カ,体育;科,体育;科,体育;科,タイイク;カ,;,;,タイイク;カ,タイイクカ,体育科
 2	2年	2年	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ネン,二;年,2;年,2;年,ニ;ネン,;,;,ニ;ネン,ニネン,2年
@@ -2224,6 +2319,7 @@
 
 # newdoc id = dev-s98
 # sent_id = dev-s98
+# parallel_id = jagsdluw/dev98
 # text = 誕生日用にホールケーキを予約してくれたのですが、これが美味!
 1	誕生日用	誕生日用	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タンジョウ;ヒ;ヨウ,誕生;日;用,誕生;日;用,誕生;日;用,タンジョー;ビ;ヨー,;;,;;,タンジョウ;ヒ;ヨウ,タンジョウビヨウ,誕生日用
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2242,6 +2338,7 @@
 
 # newdoc id = dev-s99
 # sent_id = dev-s99
+# parallel_id = jagsdluw/dev99
 # text = 組内外から高い評価を受けていたやり手で、二代目海江田組では実質的な運営を担っていた。
 1	組内外	組内外	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クミ;ナイガイ,組;内外,組;内外,組;内外,クミ;ナイガイ,;,;,クミ;ナイガイ,クミナイガイ,組内外
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -2268,6 +2365,7 @@
 
 # newdoc id = dev-s100
 # sent_id = dev-s100
+# parallel_id = jagsdluw/dev100
 # text = 実際はガセの情報だったのだが、レコードは自主回収となり、ナゴム閉社への決定打のひとつとなってしまう。
 1	実際	実際	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジッサイ,実際,実際,実際,ジッサイ,,,ジッサイ,ジッサイ,実際
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2298,6 +2396,7 @@
 
 # newdoc id = dev-s101
 # sent_id = dev-s101
+# parallel_id = jagsdluw/dev101
 # text = HDCD対応デジフィルの殆ど全てのICでは必ず-1dB絞っているので、通常の音楽CD盤を再生したとき、そのD/A変換回路のフルスケールは用いられていないことになる。
 1	HDCD対応デジフィル	HDCD対応デジフィル	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エイチディーシーディー;タイオウ;デジ;フィル,ＨＤＣＤ;対応;デジ;フィル,HDCD;対応;デジ;フィル,HDCD;対応;デジ;フィル,エーチディーシーディー;タイオー;デジ;フィル,;;;,;;;,エイチディーシーディー;タイオウ;デジ;フィル,エイチディーシーディータイオウデジフィル,HDCD対応デジフィル
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2336,6 +2435,7 @@
 
 # newdoc id = dev-s102
 # sent_id = dev-s102
+# parallel_id = jagsdluw/dev102
 # text = われわれの組織がつぶれれば良いと日共や権力が願望をもっても今のところ手を下す方法がない。
 1	われわれ	我々	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワレワレ,我々,われわれ,われわれ,ワレワレ,,,ワレワレ,ワレワレ,我々
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2366,6 +2466,7 @@
 
 # newdoc id = dev-s103
 # sent_id = dev-s103
+# parallel_id = jagsdluw/dev103
 # text = 外に出るのは、産後1か月で始めたヨガのレッスンに通う程度。
 1	外	外	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソト,外,外,外,ソト,,,ソト,ソト,外
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2388,6 +2489,7 @@
 
 # newdoc id = dev-s104
 # sent_id = dev-s104
+# parallel_id = jagsdluw/dev104
 # text = 来年の春、すぐ近くにある大きな公園で、子供たちと一緒に桜をみるのが、今からとても楽しみです。
 1	来年	来年	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ライネン,来年,来年,来年,ライネン,,,ライネン,ライネン,来年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2420,6 +2522,7 @@
 
 # newdoc id = dev-s105
 # sent_id = dev-s105
+# parallel_id = jagsdluw/dev105
 # text = これは後に本居宣長によって、現在と同じような位置に訂正された。
 1	これ	此れ	PRON	代名詞	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2442,6 +2545,7 @@
 
 # newdoc id = dev-s106
 # sent_id = dev-s106
+# parallel_id = jagsdluw/dev106
 # text = まんまとお店側の思惑にハマっている私でした。
 1	まんまと	まんまと	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マンマト,まんまと,まんまと,まんまと,マンマト,,,マンマト,マンマト,まんまと
 2	お店側	御店側	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセガワ,御;店側,お;店側,お;店側,オ;ミセガワ,;,;,オ;ミセガワ,オミセガワ,御店側
@@ -2457,6 +2561,7 @@
 
 # newdoc id = dev-s107
 # sent_id = dev-s107
+# parallel_id = jagsdluw/dev107
 # text = 小規模の駅前広場を持つ。
 1	小規模	小規模	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウ;キボ,小;規模,小;規模,小;規模,ショー;キボ,;,;,ショウ;キボ,ショウキボ,小規模
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2467,6 +2572,7 @@
 
 # newdoc id = dev-s108
 # sent_id = dev-s108
+# parallel_id = jagsdluw/dev108
 # text = 身長172cm、体重60kg。
 1	身長	身長	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=シンチョウ,身長,身長,身長,シンチョー,,,シンチョウ,シンチョウ,身長
 2	172cm	172cm	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ナナ;ニ;センチメートル,一;七;二;センチメートル,1;7;2;cm,1;7;2;cm,イチ;ナナ;ニ;センチメートル,;;;,;;;,イチ;ナナ;ニ;センチメートル,イチナナニセンチメートル,172cm
@@ -2477,6 +2583,7 @@
 
 # newdoc id = dev-s109
 # sent_id = dev-s109
+# parallel_id = jagsdluw/dev109
 # text = 胸部は格納庫になっており、弾薬など物資を積むことが可能。
 1	胸部	胸部	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウブ,胸部,胸部,胸部,キョーブ,,,キョウブ,キョウブ,胸部
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2497,6 +2604,7 @@
 
 # newdoc id = dev-s110
 # sent_id = dev-s110
+# parallel_id = jagsdluw/dev110
 # text = このような大型のゲル、大型のゲルを中心とした遊牧民の宮廷のことをふつうオルドと呼んでおり、モンゴル帝国のハーンたちは非常に大きなゲルをオルドとしていたことが知られる。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	よう	様	NOUN	形状詞-助動詞語幹	_	6	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=ヨウ,様,よう,よう,ヨー,,,ヨウ,ヨウ,様
@@ -2547,6 +2655,7 @@
 
 # newdoc id = dev-s111
 # sent_id = dev-s111
+# parallel_id = jagsdluw/dev111
 # text = 2011年3月期にLED関連照明事業で22億円の売り上げを目指す。
 1	2011年	2011年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;イチ;ネン,二;ゼロ;一;一;年,2;0;1;1;年,2;0;1;1;年,ニ;ゼロ;イチ;イチ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;イチ;ネン,ニゼロイチイチネン,2011年
 2	3月期	3月期	NOUN	名詞-普通名詞-一般	_	10	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ガツ;キ,三;月;期,3;月;期,3;月;期,サン;ガツ;キ,;;,;;,サン;ガツ;キ,サンガツキ,3月期
@@ -2562,6 +2671,7 @@
 
 # newdoc id = dev-s112
 # sent_id = dev-s112
+# parallel_id = jagsdluw/dev112
 # text = 1987年の第1回授賞式以来、この賞はアフリカ系アメリカ人のミュージシャンにとって、大変重要な存在となっている。
 1	1987年	1987年	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ハチ;シチ;ネン,一;九;八;七;年,1;9;8;7;年,1;9;8;7;年,イチ;キュー;ハチ;シチ;ネン,;;;;,;;;;,イチ;キュウ;ハチ;シチ;ネン,イチキュウハチシチネン,1987年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2586,6 +2696,7 @@
 
 # newdoc id = dev-s113
 # sent_id = dev-s113
+# parallel_id = jagsdluw/dev113
 # text = また同小説では藍染になすりつけられた罪は、元柳斎の尽力もあって藍染の謀略が認められたことから鉄裁・夜一の罪状共々取り消しとなったこと、商店も尸魂界公認となった上、破面篇で喜助の存在が広く知れ渡った為、現世駐在任務の死神が多数訪れるように手が足りなくなりつつある程忙しくなっていることが語られている。
 1	また	又	CCONJ	接続詞	_	77	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	同小説	同小説	NOUN	名詞-普通名詞-一般	_	77	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;ショウセツ,同;小説,同;小説,同;小説,ドー;ショーセツ,;,;,ドウ;ショウセツ,ドウショウセツ,同小説
@@ -2670,6 +2781,7 @@
 
 # newdoc id = dev-s114
 # sent_id = dev-s114
+# parallel_id = jagsdluw/dev114
 # text = また、未来の高度に進化した人工知能は本質的に自己書き換えを行うはずだと主張する者もいる。
 1	また	又	CCONJ	接続詞	_	22	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2697,6 +2809,7 @@
 
 # newdoc id = dev-s115
 # sent_id = dev-s115
+# parallel_id = jagsdluw/dev115
 # text = 体表面は水にぬれても毛の根元は油分により撥水効果をもち、これにより野生動物などは厳しい環境の寒暖の変化から体内の恒常性を守っている。
 1	体表面	体表面	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイヒョウ;メン,体表;面,体表;面,体表;面,タイヒョー;メン,;,;,タイヒョウ;メン,タイヒョウメン,体表面
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2737,6 +2850,7 @@
 
 # newdoc id = dev-s116
 # sent_id = dev-s116
+# parallel_id = jagsdluw/dev116
 # text = 形態としてはコンビニATMに類似している。
 1	形態	形態	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイタイ,形態,形態,形態,ケータイ,,,ケイタイ,ケイタイ,形態
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -2749,6 +2863,7 @@
 
 # newdoc id = dev-s117
 # sent_id = dev-s117
+# parallel_id = jagsdluw/dev117
 # text = 生まれついて“針”を持っており、それが彼女の能力に反映されている。
 1	生まれつい	生まれ付く	VERB	動詞-一般-五段-カ行	_	7	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウマレツク,生まれ付く,生まれつい,生まれつく,ウマレツイ,,,ウマレツク,ウマレツク,生まれ付く
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -2772,6 +2887,7 @@
 
 # newdoc id = dev-s118
 # sent_id = dev-s118
+# parallel_id = jagsdluw/dev118
 # text = 「CS 5」シリーズの中でもWebデザイナー向け製品である「Web Premium」に含まれるアプリケーションについての全体像と、それぞれの製品の役割について紹介していこう。
 1	「	「	PUNCT	補助記号-括弧開	_	4	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	CS 5	CS 5	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=シーエス;ファイブ,ＣＳ;ファイブ,CS;5,CS;5,シーエス;ファイブ,;,;,シーエス;ファイブ,シーエスファイブ,CS5
@@ -2807,6 +2923,7 @@
 
 # newdoc id = dev-s119
 # sent_id = dev-s119
+# parallel_id = jagsdluw/dev119
 # text = 日本基督教団阿佐ヶ谷教会の牧師を務める。
 1	日本基督教団阿佐ヶ谷教会	日本基督教団阿佐ヶ谷教会	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン;キリスト;キョウダン;アサガヤ;キョウカイ,日本;キリスト;教団;アサガヤ;教会,日本;基督;教団;阿佐ヶ谷;教会,日本;基督;教団;阿佐ヶ谷;教会,ニホン;キリスト;キョーダン;アサガヤ;キョーカイ,;;;;,;;;;,ニホン;キリスト;キョウダン;アサガヤ;キョウカイ,ニホンキリストキョウダンアサガヤキョウカイ,日本基督教団阿佐ヶ谷教会
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2817,6 +2934,7 @@
 
 # newdoc id = dev-s120
 # sent_id = dev-s120
+# parallel_id = jagsdluw/dev120
 # text = 405法廷,吉田被告は前回公判時の手錠に腰縄の姿とは異なり上下黒のスーツ姿で現れた。
 1	405法廷	405法廷	NOUN	名詞-普通名詞-一般	_	19	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨン;ゼロ;ゴ;ホウテイ,四;ゼロ;五;法廷,4;0;5;法廷,4;0;5;法廷,ヨン;ゼロ;ゴ;ホーテー,;;;,;;;,ヨン;ゼロ;ゴ;ホウテイ,ヨンゼロゴホウテイ,405法廷
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -2842,6 +2960,7 @@
 
 # newdoc id = dev-s121
 # sent_id = dev-s121
+# parallel_id = jagsdluw/dev121
 # text = まず予選7位の#1 ポルシェが抜群のスタートを決め、オープニングラップのグランプリコースの間にトップに浮上。
 1	まず	先ず	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マズ,先ず,まず,まず,マズ,,,マズ,マズ,先ず
 2	予選	予選	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ヨセン,予選,予選,予選,ヨセン,,,ヨセン,ヨセン,予選
@@ -2869,6 +2988,7 @@
 
 # newdoc id = dev-s122
 # sent_id = dev-s122
+# parallel_id = jagsdluw/dev122
 # text = バイオリン弓毛替をやっています。
 1	バイオリン弓毛替	バイオリン弓毛替え	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バイオリン;ユミゲ;カエ,バイオリン;弓毛;替え,バイオリン;弓毛;替,バイオリン;弓毛;替,バイオリン;ユミゲ;カエ,;;,;;,バイオリン;ユミゲ;カエ,バイオリンユミゲカエ,バイオリン弓毛替え
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -2879,6 +2999,7 @@
 
 # newdoc id = dev-s123
 # sent_id = dev-s123
+# parallel_id = jagsdluw/dev123
 # text = 施設に宿泊した人もいたようです。
 1	施設	施設	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シセツ,施設,施設,施設,シセツ,,,シセツ,シセツ,施設
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2894,12 +3015,14 @@
 
 # newdoc id = dev-s124
 # sent_id = dev-s124
+# parallel_id = jagsdluw/dev124
 # text = マダガスカル・コモロ。
 1	マダガスカル・コモロ	マダガスカル・コモロ	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=マダガスカル;;コモロ,マダガスカル;・;コモロ,マダガスカル;・;コモロ,マダガスカル;・;コモロ,マダガスカル;;コモロ,;;,;;,マダガスカル;;コモロ,マダガスカルコモロ,マダガスカル・コモロ
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s125
 # sent_id = dev-s125
+# parallel_id = jagsdluw/dev125
 # text = どこまでも自分しかいない、底なしの孤独。
 1	どこ	何処	PRON	代名詞	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドコ,何処,どこ,どこ,ドコ,,,ドコ,ドコ,何処
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -2916,6 +3039,7 @@
 
 # newdoc id = dev-s126
 # sent_id = dev-s126
+# parallel_id = jagsdluw/dev126
 # text = 低公害車はそれほど多くはないが、ハイブリッドバスやCNGバスが導入されている。
 1	低公害車	低公害車	NOUN	名詞-普通名詞-一般	_	7	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テイ;コウガイ;シャ,低;公害;車,低;公害;車,低;公害;車,テー;コーガイ;シャ,;;,;;,テイ;コウガイ;シャ,テイコウガイシャ,低公害車
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2937,6 +3061,7 @@
 
 # newdoc id = dev-s127
 # sent_id = dev-s127
+# parallel_id = jagsdluw/dev127
 # text = 8月31日の今日行ってきました。
 1	8月	8月	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ハチ;ガツ,八;月,8;月,8;月,ハチ;ガツ,;,;,ハチ;ガツ,ハチガツ,8月
 2	31日	31日	NUM	名詞-数詞	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;イチ;ニチ,三;一;日,3;1;日,3;1;日,サン;イチ;ニチ,;;,;;,サン;イチ;ニチ,サンイチニチ,31日
@@ -2950,6 +3075,7 @@
 
 # newdoc id = dev-s128
 # sent_id = dev-s128
+# parallel_id = jagsdluw/dev128
 # text = 初めて行ったお店でしたが、価格も出来も満足しています。
 1	初めて	初めて	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハジメテ,初めて,初めて,初めて,ハジメテ,,,ハジメテ,ハジメテ,初めて
 2	行っ	行く	VERB	動詞-一般-五段-カ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イク,行く,行っ,行く,イッ,,,イク,イク,行く
@@ -2970,6 +3096,7 @@
 
 # newdoc id = dev-s129
 # sent_id = dev-s129
+# parallel_id = jagsdluw/dev129
 # text = 超長距離戦に特化している分、自分から近い所には攻撃できない。
 1	超長距離戦	超長距離戦	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウ;チョウ;キョリ;セン,超;長;距離;戦,超;長;距離;戦,超;長;距離;戦,チョー;チョー;キョリ;セン,;;;,;;;,チョウ;チョウ;キョリ;セン,チョウチョウキョリセン,超長距離戦
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2989,6 +3116,7 @@
 
 # newdoc id = dev-s130
 # sent_id = dev-s130
+# parallel_id = jagsdluw/dev130
 # text = 1934年にトーキーに初出演。
 1	1934年	1934年	NUM	名詞-数詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;サン;ヨン;ネン,一;九;三;四;年,1;9;3;4;年,1;9;3;4;年,イチ;キュー;サン;ヨ;ネン,;;;;,;;;;,イチ;キュウ;サン;ヨ;ネン,イチキュウサンヨンネン,1934年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2999,6 +3127,7 @@
 
 # newdoc id = dev-s131
 # sent_id = dev-s131
+# parallel_id = jagsdluw/dev131
 # text = 願いがあって来ている!
 1	願い	願い	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネガイ,願い,願い,願い,ネガイ,,,ネガイ,ネガイ,願い
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3010,6 +3139,7 @@
 
 # newdoc id = dev-s132
 # sent_id = dev-s132
+# parallel_id = jagsdluw/dev132
 # text = 結婚11年目の夫浮気報道が持ち上がったとき、ヴィクトリアは彼を信じていたそうだが、寝も歯もないことを噂する世間に対し行き場のない怒りが湧き上がってきたのも事実だったそう。
 1	結婚	結婚	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ケッコン,結婚,結婚,結婚,ケッコン,,,ケッコン,ケッコン,結婚
 2	11年目	11年目	NUM	名詞-数詞	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;イチ;ネン;メ,一;一;年;目,1;1;年;目,1;1;年;目,イチ;イチ;ネン;メ,;;;,;;;,イチ;イチ;ネン;メ,イチイチネンメ,11年目
@@ -3059,6 +3189,7 @@
 
 # newdoc id = dev-s133
 # sent_id = dev-s133
+# parallel_id = jagsdluw/dev133
 # text = まずは,1996年の教団本部移転が隆法氏による“霊言”に振り回されたという“ドタバタ劇”のお話。
 1	まず	先ず	ADV	副詞	_	22	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マズ,先ず,まず,まず,マズ,,,マズ,マズ,先ず
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3086,6 +3217,7 @@
 
 # newdoc id = dev-s134
 # sent_id = dev-s134
+# parallel_id = jagsdluw/dev134
 # text = 一方ポリュネイケスの子テルサンドロスは戦争に勝利した後、トロイア戦争に参加したが、ギリシア軍は間違ってミューシアに上陸し、テーレポス王と戦争になった。
 1	一方	一方	CCONJ	接続詞	_	31	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	ポリュネイケス	ポリュネイケス	PROPN	名詞-固有名詞-人名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ポリュネイケース,ポリュネイケース,ポリュネイケス,ポリュネイケス,ポリュネーケス,,,ポリュネイケス,ポリュネイケス,ポリュネイケス
@@ -3123,6 +3255,7 @@
 
 # newdoc id = dev-s135
 # sent_id = dev-s135
+# parallel_id = jagsdluw/dev135
 # text = 現在は主に飼育下繁殖個体が流通する。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	6	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3134,6 +3267,7 @@
 
 # newdoc id = dev-s136
 # sent_id = dev-s136
+# parallel_id = jagsdluw/dev136
 # text = 靴屋の父は、マックスが5歳の時に家族を捨て、マックスはパンや新聞の配達で家計を助けた。
 1	靴屋	靴屋	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クツヤ,靴屋,靴屋,靴屋,クツヤ,,,クツヤ,クツヤ,靴屋
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3166,6 +3300,7 @@
 
 # newdoc id = dev-s137
 # sent_id = dev-s137
+# parallel_id = jagsdluw/dev137
 # text = 全員起立して迎える。
 1	全員	全員	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼンイン,全員,全員,全員,ゼンイン,,,ゼンイン,ゼンイン,全員
 2	起立し	起立する	VERB	動詞-一般-サ行変格	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キリツ;スル,起立;為る,起立;し,起立;する,キリツ;シ,;,;,キリツ;スル,キリツスル,起立する
@@ -3175,6 +3310,7 @@
 
 # newdoc id = dev-s138
 # sent_id = dev-s138
+# parallel_id = jagsdluw/dev138
 # text = 大学で学生に教えていた経験からか人当たりも柔らかく実直な人物である。
 1	大学	大学	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイガク,大学,大学,大学,ダイガク,,,ダイガク,ダイガク,大学
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3197,6 +3333,7 @@
 
 # newdoc id = dev-s139
 # sent_id = dev-s139
+# parallel_id = jagsdluw/dev139
 # text = 今日はランチにお刺身が食べたかったので、前々から気になっていたこちらにお邪魔しました。
 1	今日	今日	NOUN	名詞-普通名詞-一般	_	7	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウ,今日,今日,今日,キョー,,,キョウ,キョウ,今日
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3225,6 +3362,7 @@
 
 # newdoc id = dev-s140
 # sent_id = dev-s140
+# parallel_id = jagsdluw/dev140
 # text = 微塵の良さもない!
 1	微塵	微塵	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミジン,微塵,微塵,微塵,ミジン,,,ミジン,ミジン,微塵
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3235,6 +3373,7 @@
 
 # newdoc id = dev-s141
 # sent_id = dev-s141
+# parallel_id = jagsdluw/dev141
 # text = 説明も丁寧で分かりやすく、対応もとっても良かったです。
 1	説明	説明	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セツメイ,説明,説明,説明,セツメー,,,セツメイ,セツメイ,説明
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -3252,6 +3391,7 @@
 
 # newdoc id = dev-s142
 # sent_id = dev-s142
+# parallel_id = jagsdluw/dev142
 # text = そこに当事者意識が生まれ,社会が実際に動いていく。
 1	そこ	其処	PRON	代名詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソコ,其処,そこ,そこ,ソコ,,,ソコ,ソコ,其処
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3269,6 +3409,7 @@
 
 # newdoc id = dev-s143
 # sent_id = dev-s143
+# parallel_id = jagsdluw/dev143
 # text = 場所は多少わかりづらいんですけど、感じのいいところでした
 1	場所	場所	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バショ,場所,場所,場所,バショ,,,バショ,バショ,場所
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3286,6 +3427,7 @@
 
 # newdoc id = dev-s144
 # sent_id = dev-s144
+# parallel_id = jagsdluw/dev144
 # text = 駅から遠く、お酒を楽しむには不便なリッチなのが最大のネックですが、ドライバーを一人連れてでも行きたいお店です☆
 1	駅	駅	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エキ,駅,駅,駅,エキ,,,エキ,エキ,駅
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -3323,6 +3465,7 @@
 
 # newdoc id = dev-s145
 # sent_id = dev-s145
+# parallel_id = jagsdluw/dev145
 # text = そのため、三菱の携帯電話には、アニメっちゃのメール用画像素材やアプリがいくつか添付されている。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ため	為	NOUN	名詞-普通名詞-一般	_	18	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タメ,為,ため,ため,タメ,,,タメ,タメ,為
@@ -3348,6 +3491,7 @@
 
 # newdoc id = dev-s146
 # sent_id = dev-s146
+# parallel_id = jagsdluw/dev146
 # text = 興行収入は32億円。
 1	興行収入	興行収入	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウギョウ;シュウニュウ,興行;収入,興行;収入,興行;収入,コーギョー;シューニュー,;,;,コウギョウ;シュウニュウ,コウギョウシュウニュウ,興行収入
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3356,6 +3500,7 @@
 
 # newdoc id = dev-s147
 # sent_id = dev-s147
+# parallel_id = jagsdluw/dev147
 # text = 多くの欠陥を抱えていたため生産数は100門と少なく、短い期間運用されたM7 プリーストやセクストンに置き換えられる形で一線から退いた。
 1	多く	多く	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオク,多く,多く,多く,オーク,,,オオク,オオク,多く
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3392,6 +3537,7 @@
 
 # newdoc id = dev-s148
 # sent_id = dev-s148
+# parallel_id = jagsdluw/dev148
 # text = 本気で譲ってほしいという人はいるのかしらん?
 1	本気	本気	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンキ,本気,本気,本気,ホンキ,,,ホンキ,ホンキ,本気
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -3407,6 +3553,7 @@
 
 # newdoc id = dev-s149
 # sent_id = dev-s149
+# parallel_id = jagsdluw/dev149
 # text = この会が“家系のおはなし”なる講演会を毎月公共施設で開いているとの情報が潜入取材を敢行した。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	会	会	NOUN	名詞-普通名詞-一般	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイ,会,会,会,カイ,,,カイ,カイ,会
@@ -3436,6 +3583,7 @@
 
 # newdoc id = dev-s150
 # sent_id = dev-s150
+# parallel_id = jagsdluw/dev150
 # text = 横浜市近辺で英会話を習いたいという人にはかなりいいのではないでしょうか?
 1	横浜市近辺	横浜市近辺	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨコハマ;シ;キンペン,ヨコハマ;市;近辺,横浜;市;近辺,横浜;市;近辺,ヨコハマ;シ;キンペン,;;,;;,ヨコハマ;シ;キンペン,ヨコハマシキンペン,横浜市近辺
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3456,6 +3604,7 @@
 
 # newdoc id = dev-s151
 # sent_id = dev-s151
+# parallel_id = jagsdluw/dev151
 # text = 青雉に助けられた。
 1	青雉	青雉	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アオキジ,青雉,青雉,青雉,アオキジ,,,アオキジ,アオキジ,青雉
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3466,6 +3615,7 @@
 
 # newdoc id = dev-s152
 # sent_id = dev-s152
+# parallel_id = jagsdluw/dev152
 # text = 一方,淑徳大学に飯田氏を紹介したコンサルタントは,自団体のウェブサイトなどから飯田氏関連の記述を削除。
 1	一方	一方	CCONJ	接続詞	_	21	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -3492,6 +3642,7 @@
 
 # newdoc id = dev-s153
 # sent_id = dev-s153
+# parallel_id = jagsdluw/dev153
 # text = JTによると、廃作の募集は2004年に続いて2度目。
 1	JT	JT	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェーティー,ＪＴ,JT,JT,ジェーティー,,,ジェーティー,ジェーティー,JT
 2	によると	によると	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;ト,に;因る;と,に;よる;と,に;よる;と,ニ;ヨル;ト,;;,;;,ニ;ヨル;ト,ニヨルト,によると
@@ -3509,6 +3660,7 @@
 
 # newdoc id = dev-s154
 # sent_id = dev-s154
+# parallel_id = jagsdluw/dev154
 # text = 従来の同社製より素材の伸長率が35%向上し、着脱しやすくなったという。
 1	従来	従来	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウライ,従来,従来,従来,ジューライ,,,ジュウライ,ジュウライ,従来
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3530,6 +3682,7 @@
 
 # newdoc id = dev-s155
 # sent_id = dev-s155
+# parallel_id = jagsdluw/dev155
 # text = 球状星団としてはまばらな方で、口径20cm程度の望遠鏡で周辺部は完全に分離でき、口径30cmでは中心部まで分離できる。
 1	球状星団	球状星団	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウジョウ;セイダン,球状;星団,球状;星団,球状;星団,キュージョー;セーダン,;,;,キュウジョウ;セイダン,キュウジョウセイダン,球状星団
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -3561,6 +3714,7 @@
 
 # newdoc id = dev-s156
 # sent_id = dev-s156
+# parallel_id = jagsdluw/dev156
 # text = 窓側の席で若い女性が信者から入会を強く勧められている様子が確認できた。
 1	窓側	窓側	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マドガワ,窓側,窓側,窓側,マドガワ,,,マドガワ,マドガワ,窓側
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3585,6 +3739,7 @@
 
 # newdoc id = dev-s157
 # sent_id = dev-s157
+# parallel_id = jagsdluw/dev157
 # text = 山田が新作小説を発表しなくなってから、忍法帖シリーズに比べて正当に評価されていたとは言い難い作品群の再評価が始まった。
 1	山田	山田	PROPN	名詞-固有名詞-人名-姓	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤマダ,ヤマダ,山田,山田,ヤマダ,,,ヤマダ,ヤマダ,山田
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3619,6 +3774,7 @@
 
 # newdoc id = dev-s158
 # sent_id = dev-s158
+# parallel_id = jagsdluw/dev158
 # text = その呼びかけに共感した淡井真紀、田中リタ、高原零、板倉あやのが秘密のアジトに集結した。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	呼びかけ	呼び掛け	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨビカケ,呼び掛け,呼びかけ,呼びかけ,ヨビカケ,,,ヨビカケ,ヨビカケ,呼び掛け
@@ -3643,6 +3799,7 @@
 
 # newdoc id = dev-s159
 # sent_id = dev-s159
+# parallel_id = jagsdluw/dev159
 # text = 下記に主な代表作を記述する。
 1	下記	下記	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カキ,下記,下記,下記,カキ,,,カキ,カキ,下記
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3654,6 +3811,7 @@
 
 # newdoc id = dev-s160
 # sent_id = dev-s160
+# parallel_id = jagsdluw/dev160
 # text = 憑いている“虫”は巨大ムカデ。
 1	憑い	付く	VERB	動詞-一般-五段-カ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツク,付く,憑い,憑く,ツイ,,,ツク,ツク,付く
 2	ている	ている	AUX	助動詞-上一段-ア行	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ;イル,て;居る,て;いる,て;いる,テ;イル,;,;,テ;イル,テイル,ている
@@ -3666,6 +3824,7 @@
 
 # newdoc id = dev-s161
 # sent_id = dev-s161
+# parallel_id = jagsdluw/dev161
 # text = 現役時のポジションはゴールキーパー。
 1	現役時	現役時	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンエキ;ジ,現役;時,現役;時,現役;時,ゲンエキ;ジ,;,;,ゲンエキ;ジ,ゲンエキジ,現役時
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3676,6 +3835,7 @@
 
 # newdoc id = dev-s162
 # sent_id = dev-s162
+# parallel_id = jagsdluw/dev162
 # text = この時代から、日本列島に人類が住んだ遺跡や遺物が多く発見されている。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	時代	時代	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジダイ,時代,時代,時代,ジダイ,,,ジダイ,ジダイ,時代
@@ -3699,6 +3859,7 @@
 
 # newdoc id = dev-s163
 # sent_id = dev-s163
+# parallel_id = jagsdluw/dev163
 # text = 高橋由美子さんは創刊した1990年から登場。
 1	高橋由美子さん	高橋由美子さん	PROPN	名詞-固有名詞-人名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タカハシ;ユミコ;サン,タカハシ;ユミコ;さん,高橋;由美子;さん,高橋;由美子;さん,タカハシ;ユミコ;サン,;;,;;,タカハシ;ユミコ;サン,タカハシユミコサン,高橋由美子さん
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3711,6 +3872,7 @@
 
 # newdoc id = dev-s164
 # sent_id = dev-s164
+# parallel_id = jagsdluw/dev164
 # text = クイズを行う場所や形式の関係上、早押しテーブルを設置することが困難な場合は、早押しボタンのボックスを挑戦者の手に持たせてクイズを行った。
 1	クイズ	クイズ	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クイズ,クイズ,クイズ,クイズ,クイズ,,,クイズ,クイズ,クイズ
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -3750,6 +3912,7 @@
 
 # newdoc id = dev-s165
 # sent_id = dev-s165
+# parallel_id = jagsdluw/dev165
 # text = 一方、8市町以外で放射線量が高い場所が見つかった場合も、面積が広い場合には「国との協議で検討」し、局所的なら「補助金などの対象外」との認識が示された。
 1	一方	一方	CCONJ	接続詞	_	41	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3798,6 +3961,7 @@
 
 # newdoc id = dev-s167
 # sent_id = dev-s167
+# parallel_id = jagsdluw/dev167
 # text = 先日はありがとうございました。部下はヘビーナイトとバッティ、ブルームハッター、トライデントナイト。
 1	先日	先日	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センジツ,先日,先日,先日,センジツ,,,センジツ,センジツ,先日
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3819,6 +3983,7 @@
 
 # newdoc id = dev-s168
 # sent_id = dev-s168
+# parallel_id = jagsdluw/dev168
 # text = レジにて受け取る「プリペイド番号通知票」のQRコードより携帯サイトにログイン。
 1	レジ	レジ	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レジ,レジ,レジ,レジ,レジ,,,レジ,レジ,レジ
 2	にて	にて	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニテ,にて,にて,にて,ニテ,,,ニテ,ニテ,にて
@@ -3836,6 +4001,7 @@
 
 # newdoc id = dev-s169
 # sent_id = dev-s169
+# parallel_id = jagsdluw/dev169
 # text = 通信教育で挫折したので資格までとれるのか心配でしたが、無事合格し、仕事も決まりました!
 1	通信教育	通信教育	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツウシン;キョウイク,通信;教育,通信;教育,通信;教育,ツーシン;キョーイク,;,;,ツウシン;キョウイク,ツウシンキョウイク,通信教育
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3864,6 +4030,7 @@
 
 # newdoc id = dev-s170
 # sent_id = dev-s170
+# parallel_id = jagsdluw/dev170
 # text = 試読もできます!
 1	試読	試読	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シドク,試読,試読,試読,シドク,,,シドク,シドク,試読
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -3873,6 +4040,7 @@
 
 # newdoc id = dev-s171
 # sent_id = dev-s171
+# parallel_id = jagsdluw/dev171
 # text = 南アフリカで開かれるサッカーのワールドカップに合わせて、旅行会社では日本代表の試合を観戦するツアーを販売していますが、現地の治安が悪いことなどを理由に参加を見送るサポーターも多く、開幕まであと6日に迫った今もツアーが売れ残る状況が続いています。
 1	南アフリカ	南アフリカ	PROPN	名詞-固有名詞-地名-国	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミナミアフリカ,南アフリカ,南アフリカ,南アフリカ,ミナミアフリカ,,,ミナミアフリカ,ミナミアフリカ,南アフリカ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3938,6 +4106,7 @@
 
 # newdoc id = dev-s172
 # sent_id = dev-s172
+# parallel_id = jagsdluw/dev172
 # text = 一方、BOφWY、JUDY AND MARYなど人気バンドが解散していくなかで、こうしたバンドのファンが新たにコピーバンドを結成するケースも目立つように各地で活動を継続している。
 1	一方	一方	CCONJ	接続詞	_	35	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3979,6 +4148,7 @@
 
 # newdoc id = dev-s173
 # sent_id = dev-s173
+# parallel_id = jagsdluw/dev173
 # text = 診察をしながらささっと診察データを書き込んでいるようなので、患者と患者の待ち時間は少ないように思います。
 1	診察	診察	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンサツ,診察,診察,診察,シンサツ,,,シンサツ,シンサツ,診察
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4009,6 +4179,7 @@
 
 # newdoc id = dev-s174
 # sent_id = dev-s174
+# parallel_id = jagsdluw/dev174
 # text = 10年W杯南アフリカ大会後の昨夏も獲得に動いたAマドリードが、ここに来て再び獲得に乗り出していることが判明。
 1	10年	10年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ジュウ;ネン,十;年,10;年,10;年,ジュー;ネン,;,;,ジュウ;ネン,ジュウネン,10年
 2	W杯南アフリカ大会後	W杯南アフリカ大会後	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダブリュー;ハイ;ミナミアフリカ;タイカイ;ゴ,Ｗ;杯;南アフリカ;大会;後,W;杯;南アフリカ;大会;後,W;杯;南アフリカ;大会;後,ダブリュー;ハイ;ミナミアフリカ;タイカイ;ゴ,;;;;,;;;;,ダブリュー;ハイ;ミナミアフリカ;タイカイ;ゴ,ダブリューハイミナミアフリカタイカイゴ,W杯南アフリカ大会後
@@ -4038,6 +4209,7 @@
 
 # newdoc id = dev-s175
 # sent_id = dev-s175
+# parallel_id = jagsdluw/dev175
 # text = この選考について労働基準法違反に抵触する疑いがあるとして、厚生労働省が調査を開始した。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	選考	選考	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センコウ,選考,選考,選考,センコー,,,センコウ,センコウ,選考
@@ -4062,6 +4234,7 @@
 
 # newdoc id = dev-s176
 # sent_id = dev-s176
+# parallel_id = jagsdluw/dev176
 # text = 広大で対象となる亡者も多いため政令指定地獄となっているが、亡者は地表に落ちるまで2000年落下し続けるため実際に服役する数はそれほどでもなく、仕事自体はまだヒマな方である。
 1	広大	広大	ADJ	形状詞-一般	_	8	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウダイ,広大,広大,広大,コーダイ,,,コウダイ,コウダイ,広大
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -4109,6 +4282,7 @@
 
 # newdoc id = dev-s177
 # sent_id = dev-s177
+# parallel_id = jagsdluw/dev177
 # text = 内容は、下表の通り。
 1	内容	内容	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナイヨウ,内容,内容,内容,ナイヨー,,,ナイヨウ,ナイヨウ,内容
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4120,6 +4294,7 @@
 
 # newdoc id = dev-s178
 # sent_id = dev-s178
+# parallel_id = jagsdluw/dev178
 # text = 冷戦中だったため、西側の状況は国家にとっても国民にとっても指標であったが、東ドイツは西ドイツの経済成長の速度に、端から追いついておらず、このことは国民を怒らせた。
 1	冷戦中	冷戦中	NOUN	名詞-普通名詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レイセン;チュウ,冷戦;中,冷戦;中,冷戦;中,レーセン;チュー,;,;,レイセン;チュウ,レイセンチュウ,冷戦中
 2	だっ	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だっ,だ,ダッ,,,ダ,ダ,だ
@@ -4168,6 +4343,7 @@
 
 # newdoc id = dev-s179
 # sent_id = dev-s179
+# parallel_id = jagsdluw/dev179
 # text = ジェボムの俳優および歌手活動など、芸能活動全般を支援する見通しだ。
 1	ジェボム	ジェボム	PROPN	名詞-固有名詞-人名-一般	_	8	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェボム,ジェボム,ジェボム,ジェボム,ジェボム,,,ジェボム,ジェボム,ジェボム
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4185,6 +4361,7 @@
 
 # newdoc id = dev-s180
 # sent_id = dev-s180
+# parallel_id = jagsdluw/dev180
 # text = 美声ではないのに演歌の心というか魂の叫びというか、とにかくこちらにズシーンと響いてくるような歌唱力の持ち主だった。
 1	美声	美声	NOUN	名詞-普通名詞-一般	_	29	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビセイ,美声,美声,美声,ビセー,,,ビセイ,ビセイ,美声
 2	ではない	ではない	AUX	助動詞-形容詞	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ;ハ;ナイ,だ;は;無い,で;は;ない,だ;は;ない,デ;ワ;ナイ,;;,;;,ダ;ハ;ナイ,デハナイ,ではない
@@ -4221,6 +4398,7 @@
 
 # newdoc id = dev-s181
 # sent_id = dev-s181
+# parallel_id = jagsdluw/dev181
 # text = ネバダとは「雪に覆われた」という意味であり、地域の雪を冠した山々を指すものだった。
 1	ネバダ	ネバダ	PROPN	名詞-固有名詞-地名-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネバダ,ネバダ,ネバダ,ネバダ,ネバダ,,,ネバダ,ネバダ,ネバダ
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -4252,6 +4430,7 @@
 
 # newdoc id = dev-s182
 # sent_id = dev-s182
+# parallel_id = jagsdluw/dev182
 # text = ホテル・コルテシア東京で挙式予定の客。
 1	ホテル・コルテシア東京	ホテル・コルテシア東京	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホテル;;コルテシア;トウキョウ,ホテル;・;コルテシア;トウキョウ,ホテル;・;コルテシア;東京,ホテル;・;コルテシア;東京,ホテル;;コルテシア;トーキョー,;;;,;;;,ホテル;;コルテシア;トウキョウ,ホテルコルテシアトウキョウ,ホテル・コルテシア東京
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -4262,6 +4441,7 @@
 
 # newdoc id = dev-s183
 # sent_id = dev-s183
+# parallel_id = jagsdluw/dev183
 # text = サクラも動員されていたようだ。
 1	サクラ	桜	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクラ,桜,サクラ,サクラ,サクラ,,,サクラ,サクラ,桜
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4275,6 +4455,7 @@
 
 # newdoc id = dev-s184
 # sent_id = dev-s184
+# parallel_id = jagsdluw/dev184
 # text = せまい待合室の受付で、症状を口頭で言わされました。
 1	せまい	狭い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セマイ,狭い,せまい,せまい,セマイ,,,セマイ,セマイ,狭い
 2	待合室	待ち合い室	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マチアイ;シツ,待ち合い;室,待合;室,待合;室,マチアイ;シツ,;,;,マチアイ;シツ,マチアイシツ,待ち合い室
@@ -4294,6 +4475,7 @@
 
 # newdoc id = dev-s185
 # sent_id = dev-s185
+# parallel_id = jagsdluw/dev185
 # text = KGBの文書には、死因は「動脈硬化に伴う循環器疾患」と記録されている。
 1	KGB	KGB	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケージービー,ＫＧＢ,KGB,KGB,ケージービー,,,ケージービー,ケージービー,KGB
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4317,6 +4499,7 @@
 
 # newdoc id = dev-s186
 # sent_id = dev-s186
+# parallel_id = jagsdluw/dev186
 # text = FBIがポールセンを追い始めた時、彼は逃亡者として地下に潜っていた。
 1	FBI	FBI	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エフビーアイ,ＦＢＩ,FBI,FBI,エフビーアイ,,,エフビーアイ,エフビーアイ,FBI
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4339,6 +4522,7 @@
 
 # newdoc id = dev-s187
 # sent_id = dev-s187
+# parallel_id = jagsdluw/dev187
 # text = 再装填は人力である。
 1	再装填	再装填	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイ;ソウテン,再;装填,再;装填,再;装填,サイ;ソーテン,;,;,サイ;ソウテン,サイソウテン,再装填
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4348,6 +4532,7 @@
 
 # newdoc id = dev-s188
 # sent_id = dev-s188
+# parallel_id = jagsdluw/dev188
 # text = スタッフの方やお店の雰囲気良かったです。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフ,スタッフ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4363,6 +4548,7 @@
 
 # newdoc id = dev-s189
 # sent_id = dev-s189
+# parallel_id = jagsdluw/dev189
 # text = 現代でもイランやパキスタンではこのナスタアリーク体が使われているようです。
 1	現代	現代	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンダイ,現代,現代,現代,ゲンダイ,,,ゲンダイ,ゲンダイ,現代
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -4384,6 +4570,7 @@
 
 # newdoc id = dev-s190
 # sent_id = dev-s190
+# parallel_id = jagsdluw/dev190
 # text = 市政委員会が火薬は植民地の財産であり、イギリス国王のものではないと主張して、火薬の返還を要求した。
 1	市政委員会	市政委員会	NOUN	名詞-普通名詞-一般	_	22	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シセイ;イイン;カイ,市政;委員;会,市政;委員;会,市政;委員;会,シセー;イイン;カイ,;;,;;,シセイ;イイン;カイ,シセイイインカイ,市政委員会
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4412,6 +4599,7 @@
 
 # newdoc id = dev-s191
 # sent_id = dev-s191
+# parallel_id = jagsdluw/dev191
 # text = 薬の事全然わかりませんでしたが、丁寧に案内してもらい、買いたい物が買えました。
 1	薬	薬	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クスリ,薬,薬,薬,クスリ,,,クスリ,クスリ,薬
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4440,6 +4628,7 @@
 
 # newdoc id = dev-s192
 # sent_id = dev-s192
+# parallel_id = jagsdluw/dev192
 # text = だから,日本が軍備をしちゃいかんというんだったら,もう自衛隊なんてやめてまえ。
 1	だから	だから	CCONJ	接続詞	_	19	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;カラ,だ;から,だ;から,だ;から,ダ;カラ,;,;,ダ;カラ,ダカラ,だから
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -4465,6 +4654,7 @@
 
 # newdoc id = dev-s193
 # sent_id = dev-s193
+# parallel_id = jagsdluw/dev193
 # text = なお、町田修は「店長くん」として同社のキャラクターとなっている。
 1	なお	猶	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4484,6 +4674,7 @@
 
 # newdoc id = dev-s194
 # sent_id = dev-s194
+# parallel_id = jagsdluw/dev194
 # text = NBAのコーチの中には試合中に大きな声や身振り手振りで選手に指示をする者も多いが、スコットは腕組みをしたまま寡黙に試合の行方を見守る。
 1	NBA	NBA	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エヌビーエー,ＮＢＡ,NBA,NBA,エヌビーエー,,,エヌビーエー,エヌビーエー,NBA
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4527,6 +4718,7 @@
 
 # newdoc id = dev-s195
 # sent_id = dev-s195
+# parallel_id = jagsdluw/dev195
 # text = 設立は1965年。
 1	設立	設立	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セツリツ,設立,設立,設立,セツリツ,,,セツリツ,セツリツ,設立
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4535,6 +4727,7 @@
 
 # newdoc id = dev-s196
 # sent_id = dev-s196
+# parallel_id = jagsdluw/dev196
 # text = 彼女の存在は、ゲーテのほかシラー、ヘルダーなど同時代のヴァイマルの文人たちに大きな影響を与えた。
 1	彼女	彼女	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カノジョ,彼女,彼女,彼女,カノジョ,,,カノジョ,カノジョ,彼女
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4563,6 +4756,7 @@
 
 # newdoc id = dev-s197
 # sent_id = dev-s197
+# parallel_id = jagsdluw/dev197
 # text = 2500円のコースで、私はお肉・相方がお魚を選びました。
 1	2500円	2500円	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゴ;ゼロ;ゼロ;エン,二;五;ゼロ;ゼロ;円,2;5;0;0;円,2;5;0;0;円,ニ;ゴ;ゼロ;ゼロ;エン,;;;;,;;;;,ニ;ゴ;ゼロ;ゼロ;エン,ニゴゼロゼロエン,2500円
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4584,6 +4778,7 @@
 
 # newdoc id = dev-s198
 # sent_id = dev-s198
+# parallel_id = jagsdluw/dev198
 # text = そのため人間界での舞台は里帰りのみとなる。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ため	為	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タメ,為,ため,ため,タメ,,,タメ,タメ,為
@@ -4600,12 +4795,14 @@
 
 # newdoc id = dev-s199
 # sent_id = dev-s199
+# parallel_id = jagsdluw/dev199
 # text = ヴァイオリニスト。
 1	ヴァイオリニスト	バイオリニスト	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=バイオリニスト,バイオリニスト,ヴァイオリニスト,ヴァイオリニスト,バイオリニスト,,,バイオリニスト,バイオリニスト,バイオリニスト
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s200
 # sent_id = dev-s200
+# parallel_id = jagsdluw/dev200
 # text = 他の軍団員と違ってシュララ軍団から足を洗いたいと思っており、登場目的はケロロ小隊に捕らえられた兄を救うことであった。
 1	他	他	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,他,他,ホカ,,,ホカ,ホカ,他
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4640,6 +4837,7 @@
 
 # newdoc id = dev-s201
 # sent_id = dev-s201
+# parallel_id = jagsdluw/dev201
 # text = *1902年-ドイツ選手権がスタート。
 1	*	*	PUNCT	補助記号-一般	_	6	punct	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=,＊,*,*,,,,,,＊
 2	1902年	1902年	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;ゼロ;ニ;ネン,一;九;ゼロ;二;年,1;9;0;2;年,1;9;0;2;年,イチ;キュー;ゼロ;ニ;ネン,;;;;,;;;;,イチ;キュウ;ゼロ;ニ;ネン,イチキュウゼロニネン,1902年
@@ -4651,6 +4849,7 @@
 
 # newdoc id = dev-s202
 # sent_id = dev-s202
+# parallel_id = jagsdluw/dev202
 # text = 週に3回は行ってます。
 1	週	週	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウ,週,週,週,シュー,,,シュウ,シュウ,週
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4663,6 +4862,7 @@
 
 # newdoc id = dev-s203
 # sent_id = dev-s203
+# parallel_id = jagsdluw/dev203
 # text = ノンビリキング十三世の部屋。
 1	ノンビリキング	のんびりキング	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ノンビリ;キング,のんびり;キング,ノンビリ;キング,ノンビリ;キング,ノンビリ;キング,;,;,ノンビリ;キング,ノンビリキング,のんびりキング
 2	十三世	十三世	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウ;サン;セイ,十;三;世,十;三;世,十;三;世,ジュー;サン;セー,;;,;;,ジュウ;サン;セイ,ジュウサンセイ,十三世
@@ -4672,6 +4872,7 @@
 
 # newdoc id = dev-s204
 # sent_id = dev-s204
+# parallel_id = jagsdluw/dev204
 # text = 現在、その名称はアトレティコの下部組織の名前として残っている。
 1	現在	現在	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4690,6 +4891,7 @@
 
 # newdoc id = dev-s205
 # sent_id = dev-s205
+# parallel_id = jagsdluw/dev205
 # text = 特に六代目尾上梅幸を相方とした演目は名高い。
 1	特に	特に	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トクニ,特に,特に,特に,トクニ,,,トクニ,トクニ,特に
 2	六代目尾上梅幸	六代目尾上梅幸	PROPN	名詞-固有名詞-人名-一般	_	6	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ロク;ダイ;メ;オノエ;バイコウ,六;代;目;オノエ;バイコウ,六;代;目;尾上;梅幸,六;代;目;尾上;梅幸,ロク;ダイ;メ;オノエ;バイコー,;;;;,;;;;,ロク;ダイ;メ;オノエ;バイコウ,ロクダイメオノエバイコウ,六代目尾上梅幸
@@ -4705,6 +4907,7 @@
 
 # newdoc id = dev-s206
 # sent_id = dev-s206
+# parallel_id = jagsdluw/dev206
 # text = 東日本大震災をきっかけに東京電力福島第1原発の危機的な状況が続いている。
 1	東日本大震災	東日本大震災	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒガシ;ニッポン;ダイ;シンサイ,東;日本;大;震災,東;日本;大;震災,東;日本;大;震災,ヒガシ;ニホン;ダイ;シンサイ,;;;,;;;,ヒガシ;ニホン;ダイ;シンサイ,ヒガシニホンダイシンサイ,東日本大震災
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4722,6 +4925,7 @@
 
 # newdoc id = dev-s207
 # sent_id = dev-s207
+# parallel_id = jagsdluw/dev207
 # text = 何故か教員用の大型の三角定規を持っている事が多い。
 1	何故	何故	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナゼ,何故,何故,何故,ナゼ,,,ナゼ,ナゼ,何故
 2	か	か	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カ,か,か,か,カ,,,カ,カ,か
@@ -4740,6 +4944,7 @@
 
 # newdoc id = dev-s208
 # sent_id = dev-s208
+# parallel_id = jagsdluw/dev208
 # text = 最初の2ヶ月間,自社のサービスを理解するためって事でユーザーサポートを担当しました。
 1	最初	最初	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイショ,最初,最初,最初,サイショ,,,サイショ,サイショ,最初
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4763,6 +4968,7 @@
 
 # newdoc id = dev-s209
 # sent_id = dev-s209
+# parallel_id = jagsdluw/dev209
 # text = 2011年1月でレギュラー放送が終了し、今後は特番前の特別番組として放送される。
 1	2011年	2011年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;イチ;ネン,二;ゼロ;一;一;年,2;0;1;1;年,2;0;1;1;年,ニ;ゼロ;イチ;イチ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;イチ;ネン,ニゼロイチイチネン,2011年
 2	1月	1月	NUM	名詞-数詞	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ガツ,一;月,1;月,1;月,イチ;ガツ,;,;,イチ;ガツ,イチガツ,1月
@@ -4783,6 +4989,7 @@
 
 # newdoc id = dev-s210
 # sent_id = dev-s210
+# parallel_id = jagsdluw/dev210
 # text = その後、他の音楽番組を担当し、TBSを退職。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -4800,6 +5007,7 @@
 
 # newdoc id = dev-s211
 # sent_id = dev-s211
+# parallel_id = jagsdluw/dev211
 # text = これが無い場合、作業者は死に至る致命傷を負う場合もある。
 1	これ	此れ	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4821,6 +5029,7 @@
 
 # newdoc id = dev-s212
 # sent_id = dev-s212
+# parallel_id = jagsdluw/dev212
 # text = SMEが、生産性の向上と革新を進め、経済の牽引役となることを目的としている。
 1	SME	SME	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エスエムイー,ＳＭＥ,SME,SME,エスエムイー,,,エスエムイー,エスエムイー,SME
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4848,6 +5057,7 @@
 
 # newdoc id = dev-s213
 # sent_id = dev-s213
+# parallel_id = jagsdluw/dev213
 # text = 当時3回連続でオーダーミス。
 1	当時	当時	NOUN	名詞-普通名詞-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウジ,当時,当時,当時,トージ,,,トウジ,トウジ,当時
 2	3回連続	3回連続	NOUN	名詞-普通名詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;カイ;レンゾク,三;回;連続,3;回;連続,3;回;連続,サン;カイ;レンゾク,;;,;;,サン;カイ;レンゾク,サンカイレンゾク,3回連続
@@ -4857,6 +5067,7 @@
 
 # newdoc id = dev-s214
 # sent_id = dev-s214
+# parallel_id = jagsdluw/dev214
 # text = また、香辛料を輸入するため、さかんにマカッサル王国とも交易をおこなった。
 1	また	又	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4878,6 +5089,7 @@
 
 # newdoc id = dev-s215
 # sent_id = dev-s215
+# parallel_id = jagsdluw/dev215
 # text = 彼等の遺体は数日間晒されて、最終的にノグ山に埋葬された。
 1	彼等	彼等	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カレ;ラ,彼;等,彼;等,彼;等,カレ;ラ,;,;,カレ;ラ,カレラ,彼等
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4899,6 +5111,7 @@
 
 # newdoc id = dev-s216
 # sent_id = dev-s216
+# parallel_id = jagsdluw/dev216
 # text = 伊勢丹時代にカリスマバイヤーとして名を馳せ、その後、様々な再建、ブランド創成、売り場プロデュースなどを手がけてきた藤巻幸夫氏。
 1	伊勢丹時代	伊勢丹時代	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イセタン;ジダイ,伊勢丹;時代,伊勢丹;時代,伊勢丹;時代,イセタン;ジダイ,;,;,イセタン;ジダイ,イセタンジダイ,伊勢丹時代
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4928,6 +5141,7 @@
 
 # newdoc id = dev-s217
 # sent_id = dev-s217
+# parallel_id = jagsdluw/dev217
 # text = ちなみにここには載せきれませんでしたが,ラッパを吹いている天使はコンクリート製。
 1	ちなみに	因みに	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チナミ;ニ,因み;に,ちなみ;に,ちなみ;に,チナミ;ニ,;,;,チナミ;ニ,チナミニ,因みに
 2	ここ	此処	PRON	代名詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
@@ -4951,6 +5165,7 @@
 
 # newdoc id = dev-s218
 # sent_id = dev-s218
+# parallel_id = jagsdluw/dev218
 # text = 佐脇有紀裁判長は,吉田被告について“本件に果たした役割は主導的で積極的”とし,元警察官として“犯行の情状も悪い”としながらも,被告が素直に犯行を認め二度と犯罪を起こさないと反省していることや弁護士会に100万円を寄付したことなどを総合考慮し執行猶予付きの判決となったと述べた。
 1	佐脇有紀裁判長	佐脇有紀裁判長	PROPN	名詞-固有名詞-人名-一般	_	69	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サワキ;ユキ;サイバン;チョウ,サワキ;ユキ;裁判;長,佐脇;有紀;裁判;長,佐脇;有紀;裁判;長,サワキ;ユキ;サイバン;チョー,;;;,;;;,サワキ;ユキ;サイバン;チョウ,サワキユキサイバンチョウ,佐脇有紀裁判長
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5026,6 +5241,7 @@
 
 # newdoc id = dev-s219
 # sent_id = dev-s219
+# parallel_id = jagsdluw/dev219
 # text = 髪は薄茶色で毛先が渦巻きカールになった髪型をしている。
 1	髪	髪	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カミ,髪,髪,髪,カミ,,,カミ,カミ,髪
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5046,6 +5262,7 @@
 
 # newdoc id = dev-s220
 # sent_id = dev-s220
+# parallel_id = jagsdluw/dev220
 # text = 2月17日にグアムアプラ港に寄港し、グアム到着後は燃料と物資を補給して2月17日に出港。
 1	2月	2月	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ガツ,二;月,2;月,2;月,ニ;ガツ,;,;,ニ;ガツ,ニガツ,2月
 2	17日	17日	NUM	名詞-数詞	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;シチ;ニチ,一;七;日,1;7;日,1;7;日,イチ;シチ;ニチ,;;,;;,イチ;シチ;ニチ,イチシチニチ,17日
@@ -5071,6 +5288,7 @@
 
 # newdoc id = dev-s221
 # sent_id = dev-s221
+# parallel_id = jagsdluw/dev221
 # text = 表題曲『港の五番町』の作詞は阿久悠、作曲は彩木雅夫である。
 1	表題曲	表題曲	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒョウダイ;キョク,表題;曲,表題;曲,表題;曲,ヒョーダイ;キョク,;,;,ヒョウダイ;キョク,ヒョウダイキョク,表題曲
 2	『	『	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
@@ -5091,6 +5309,7 @@
 
 # newdoc id = dev-s222
 # sent_id = dev-s222
+# parallel_id = jagsdluw/dev222
 # text = 安くてうまいです。
 1	安く	安い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤスイ,安い,安く,安い,ヤスク,,,ヤスイ,ヤスイ,安い
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -5100,6 +5319,7 @@
 
 # newdoc id = dev-s223
 # sent_id = dev-s223
+# parallel_id = jagsdluw/dev223
 # text = マイクスタンドは彼の背後から伸び、頭上を通って眼前に降ろす可動式のものを使用、必要に応じて都度、ドラム・テクがマイクスタンドを操作している。
 1	マイクスタンド	マイクスタンド	NOUN	名詞-普通名詞-一般	_	20	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マイク;スタンド,マイク;スタンド,マイク;スタンド,マイク;スタンド,マイク;スタンド,;,;,マイク;スタンド,マイクスタンド,マイクスタンド
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5138,6 +5358,7 @@
 
 # newdoc id = dev-s224
 # sent_id = dev-s224
+# parallel_id = jagsdluw/dev224
 # text = 宗教法人格の取り消し云々は,結局のところ,その宗教の持つ教義そのものについて,善悪の判断を加えることになるだろう。
 1	宗教法人格	宗教法人格	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウキョウ;ホウジン;カク,宗教;法人;格,宗教;法人;格,宗教;法人;格,シューキョー;ホージン;カク,;;,;;,シュウキョウ;ホウジン;カク,シュウキョウホウジンカク,宗教法人格
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5168,6 +5389,7 @@
 
 # newdoc id = dev-s225
 # sent_id = dev-s225
+# parallel_id = jagsdluw/dev225
 # text = 同氏はドジャースで2度ワールドシリーズを制覇。
 1	同氏	同氏	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウシ,同氏,同氏,同氏,ドーシ,,,ドウシ,ドウシ,同氏
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5181,6 +5403,7 @@
 
 # newdoc id = dev-s226
 # sent_id = dev-s226
+# parallel_id = jagsdluw/dev226
 # text = 男性による、番組名・曲名等の簡単な英語ナビゲートがあったが、WEB上で情報が一切公開されておらず、氏名等は一切不明である。
 1	男性	男性	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダンセイ,男性,男性,男性,ダンセー,,,ダンセイ,ダンセイ,男性
 2	による	による	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル,に;因る,に;よる,に;よる,ニ;ヨル,;,;,ニ;ヨル,ニヨル,による
@@ -5214,6 +5437,7 @@
 
 # newdoc id = dev-s227
 # sent_id = dev-s227
+# parallel_id = jagsdluw/dev227
 # text = そして回答の最後に,週刊誌の編集部に対して,こんな一文。
 1	そして	そして	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	回答	回答	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイトウ,回答,回答,回答,カイトー,,,カイトウ,カイトウ,回答
@@ -5232,6 +5456,7 @@
 
 # newdoc id = dev-s228
 # sent_id = dev-s228
+# parallel_id = jagsdluw/dev228
 # text = 日本では江戸時代から昭和にかけて、主に農家以外で飼い猫の首輪の喉の部分に鈴を一つつけることが行われてきた。
 1	日本	日本	PROPN	名詞-固有名詞-地名-国	_	28	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニッポン,,,ニッポン,ニッポン,日本
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -5268,6 +5493,7 @@
 
 # newdoc id = dev-s229
 # sent_id = dev-s229
+# parallel_id = jagsdluw/dev229
 # text = 既に高麗の太祖の時期から、貴族は王権に対する強力な挑戦者だった。
 1	既に	既に	ADV	副詞	_	15	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スデニ,既に,既に,既に,スデニ,,,スデニ,スデニ,既に
 2	高麗	高麗	PROPN	名詞-固有名詞-地名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウライ,コウライ,高麗,高麗,コーライ,,,コウライ,コウライ,高麗
@@ -5290,6 +5516,7 @@
 
 # newdoc id = dev-s230
 # sent_id = dev-s230
+# parallel_id = jagsdluw/dev230
 # text = 1800年代は旧制高等学校の医学部薬学科として設置されたが、1900年代には旧制高等学校から医学専門学校が分離された、また私立の薬学専門学校も設置された。
 1	1800年代	1800年代	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;ゼロ;ゼロ;ネン;ダイ,一;八;ゼロ;ゼロ;年;代,1;8;0;0;年;代,1;8;0;0;年;代,イチ;ハチ;ゼロ;ゼロ;ネン;ダイ,;;;;;,;;;;;,イチ;ハチ;ゼロ;ゼロ;ネン;ダイ,イチハチゼロゼロネンダイ,1800年代
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5326,6 +5553,7 @@
 
 # newdoc id = dev-s231
 # sent_id = dev-s231
+# parallel_id = jagsdluw/dev231
 # text = 店員の教育が残念な店。
 1	店員	店員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンイン,店員,店員,店員,テンイン,,,テンイン,テンイン,店員
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5338,6 +5566,7 @@
 
 # newdoc id = dev-s232
 # sent_id = dev-s232
+# parallel_id = jagsdluw/dev232
 # text = 昭和が最も輝いていた昭和30年代中盤以降の日用雑貨、菓子のパッケージ、ビール瓶や飲料水の缶、そしてポスターにパネルなど。
 1	昭和	昭和	PROPN	名詞-固有名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウワ,昭和,昭和,昭和,ショーワ,,,ショウワ,ショウワ,昭和
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5368,6 +5597,7 @@
 
 # newdoc id = dev-s233
 # sent_id = dev-s233
+# parallel_id = jagsdluw/dev233
 # text = 後藤の事が大好きになってしまった様々な作戦を使い嫌われようという企画。
 1	後藤	後藤	PROPN	名詞-固有名詞-人名-姓	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴトウ,ゴトウ,後藤,後藤,ゴトー,,,ゴトウ,ゴトウ,後藤
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5391,6 +5621,7 @@
 
 # newdoc id = dev-s234
 # sent_id = dev-s234
+# parallel_id = jagsdluw/dev234
 # text = 大きさが全く違う海老とか調理側は何故平気なんだろ。
 1	大きさ	大きさ	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキイ;サ,大きい;さ,大き;さ,大きい;さ,オーキ;サ,;,;,オオキイ;サ,オオキサ,大きさ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5409,6 +5640,7 @@
 
 # newdoc id = dev-s235
 # sent_id = dev-s235
+# parallel_id = jagsdluw/dev235
 # text = でも、リニューアルしたゲストハウス風のロビー?
 1	でも	でも	CCONJ	接続詞	_	7	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;モ,で;も,で;も,で;も,デ;モ,;,;,デ;モ,デモ,でも
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5421,6 +5653,7 @@
 
 # newdoc id = dev-s236
 # sent_id = dev-s236
+# parallel_id = jagsdluw/dev236
 # text = 2008年に入り、楽天がイーバンク銀行と資本提携を行うこととなり、イーバンク銀行が新規に発行する第三者割当の優先株を楽天が引き受けることになり、同年9月30日付で社長を含む一部経営陣も楽天の役員から起用された。
 1	2008年	2008年	NUM	名詞-数詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ハチ;ネン,二;ゼロ;ゼロ;八;年,2;0;0;8;年,2;0;0;8;年,ニ;ゼロ;ゼロ;ハチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ハチ;ネン,ニゼロゼロハチネン,2008年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -5469,6 +5702,7 @@
 
 # newdoc id = dev-s237
 # sent_id = dev-s237
+# parallel_id = jagsdluw/dev237
 # text = 導入にあたっては10回線以上299回線以下が条件であり2回線から、および300回線以上も導入できるソフトバンクモバイルオフィスと比べると条件を問われる。
 1	導入	導入	NOUN	名詞-普通名詞-一般	_	22	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウニュウ,導入,導入,導入,ドーニュー,,,ドウニュウ,ドウニュウ,導入
 2	にあたって	にあたって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;アタル;テ,に;当たる;て,に;あたっ;て,に;あたる;て,ニ;アタッ;テ,;;,;;,ニ;アタル;テ,ニアタッテ,にあたって
@@ -5497,6 +5731,7 @@
 
 # newdoc id = dev-s238
 # sent_id = dev-s238
+# parallel_id = jagsdluw/dev238
 # text = 2007年からは、加藤ピンの仕事が多い。
 1	2007年	2007年	NUM	名詞-数詞	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;シチ;ネン,二;ゼロ;ゼロ;七;年,2;0;0;7;年,2;0;0;7;年,ニ;ゼロ;ゼロ;シチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;シチ;ネン,ニゼロゼロシチネン,2007年
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -5512,6 +5747,7 @@
 
 # newdoc id = dev-s239
 # sent_id = dev-s239
+# parallel_id = jagsdluw/dev239
 # text = 突如、臆病な人格となって弱体化してしまう負の時間と呼ばれる一定の時間があるのが、この種族の最大の弱点。
 1	突如	突如	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トツジョ,突如,突如,突如,トツジョ,,,トツジョ,トツジョ,突如
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5547,6 +5783,7 @@
 
 # newdoc id = dev-s240
 # sent_id = dev-s240
+# parallel_id = jagsdluw/dev240
 # text = 昨年の12月30日、日中は病棟当番だった鈴木は、夕方当直勤務に入った。
 1	昨年	昨年	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクネン,昨年,昨年,昨年,サクネン,,,サクネン,サクネン,昨年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5570,6 +5807,7 @@
 
 # newdoc id = dev-s241
 # sent_id = dev-s241
+# parallel_id = jagsdluw/dev241
 # text = “創価学会”のラベルの記事には,しばしば“創価学会に人気の霊園”という広告が表示されています。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	創価学会	創価学会	PROPN	名詞-固有名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソウカ;ガッカイ,創価;学会,創価;学会,創価;学会,ソーカ;ガッカイ,;,;,ソウカ;ガッカイ,ソウカガッカイ,創価学会
@@ -5600,6 +5838,7 @@
 
 # newdoc id = dev-s242
 # sent_id = dev-s242
+# parallel_id = jagsdluw/dev242
 # text = それでも小原は1963年4月に持っていた金は事件と無関係と言い張ったが、平塚らは「これだけ材料を突きつけられてまだ逃れられると思っているのか」と小原を追い詰め、それからほどなくして小原は金が吉展ちゃん事件と関係のあるものだと供述した。
 1	それでも	其れでも	CCONJ	接続詞	_	16	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ;デ;モ,其れ;で;も,それ;で;も,それ;で;も,ソレ;デ;モ,;;,;;,ソレ;デ;モ,ソレデモ,其れでも
 2	小原	小原	PROPN	名詞-固有名詞-人名-姓	_	16	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オバラ,オバラ,小原,小原,オバラ,,,オバラ,オバラ,小原
@@ -5667,6 +5906,7 @@
 
 # newdoc id = dev-s243
 # sent_id = dev-s243
+# parallel_id = jagsdluw/dev243
 # text = 同基金では、ひとり親家庭の就業支援も新規に実施。
 1	同基金	同基金	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;キキン,同;基金,同;基金,同;基金,ドー;キキン,;,;,ドウ;キキン,ドウキキン,同基金
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -5683,6 +5923,7 @@
 
 # newdoc id = dev-s244
 # sent_id = dev-s244
+# parallel_id = jagsdluw/dev244
 # text = でも、まずはハーフドリアではなく1人前のドリアをお試し下さい。
 1	でも	でも	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;モ,で;も,で;も,で;も,デ;モ,;,;,デ;モ,デモ,でも
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5699,6 +5940,7 @@
 
 # newdoc id = dev-s245
 # sent_id = dev-s245
+# parallel_id = jagsdluw/dev245
 # text = 出場国は6カ国。
 1	出場国	出場国	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュツジョウ;コク,出場;国,出場;国,出場;国,シュツジョー;コク,;,;,シュツジョウ;コク,シュツジョウコク,出場国
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5707,6 +5949,7 @@
 
 # newdoc id = dev-s246
 # sent_id = dev-s246
+# parallel_id = jagsdluw/dev246
 # text = 文字を取り扱う範囲は10FFFFまでである。
 1	文字	文字	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モジ,文字,文字,文字,モジ,,,モジ,モジ,文字
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -5720,6 +5963,7 @@
 
 # newdoc id = dev-s247
 # sent_id = dev-s247
+# parallel_id = jagsdluw/dev247
 # text = 2010年11月28日のDDT・後楽園ホール大会で首を負傷し「後縦靱帯骨化症」と診断される。
 1	2010年	2010年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;ゼロ;ネン,二;ゼロ;一;ゼロ;年,2;0;1;0;年,2;0;1;0;年,ニ;ゼロ;イチ;ゼロ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;ゼロ;ネン,ニゼロイチゼロネン,2010年
 2	11月	11月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;イチ;ガツ,一;一;月,1;1;月,1;1;月,イチ;イチ;ガツ,;;,;;,イチ;イチ;ガツ,イチイチガツ,11月
@@ -5740,6 +5984,7 @@
 
 # newdoc id = dev-s248
 # sent_id = dev-s248
+# parallel_id = jagsdluw/dev248
 # text = 郡内には自然湖が無いが、多くの河川がある。
 1	郡内	郡内	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=グンナイ,郡内,郡内,郡内,グンナイ,,,グンナイ,グンナイ,郡内
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -5758,6 +6003,7 @@
 
 # newdoc id = dev-s249
 # sent_id = dev-s249
+# parallel_id = jagsdluw/dev249
 # text = クラブの経営を支える大きな柱の一つである入場料収入も、2005年をピークに年々減少しております。
 1	クラブ	クラブ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クラブ,クラブ,クラブ,クラブ,クラブ,,,クラブ,クラブ,クラブ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5784,6 +6030,7 @@
 
 # newdoc id = dev-s250
 # sent_id = dev-s250
+# parallel_id = jagsdluw/dev250
 # text = 福音書はヘンリー8世の命令による修道院の解散時にダラム大聖堂から持ち出され、17世紀初頭に英国議会の書記官、トーマス・ウォーカーからロバート・コットンの手に渡り、18世紀には大英博物館に納められ、更にそこからロンドンの大英図書館に移された。
 1	福音書	福音書	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フクイン;ショ,福音;書,福音;書,福音;書,フクイン;ショ,;,;,フクイン;ショ,フクインショ,福音書
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5837,6 +6084,7 @@
 
 # newdoc id = dev-s251
 # sent_id = dev-s251
+# parallel_id = jagsdluw/dev251
 # text = 2011年の日本トンデモ本大賞は,ニコニコ生放送の投票だけでなく,会場の新宿ロフトプラスワンでの投票も影響するので,これだけで大川隆法氏の受賞が決まったわけではありません。
 1	2011年	2011年	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;イチ;ネン,二;ゼロ;一;一;年,2;0;1;1;年,2;0;1;1;年,ニ;ゼロ;イチ;イチ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;イチ;ネン,ニゼロイチイチネン,2011年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5873,6 +6121,7 @@
 
 # newdoc id = dev-s252
 # sent_id = dev-s252
+# parallel_id = jagsdluw/dev252
 # text = 横浜横須賀道路と新湘南バイパスは、終日5割引。
 1	横浜横須賀道路	横浜横須賀道路	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨコハマ;ヨコスカ;ドウロ,ヨコハマ;ヨコスカ;道路,横浜;横須賀;道路,横浜;横須賀;道路,ヨコハマ;ヨコスカ;ドーロ,;;,;;,ヨコハマ;ヨコスカ;ドウロ,ヨコハマヨコスカドウロ,横浜横須賀道路
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -5885,6 +6134,7 @@
 
 # newdoc id = dev-s253
 # sent_id = dev-s253
+# parallel_id = jagsdluw/dev253
 # text = 月のお社から脱走したシモーヌという名の女精霊使いを探している。
 1	月	肉月	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツキ,月,月,月,ツキ,,,ツキ,ニクヅキ,肉月
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5904,6 +6154,7 @@
 
 # newdoc id = dev-s254
 # sent_id = dev-s254
+# parallel_id = jagsdluw/dev254
 # text = すべて私のせいでとんでもないご迷惑ばかりおかけし,この期に及んでも足をひっぱるばかりで,もう本当にお詫びの言葉もありません。
 1	すべて	全て	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スベテ,全て,すべて,すべて,スベテ,,,スベテ,スベテ,全て
 2	私	私	PRON	代名詞	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
@@ -5942,6 +6193,7 @@
 
 # newdoc id = dev-s255
 # sent_id = dev-s255
+# parallel_id = jagsdluw/dev255
 # text = 現在は女優となり、最近はドラマで母親役が多い。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5960,6 +6212,7 @@
 
 # newdoc id = dev-s256
 # sent_id = dev-s256
+# parallel_id = jagsdluw/dev256
 # text = 東京らしいシンプルな銭湯。
 1	東京らしい	東京らしい	ADJ	形容詞-一般-形容詞	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウキョウ;ラシイ,トウキョウ;らしい,東京;らしい,東京;らしい,トーキョー;ラシー,;,;,トウキョウ;ラシイ,トウキョウラシイ,東京らしい
 2	シンプル	シンプル	ADJ	形状詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンプル,シンプル,シンプル,シンプル,シンプル,,,シンプル,シンプル,シンプル
@@ -5969,6 +6222,7 @@
 
 # newdoc id = dev-s257
 # sent_id = dev-s257
+# parallel_id = jagsdluw/dev257
 # text = ベンが処刑され、ウィラが地元のアイスクリーム屋で働いて生計を立てるようになった或る日、クリーサップの街にハリーが突然あらわれた。
 1	ベン	ベン	PROPN	名詞-固有名詞-人名-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベン,ベン,ベン,ベン,ベン,,,ベン,ベン,ベン
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6006,6 +6260,7 @@
 
 # newdoc id = dev-s258
 # sent_id = dev-s258
+# parallel_id = jagsdluw/dev258
 # text = 徳島市の東部に位置し、吉野川下流デルタ地帯の一角をなす。
 1	徳島市	徳島市	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トクシマ;シ,トクシマ;市,徳島;市,徳島;市,トクシマ;シ,;,;,トクシマ;シ,トクシマシ,徳島市
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6022,6 +6277,7 @@
 
 # newdoc id = dev-s259
 # sent_id = dev-s259
+# parallel_id = jagsdluw/dev259
 # text = 地元の農家の方が作った野菜のコーナーが好きです。
 1	地元	地元	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジモト,地元,地元,地元,ジモト,,,ジモト,ジモト,地元
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6041,6 +6297,7 @@
 
 # newdoc id = dev-s260
 # sent_id = dev-s260
+# parallel_id = jagsdluw/dev260
 # text = ※GI昇格後の年度に限定。
 1	※	※	SYM	補助記号-一般	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=,※,※,※,,,,,,※
 2	GI昇格後	GI昇格後	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジーアイ;ショウカク;ゴ,ＧＩ;昇格;後,GI;昇格;後,GI;昇格;後,ジーアイ;ショーカク;ゴ,;;,;;,ジーアイ;ショウカク;ゴ,ジーアイショウカクゴ,GI昇格後
@@ -6052,6 +6309,7 @@
 
 # newdoc id = dev-s261
 # sent_id = dev-s261
+# parallel_id = jagsdluw/dev261
 # text = 第3次以降の平成23年度補正予算案にNEMIC整備のための調査費計上を目指している。
 1	第3次以降	第3次以降	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;サン;ジ;イコウ,第;三;次;以降,第;3;次;以降,第;3;次;以降,ダイ;サン;ジ;イコー,;;;,;;;,ダイ;サン;ジ;イコウ,ダイサンジイコウ,第3次以降
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6069,6 +6327,7 @@
 
 # newdoc id = dev-s262
 # sent_id = dev-s262
+# parallel_id = jagsdluw/dev262
 # text = 「ありがとうございます」とお礼を言い、笑顔で味わっていた。
 1	「	「	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	ありがとう	有り難い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アリガタイ,有り難い,ありがとう,ありがたい,アリガトー,,,アリガタイ,アリガタイ,有り難い
@@ -6089,6 +6348,7 @@
 
 # newdoc id = dev-s263
 # sent_id = dev-s263
+# parallel_id = jagsdluw/dev263
 # text = 主な項目に関する最終案の内容は以下のとおり。
 1	主な	主な	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オモナ,主な,主な,主な,オモナ,,,オモナ,オモナ,主な
 2	項目	項目	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウモク,項目,項目,項目,コーモク,,,コウモク,コウモク,項目
@@ -6104,6 +6364,7 @@
 
 # newdoc id = dev-s264
 # sent_id = dev-s264
+# parallel_id = jagsdluw/dev264
 # text = 先を歩いていたミニスカートの女性がNKプリントの前で自動車にはね飛ばされる。
 1	先	先	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サキ,先,先,先,サキ,,,サキ,サキ,先
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6126,6 +6387,7 @@
 
 # newdoc id = dev-s265
 # sent_id = dev-s265
+# parallel_id = jagsdluw/dev265
 # text = 『ミューミューニャーニャー』はNHKの幼児向け番組『おかあさんといっしょ』の人形劇のコーナー。
 1	『	『	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
 2	ミューミューニャーニャー	みゅーみゅーにゃあにゃあ	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミューミュー;ニャアニャア,みゅーみゅー;にゃあにゃあ,ミューミュー;ニャーニャー,ミューミュー;ニャーニャー,ミューミュー;ニャーニャー,;,;,ミューミュー;ニャアニャア,ミューミューニャアニャア,みゅーみゅーにゃあにゃあ
@@ -6147,6 +6409,7 @@
 
 # newdoc id = dev-s266
 # sent_id = dev-s266
+# parallel_id = jagsdluw/dev266
 # text = 同年はリザーブチームで6回プレーした。
 1	同年	同年	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウネン,同年,同年,同年,ドーネン,,,ドウネン,ドウネン,同年
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6159,6 +6422,7 @@
 
 # newdoc id = dev-s267
 # sent_id = dev-s267
+# parallel_id = jagsdluw/dev267
 # text = 女性教会員が立候補した松戸市議選でも,足立教会の信者が大量動員されていた。
 1	女性教会員	女性教会員	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョセイ;キョウカイ;イン,女性;教会;員,女性;教会;員,女性;教会;員,ジョセー;キョーカイ;イン,;;,;;,ジョセイ;キョウカイ;イン,ジョセイキョウカイイン,女性教会員
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6180,6 +6444,7 @@
 
 # newdoc id = dev-s268
 # sent_id = dev-s268
+# parallel_id = jagsdluw/dev268
 # text = 2000年のシドニーオリンピックではいずれも予選敗退だった。
 1	2000年	2000年	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ゼロ;ネン,二;ゼロ;ゼロ;ゼロ;年,2;0;0;0;年,2;0;0;0;年,ニ;ゼロ;ゼロ;ゼロ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ゼロ;ネン,ニゼロゼロゼロネン,2000年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6195,6 +6460,7 @@
 
 # newdoc id = dev-s269
 # sent_id = dev-s269
+# parallel_id = jagsdluw/dev269
 # text = 東京の中でも新宿といういい立地でありながら、お料理の味やドレスの素敵さを考えるととても良心的な結婚式場という感じがしました。
 1	東京	東京	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウキョウ,トウキョウ,東京,東京,トーキョー,,,トウキョウ,トウキョウ,東京
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6232,6 +6498,7 @@
 
 # newdoc id = dev-s270
 # sent_id = dev-s270
+# parallel_id = jagsdluw/dev270
 # text = 陳敦仁:統振株式有限会社理事長。
 1	陳敦仁	陳敦仁	PROPN	名詞-固有名詞-人名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チン;トンジン,チン;トンジン,陳;敦仁,陳;敦仁,チン;トンジン,;,;,チン;トンジン,チントンジン,陳敦仁
 2	:	:	SYM	補助記号-一般	_	1	dep	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,：,:,:,,,,,,：
@@ -6241,6 +6508,7 @@
 
 # newdoc id = dev-s271
 # sent_id = dev-s271
+# parallel_id = jagsdluw/dev271
 # text = 水曜日と金曜日に図書室で貸し出しの作業をしている。
 1	水曜日	水曜日	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スイヨウ;ヒ,水曜;日,水曜;日,水曜;日,スイヨー;ビ,;,;,スイヨウ;ヒ,スイヨウビ,水曜日
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -6258,6 +6526,7 @@
 
 # newdoc id = dev-s272
 # sent_id = dev-s272
+# parallel_id = jagsdluw/dev272
 # text = 本作の隠しキャラクターの1人。
 1	本作	本作	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンサク,本作,本作,本作,ホンサク,,,ホンサク,ホンサク,本作
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6268,6 +6537,7 @@
 
 # newdoc id = dev-s273
 # sent_id = dev-s273
+# parallel_id = jagsdluw/dev273
 # text = セキュリティの点でも、安心して住めるよう、オートロックシステムをはじめ、防犯カメラ、ディンプルキー・鎌デッド錠、エレベータには防犯モニタが設置されています。
 1	セキュリティ	セキュリティ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セキュリティー,セキュリティー,セキュリティ,セキュリティ,セキュリティ,,,セキュリティ,セキュリティ,セキュリティ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6300,6 +6570,7 @@
 
 # newdoc id = dev-s274
 # sent_id = dev-s274
+# parallel_id = jagsdluw/dev274
 # text = 超新星の所属事務所,株式会社maroo企画です。
 1	超新星	超新星	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウ;シンセイ,超;新星,超;新星,超;新星,チョー;シンセー,;,;,チョウ;シンセイ,チョウシンセイ,超新星
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6311,6 +6582,7 @@
 
 # newdoc id = dev-s275
 # sent_id = dev-s275
+# parallel_id = jagsdluw/dev275
 # text = 2012年現在、外車だけでもランボルギーニ・ミウラP400SV、フェラーリ・F512M、ベンツ、BMWの4台を保有し、中でもランボルギーニ・ミウラは1971年生産の車体で41年が経過した時点でも走行可能と、極めて良好なコンディションである。
 1	2012年現在	2012年現在	ADV	副詞	_	17	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;ニ;ネン;ゲンザイ,二;ゼロ;一;二;年;現在,2;0;1;2;年;現在,2;0;1;2;年;現在,ニ;ゼロ;イチ;ニ;ネン;ゲンザイ,;;;;;,;;;;;,ニ;ゼロ;イチ;ニ;ネン;ゲンザイ,ニゼロイチニネンゲンザイ,2012年現在
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6358,6 +6630,7 @@
 
 # newdoc id = dev-s276
 # sent_id = dev-s276
+# parallel_id = jagsdluw/dev276
 # text = 今後とも超新星を応援いただきますよう,よろしくお願いいたします。
 1	今後とも	今後共	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンゴ;トモ,今後;共,今後;とも,今後;とも,コンゴ;トモ,;,;,コンゴ;トモ,コンゴトモ,今後共
 2	超新星	超新星	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウ;シンセイ,超;新星,超;新星,超;新星,チョー;シンセー,;,;,チョウ;シンセイ,チョウシンセイ,超新星
@@ -6373,6 +6646,7 @@
 
 # newdoc id = dev-s277
 # sent_id = dev-s277
+# parallel_id = jagsdluw/dev277
 # text = 山頂までの距離は、4.8kmである。
 1	山頂	山頂	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サンチョウ,山頂,山頂,山頂,サンチョー,,,サンチョウ,サンチョウ,山頂
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -6386,6 +6660,7 @@
 
 # newdoc id = dev-s278
 # sent_id = dev-s278
+# parallel_id = jagsdluw/dev278
 # text = さっさと潰れろ!
 1	さっさと	さっさと	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サッサト,さっさと,さっさと,さっさと,サッサト,,,サッサト,サッサト,さっさと
 2	潰れろ	潰れる	VERB	動詞-一般-下一段-ラ行	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ツブレル,潰れる,潰れろ,潰れる,ツブレロ,,,ツブレル,ツブレル,潰れる
@@ -6393,6 +6668,7 @@
 
 # newdoc id = dev-s279
 # sent_id = dev-s279
+# parallel_id = jagsdluw/dev279
 # text = 台湾守備混成第2旅団長を経て、日露戦争に歩兵第1旅団長として出征し、南山の戦いに参戦。
 1	台湾守備混成第2旅団長	台湾守備混成第2旅団長	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイワン;シュビ;コンセイ;ダイ;ニ;リョダン;チョウ,タイワン;守備;混成;第;二;旅団;長,台湾;守備;混成;第;2;旅団;長,台湾;守備;混成;第;2;旅団;長,タイワン;シュビ;コンセー;ダイ;ニ;リョダン;チョー,;;;;;;,;;;;;;,タイワン;シュビ;コンセイ;ダイ;ニ;リョダン;チョウ,タイワンシュビコンセイダイニリョダンチョウ,台湾守備混成第2旅団長
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6414,6 +6690,7 @@
 
 # newdoc id = dev-s280
 # sent_id = dev-s280
+# parallel_id = jagsdluw/dev280
 # text = 主な内容は本格的な古典演奏から和楽器を使ったロックやポップスの紹介と、DJによる大学生活や舞台でのエピソードトーク。
 1	主な	主な	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オモナ,主な,主な,主な,オモナ,,,オモナ,オモナ,主な
 2	内容	内容	NOUN	名詞-普通名詞-一般	_	26	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナイヨウ,内容,内容,内容,ナイヨー,,,ナイヨウ,ナイヨウ,内容
@@ -6445,6 +6722,7 @@
 
 # newdoc id = dev-s281
 # sent_id = dev-s281
+# parallel_id = jagsdluw/dev281
 # text = 連合は緒戦の勢いを失い、双方の首都をめぐりバージニア州で行われていた東部戦線は膠着状態に陥る一方、南軍の西部戦線にほころびが生じた。
 1	連合	連合	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レンゴウ,連合,連合,連合,レンゴー,,,レンゴウ,レンゴウ,連合
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6484,6 +6762,7 @@
 
 # newdoc id = dev-s282
 # sent_id = dev-s282
+# parallel_id = jagsdluw/dev282
 # text = とりわけバグダードでは神学教授のガザーリーなどが活躍した。
 1	とりわけ	取り分け	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トリワケ,取り分け,とりわけ,とりわけ,トリワケ,,,トリワケ,トリワケ,取り分け
 2	バグダード	バグダード	PROPN	名詞-固有名詞-地名-一般	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バグダッド,バグダッド,バグダード,バグダード,バグダード,,,バグダード,バグダード,バグダード
@@ -6500,6 +6779,7 @@
 
 # newdoc id = dev-s283
 # sent_id = dev-s283
+# parallel_id = jagsdluw/dev283
 # text = これにあたる語としてはملكがあり、字義としては「今まさに持っている」という意味合いになる。
 1	これ	此れ	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6528,6 +6808,7 @@
 
 # newdoc id = dev-s284
 # sent_id = dev-s284
+# parallel_id = jagsdluw/dev284
 # text = 先日,坂本弁護士失踪事件直後のテレビ放送のVTRや波野村での反対集会の映像を観る機会があった。
 1	先日	先日	ADV	副詞	_	19	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センジツ,先日,先日,先日,センジツ,,,センジツ,センジツ,先日
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -6553,6 +6834,7 @@
 
 # newdoc id = dev-s285
 # sent_id = dev-s285
+# parallel_id = jagsdluw/dev285
 # text = 一部を抜粋します。
 1	一部	一部	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチブ,一部,一部,一部,イチブ,,,イチブ,イチブ,一部
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6562,6 +6844,7 @@
 
 # newdoc id = dev-s286
 # sent_id = dev-s286
+# parallel_id = jagsdluw/dev286
 # text = 調子に乗りやすく、危険な獣相手にピンチに陥ることも。
 1	調子	調子	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウシ,調子,調子,調子,チョーシ,,,チョウシ,チョウシ,調子
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6580,6 +6863,7 @@
 
 # newdoc id = dev-s287
 # sent_id = dev-s287
+# parallel_id = jagsdluw/dev287
 # text = 白馬に入る入り口のスキー場でもあってとても奇麗でやることいっぱい!
 1	白馬	白馬	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハクバ,ハクバ,白馬,白馬,ハクバ,,,ハクバ,ハクバ,白馬
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6599,6 +6883,7 @@
 
 # newdoc id = dev-s288
 # sent_id = dev-s288
+# parallel_id = jagsdluw/dev288
 # text = 普段は成績が悪く遅刻を繰り返す問題児で、第1話では喧嘩で相手を骨折させて自宅謹慎まで受けていたが、その反面、正義感が強く仲間からの信頼も厚い。
 1	普段	普段	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フダン,普段,普段,普段,フダン,,,フダン,フダン,普段
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6644,6 +6929,7 @@
 
 # newdoc id = dev-s289
 # sent_id = dev-s289
+# parallel_id = jagsdluw/dev289
 # text = また、同ライブへ向け、両バンドのカップリング楽曲と映像を収録したCD&DVDパッケージ『Phoenix Rising』が10月12日にリリースされる。
 1	また	又	CCONJ	接続詞	_	23	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6673,6 +6959,7 @@
 
 # newdoc id = dev-s290
 # sent_id = dev-s290
+# parallel_id = jagsdluw/dev290
 # text = 出演者も特有の風と降りしきる雨に悩ませられた。
 1	出演者	出演者	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュツエン;シャ,出演;者,出演;者,出演;者,シュツエン;シャ,;,;,シュツエン;シャ,シュツエンシャ,出演者
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -6691,6 +6978,7 @@
 
 # newdoc id = dev-s291
 # sent_id = dev-s291
+# parallel_id = jagsdluw/dev291
 # text = コダールの完成型であるコダールiも『揺れるイントゥ・ザ・ブルー』でビルの倒壊に対してラムダ・ドライバを発動させオーバーヒートを起こしているが、検査の結果何の異常も見られなかったため、こちらはガウルンによるブラフと見られる。
 1	コダール	コダール	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コダール,コダール,コダール,コダール,コダール,,,コダール,コダール,コダール
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6742,6 +7030,7 @@
 
 # newdoc id = dev-s292
 # sent_id = dev-s292
+# parallel_id = jagsdluw/dev292
 # text = 意識を取り戻した友作は階段から落ちた後、危篤状態だった時間と同じ57分間だけ他人の心の声が聞こえる能力を手に入れていた。
 1	意識	意識	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イシキ,意識,意識,意識,イシキ,,,イシキ,イシキ,意識
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6781,6 +7070,7 @@
 
 # newdoc id = dev-s293
 # sent_id = dev-s293
+# parallel_id = jagsdluw/dev293
 # text = 全国霊感商法対策弁護士連絡会の渡辺博弁護士は2009年7月,統一日報の取材に“統一教会は民団や総連といった在日韓国人組織の活動にも入り込み,信者獲得を進めている”と語っている。
 1	全国霊感商法対策弁護士連絡会	全国霊感商法対策弁護士連絡会	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼンコク;レイカン;ショウホウ;タイサク;ベンゴ;シ;レンラク;カイ,全国;霊感;商法;対策;弁護;士;連絡;会,全国;霊感;商法;対策;弁護;士;連絡;会,全国;霊感;商法;対策;弁護;士;連絡;会,ゼンコク;レーカン;ショーホー;タイサク;ベンゴ;シ;レンラク;カイ,;;;;;;;,;;;;;;;,ゼンコク;レイカン;ショウホウ;タイサク;ベンゴ;シ;レンラク;カイ,ゼンコクレイカンショウホウタイサクベンゴシレンラクカイ,全国霊感商法対策弁護士連絡会
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6819,6 +7109,7 @@
 
 # newdoc id = dev-s294
 # sent_id = dev-s294
+# parallel_id = jagsdluw/dev294
 # text = 編成番号は2両・3両単位で付番され、識別記号「HE」を冠し「HE-104」のように表す。
 1	編成番号	編成番号	NOUN	名詞-普通名詞-一般	_	20	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヘンセイ;バンゴウ,編成;番号,編成;番号,編成;番号,ヘンセー;バンゴー,;,;,ヘンセイ;バンゴウ,ヘンセイバンゴウ,編成番号
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6844,6 +7135,7 @@
 
 # newdoc id = dev-s295
 # sent_id = dev-s295
+# parallel_id = jagsdluw/dev295
 # text = 信者にとってはありがたい存在なのであろうが,正直カリスマ性は感じられなかった。
 1	信者	信者	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンジャ,信者,信者,信者,シンジャ,,,シンジャ,シンジャ,信者
 2	にとって	にとって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;トル;テ,に;取る;て,に;とっ;て,に;とる;て,ニ;トッ;テ,;;,;;,ニ;トル;テ,ニトッテ,にとって
@@ -6865,6 +7157,7 @@
 
 # newdoc id = dev-s296
 # sent_id = dev-s296
+# parallel_id = jagsdluw/dev296
 # text = 単に「属人主義」という積極的属人主義を指す場合が多い。
 1	単に	単に	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タンニ,単に,単に,単に,タンニ,,,タンニ,タンニ,単に
 2	「	「	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
@@ -6881,6 +7174,7 @@
 
 # newdoc id = dev-s297
 # sent_id = dev-s297
+# parallel_id = jagsdluw/dev297
 # text = この特別代表は、現在知られているサイトは日本や韓国の北朝鮮支持者が運営していると明らかにしたという。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	特別代表	特別代表	NOUN	名詞-普通名詞-一般	_	22	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トクベツ;ダイヒョウ,特別;代表,特別;代表,特別;代表,トクベツ;ダイヒョー,;,;,トクベツ;ダイヒョウ,トクベツダイヒョウ,特別代表
@@ -6911,6 +7205,7 @@
 
 # newdoc id = dev-s298
 # sent_id = dev-s298
+# parallel_id = jagsdluw/dev298
 # text = 幸福の科学の広報担当者によると,今回の広告掲載は“フライデー事件”以来,19年ぶりとのことです。
 1	幸福の科学	幸福の科学	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ノ;カガク,幸福;の;科学,幸福;の;科学,幸福;の;科学,コーフク;ノ;カガク,;;,;;,コウフク;ノ;カガク,コウフクノカガク,幸福の科学
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6935,6 +7230,7 @@
 
 # newdoc id = dev-s299
 # sent_id = dev-s299
+# parallel_id = jagsdluw/dev299
 # text = 統一教会広報に問い合わせた。
 1	統一教会広報	統一教会広報	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウイツ;キョウカイ;コウホウ,統一;教会;広報,統一;教会;広報,統一;教会;広報,トーイツ;キョーカイ;コーホー,;;,;;,トウイツ;キョウカイ;コウホウ,トウイツキョウカイコウホウ,統一教会広報
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6944,6 +7240,7 @@
 
 # newdoc id = dev-s300
 # sent_id = dev-s300
+# parallel_id = jagsdluw/dev300
 # text = PRACTICEモードはステージ3で終了だが、クリア時にベルを50個以上保持していればステージ4以降に進める。
 1	PRACTICEモード	PRACTICEモード	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=プラクティス;モード,プラクティス;モード,PRACTICE;モード,PRACTICE;モード,プラクティス;モード,;,;,プラクティス;モード,プラクティスモード,PRACTICEモード
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6970,6 +7267,7 @@
 
 # newdoc id = dev-s301
 # sent_id = dev-s301
+# parallel_id = jagsdluw/dev301
 # text = 主人公の隣のアパートに引っ越してきた幼稚園の先生。
 1	主人公	主人公	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュジン;コウ,主人;公,主人;公,主人;公,シュジン;コー,;,;,シュジン;コウ,シュジンコウ,主人公
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6987,6 +7285,7 @@
 
 # newdoc id = dev-s302
 # sent_id = dev-s302
+# parallel_id = jagsdluw/dev302
 # text = アンジェロの一人娘であるジェニファーは、命の危険から遠ざけるために、幼い頃に養女に出されていた。
 1	アンジェロ	アンジェロ	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アンジェロ,アンジェロ,アンジェロ,アンジェロ,アンジェロ,,,アンジェロ,アンジェロ,アンジェロ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7015,6 +7314,7 @@
 
 # newdoc id = dev-s303
 # sent_id = dev-s303
+# parallel_id = jagsdluw/dev303
 # text = 桜井高校はランナー1.3塁から内野ゴロで先制します。
 1	桜井高校	桜井高校	PROPN	名詞-固有名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクライ;コウコウ,サクライ;高校,桜井;高校,桜井;高校,サクライ;コーコー,;,;,サクライ;コウコウ,サクライコウコウ,桜井高校
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7029,6 +7329,7 @@
 
 # newdoc id = dev-s304
 # sent_id = dev-s304
+# parallel_id = jagsdluw/dev304
 # text = 5人以上だときついかもしれないけど、少人数の時にはまた使いたいです。
 1	5人以上	5人以上	NOUN	名詞-普通名詞-一般	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ;ニン;イジョウ,五;人;以上,5;人;以上,5;人;以上,ゴ;ニン;イジョー,;;,;;,ゴ;ニン;イジョウ,ゴニンイジョウ,5人以上
 2	だ	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダ,だ
@@ -7050,6 +7351,7 @@
 
 # newdoc id = dev-s305
 # sent_id = dev-s305
+# parallel_id = jagsdluw/dev305
 # text = シーズン終了後球団社長のジョン・ショーは辞任し、12月22日にはジェイ・ジグムンドに代わってビリー・ディバニーがゼネラルマネージャーとなった。
 1	シーズン終了後	シーズン終了後	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シーズン;シュウリョウ;ゴ,シーズン;終了;後,シーズン;終了;後,シーズン;終了;後,シーズン;シューリョー;ゴ,;;,;;,シーズン;シュウリョウ;ゴ,シーズンシュウリョウゴ,シーズン終了後
 2	球団社長	球団社長	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウダン;シャチョウ,球団;社長,球団;社長,球団;社長,キューダン;シャチョー,;,;,キュウダン;シャチョウ,キュウダンシャチョウ,球団社長
@@ -7076,6 +7378,7 @@
 
 # newdoc id = dev-s306
 # sent_id = dev-s306
+# parallel_id = jagsdluw/dev306
 # text = 1462年、アラゴン王フアン2世と、最初の妃であるナバラ女王ブランカ1世との間の王子カルラスが、ナバラ王位を巡って争うことになった。
 1	1462年	1462年	NUM	名詞-数詞	_	24	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ヨン;ロク;ニ;ネン,一;四;六;二;年,1;4;6;2;年,1;4;6;2;年,イチ;ヨン;ロク;ニ;ネン,;;;;,;;;;,イチ;ヨン;ロク;ニ;ネン,イチヨンロクニネン,1462年
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7107,6 +7410,7 @@
 
 # newdoc id = dev-s307
 # sent_id = dev-s307
+# parallel_id = jagsdluw/dev307
 # text = 大部分が6車線で、品川埠頭の連絡道である。
 1	大部分	大部分	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;ブブン,大;部分,大;部分,大;部分,ダイ;ブブン,;,;,ダイ;ブブン,ダイブブン,大部分
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7121,6 +7425,7 @@
 
 # newdoc id = dev-s308
 # sent_id = dev-s308
+# parallel_id = jagsdluw/dev308
 # text = 旅の途中で出会うモンスターを模した家具を、マイハウスに設置可能。
 1	旅	旅	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タビ,旅,旅,旅,タビ,,,タビ,タビ,旅
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7141,6 +7446,7 @@
 
 # newdoc id = dev-s309
 # sent_id = dev-s309
+# parallel_id = jagsdluw/dev309
 # text = さらにその後、ビデオによる撮影が主流となるに従い、ビデオ機材を組み込んだ総合的なシステムとしてのスタジオが主流となった。
 1	さらに	更に	CCONJ	接続詞	_	27	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サラニ,更に,さらに,さらに,サラニ,,,サラニ,サラニ,更に
 2	その	其の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
@@ -7174,6 +7480,7 @@
 
 # newdoc id = dev-s310
 # sent_id = dev-s310
+# parallel_id = jagsdluw/dev310
 # text = 外見は田舎の一般住宅のノリですが、津幡の店とは思えないクオリティーです。
 1	外見	外見	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガイケン,外見,外見,外見,ガイケン,,,ガイケン,ガイケン,外見
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7198,6 +7505,7 @@
 
 # newdoc id = dev-s311
 # sent_id = dev-s311
+# parallel_id = jagsdluw/dev311
 # text = 九州大学大学院法学研究院准教授を経て、現在同教授。
 1	九州大学大学院	九州大学大学院	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウシュウ;ダイガク;ダイガク;イン,キュウシュウ;大学;大学;院,九州;大学;大学;院,九州;大学;大学;院,キューシュー;ダイガク;ダイガク;イン,;;;,;;;,キュウシュウ;ダイガク;ダイガク;イン,キュウシュウダイガクダイガクイン,九州大学大学院
 2	法学研究院	法学研究院	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ホウガク;ケンキュウ;イン,法学;研究;院,法学;研究;院,法学;研究;院,ホーガク;ケンキュー;イン,;;,;;,ホウガク;ケンキュウ;イン,ホウガクケンキュウイン,法学研究院
@@ -7212,6 +7520,7 @@
 
 # newdoc id = dev-s312
 # sent_id = dev-s312
+# parallel_id = jagsdluw/dev312
 # text = 実に狡猾なやり口だ。
 1	実	実	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジツ,実,実,実,ジツ,,,ジツ,ジツ,実
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7223,6 +7532,7 @@
 
 # newdoc id = dev-s313
 # sent_id = dev-s313
+# parallel_id = jagsdluw/dev313
 # text = 車両手配上の都合からホンダ車以外の他社の車両を使用する際には、車両の前部・後部に番組タイトルロゴ付きの板を被せていた。
 1	車両手配上	車両手配上	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シャリョウ;テハイ;ジョウ,車両;手配;上,車両;手配;上,車両;手配;上,シャリョー;テハイ;ジョー,;;,;;,シャリョウ;テハイ;ジョウ,シャリョウテハイジョウ,車両手配上
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7253,6 +7563,7 @@
 
 # newdoc id = dev-s314
 # sent_id = dev-s314
+# parallel_id = jagsdluw/dev314
 # text = 日本向けには脱脂粉乳、雑穀類を食料として送った。
 1	日本向け	日本向け	NOUN	名詞-普通名詞-一般	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン;ムケ,日本;向け,日本;向け,日本;向け,ニッポン;ムケ,;,;,ニッポン;ムケ,ニッポンムケ,日本向け
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7269,6 +7580,7 @@
 
 # newdoc id = dev-s315
 # sent_id = dev-s315
+# parallel_id = jagsdluw/dev315
 # text = 今後は高校野球などアマチュア野球の公式戦の他、プロ野球の二軍公式戦を誘致する方針である。
 1	今後	今後	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンゴ,今後,今後,今後,コンゴ,,,コンゴ,コンゴ,今後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7291,6 +7603,7 @@
 
 # newdoc id = dev-s316
 # sent_id = dev-s316
+# parallel_id = jagsdluw/dev316
 # text = そもそも港市支配者は、外来商人と領域内の住民とを仲立ちすることこそが自らの拠って立つ基盤であった。
 1	そもそも	抑	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソモソモ,抑,そもそも,そもそも,ソモソモ,,,ソモソモ,ソモソモ,抑
 2	港市支配者	港市支配者	NOUN	名詞-普通名詞-一般	_	12	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウシ;シハイ;シャ,港市;支配;者,港市;支配;者,港市;支配;者,コーシ;シハイ;シャ,;;,;;,コウシ;シハイ;シャ,コウシシハイシャ,港市支配者
@@ -7319,6 +7632,7 @@
 
 # newdoc id = dev-s317
 # sent_id = dev-s317
+# parallel_id = jagsdluw/dev317
 # text = そして現場へ着くと不思議な光に包まれる。
 1	そして	そして	CCONJ	接続詞	_	10	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	現場	現場	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンバ,現場,現場,現場,ゲンバ,,,ゲンバ,ゲンバ,現場
@@ -7335,6 +7649,7 @@
 
 # newdoc id = dev-s318
 # sent_id = dev-s318
+# parallel_id = jagsdluw/dev318
 # text = 私はよく通ってますが、親切丁寧に対応してくださって安心です。
 1	私	私	PRON	代名詞	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7355,6 +7670,7 @@
 
 # newdoc id = dev-s319
 # sent_id = dev-s319
+# parallel_id = jagsdluw/dev319
 # text = 大学在学中に、最初の文学賞を受賞する。
 1	大学在学中	大学在学中	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイガク;ザイガク;チュウ,大学;在学;中,大学;在学;中,大学;在学;中,ダイガク;ザイガク;チュー,;;,;;,ダイガク;ザイガク;チュウ,ダイガクザイガクチュウ,大学在学中
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7368,6 +7684,7 @@
 
 # newdoc id = dev-s320
 # sent_id = dev-s320
+# parallel_id = jagsdluw/dev320
 # text = 私たちはビュッフェスタイルだったのですが、いろいろなプランでやってくれるみたいです。
 1	私たち	私達	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ;タチ,私;達,私;たち,私;たち,ワタシ;タチ,;,;,ワタシ;タチ,ワタシタチ,私達
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7389,6 +7706,7 @@
 
 # newdoc id = dev-s321
 # sent_id = dev-s321
+# parallel_id = jagsdluw/dev321
 # text = 豚が美味しかったので、また行きます。
 1	豚	豚	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ブタ,豚,豚,豚,ブタ,,,ブタ,ブタ,豚
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7403,6 +7721,7 @@
 
 # newdoc id = dev-s322
 # sent_id = dev-s322
+# parallel_id = jagsdluw/dev322
 # text = 同百貨店は「成長していく東京スカイツリーをリアルに体感してもらいたい」としている。
 1	同百貨店	同百貨店	NOUN	名詞-普通名詞-一般	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;ヒャッカ;テン,同;百貨;店,同;百貨;店,同;百貨;店,ドー;ヒャッカ;テン,;;,;;,ドウ;ヒャッカ;テン,ドウヒャッカテン,同百貨店
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7424,6 +7743,7 @@
 
 # newdoc id = dev-s323
 # sent_id = dev-s323
+# parallel_id = jagsdluw/dev323
 # text = ウエイトが増え、トレードマークだった金髪のロングヘアもすっかり薄くなったことから、それまでの伊達男キャラクターを完全に払拭。
 1	ウエイト	ウエイト	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウエート,ウエート,ウエイト,ウエイト,ウエート,,,ウエイト,ウエイト,ウエイト
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7455,6 +7775,7 @@
 
 # newdoc id = dev-s324
 # sent_id = dev-s324
+# parallel_id = jagsdluw/dev324
 # text = ヨーロッパで重要なロマネスク建築の一つで、ユネスコの世界遺産に登録されている。
 1	ヨーロッパ	ヨーロッパ	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨーロッパ,ヨーロッパ,ヨーロッパ,ヨーロッパ,ヨーロッパ,,,ヨーロッパ,ヨーロッパ,ヨーロッパ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -7476,6 +7797,7 @@
 
 # newdoc id = dev-s325
 # sent_id = dev-s325
+# parallel_id = jagsdluw/dev325
 # text = 本当に健康な人は,身体だけでなく肌もきれいです。
 1	本当	本当	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホントウ,本当,本当,本当,ホント,,,ホント,ホントウ,本当
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7494,6 +7816,7 @@
 
 # newdoc id = dev-s326
 # sent_id = dev-s326
+# parallel_id = jagsdluw/dev326
 # text = 2万人を収容可能。
 1	2万人	2万人	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;マン;ニン,二;万;人,2;万;人,2;万;人,ニ;マン;ニン,;;,;;,ニ;マン;ニン,ニマンニン,2万人
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7502,6 +7825,7 @@
 
 # newdoc id = dev-s327
 # sent_id = dev-s327
+# parallel_id = jagsdluw/dev327
 # text = これでも関係がないと言えるのか?
 1	これ	此れ	PRON	代名詞	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -7517,6 +7841,7 @@
 
 # newdoc id = dev-s328
 # sent_id = dev-s328
+# parallel_id = jagsdluw/dev328
 # text = お医者さんも、日大の大学病院で脳神経外科にて手術などの実績が多数あり、脳神経外科を経て同じく耳鼻科の教授にスカウトされ脳の近くの部位である耳鼻咽喉科にて実績を積んだ優秀な先生と聞いています。
 1	お医者さん	御医者さん	NOUN	名詞-普通名詞-一般	_	16	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;イシャ;サン,御;医者;さん,お;医者;さん,お;医者;さん,オ;イシャ;サン,;;,;;,オ;イシャ;サン,オイシャサン,御医者さん
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -7569,6 +7894,7 @@
 
 # newdoc id = dev-s329
 # sent_id = dev-s329
+# parallel_id = jagsdluw/dev329
 # text = それに,病気を治す力も知識もない人間がさも病気を治せるかのように言っていただけなのであれば,そもそも10円だって払う筋合いはないでしょう。
 1	それ	其れ	PRON	代名詞	_	37	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7612,6 +7938,7 @@
 
 # newdoc id = dev-s330
 # sent_id = dev-s330
+# parallel_id = jagsdluw/dev330
 # text = 若い脳細胞に与える傷は,一生消えないでしょう。
 1	若い	若い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワカイ,若い,若い,若い,ワカイ,,,ワカイ,ワカイ,若い
 2	脳細胞	脳細胞	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノウ;サイボウ,脳;細胞,脳;細胞,脳;細胞,ノー;サイボー,;,;,ノウ;サイボウ,ノウサイボウ,脳細胞
@@ -7628,6 +7955,7 @@
 
 # newdoc id = dev-s331
 # sent_id = dev-s331
+# parallel_id = jagsdluw/dev331
 # text = 1225年にバーベンベルク家のオーストリア公レオポルト6世の娘マルガレーテと結婚、ハインリヒ8世とフリードリヒ4世を儲けたがいずれも若くして早世した。
 1	1225年	1225年	NUM	名詞-数詞	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ニ;ニ;ゴ;ネン,一;二;二;五;年,1;2;2;5;年,1;2;2;5;年,イチ;ニ;ニ;ゴ;ネン,;;;;,;;;;,イチ;ニ;ニ;ゴ;ネン,イチニニゴネン,1225年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7661,6 +7989,7 @@
 
 # newdoc id = dev-s332
 # sent_id = dev-s332
+# parallel_id = jagsdluw/dev332
 # text = 午前中の西光寺と違って,かなり広大な境内だったため,門の外からはモニターも見えずスピーカーからの声も聞き取れません。
 1	午前中	午前中	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴゼン;チュウ,午前;中,午前;中,午前;中,ゴゼン;チュー,;,;,ゴゼン;チュウ,ゴゼンチュウ,午前中
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7698,6 +8027,7 @@
 
 # newdoc id = dev-s333
 # sent_id = dev-s333
+# parallel_id = jagsdluw/dev333
 # text = 松濤本部では拉致問題対策委員長補佐を務めているようだ。
 1	松濤本部	松濤本部	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショートー;ホンブ,ショートー;本部,松濤;本部,松濤;本部,ショートー;ホンブ,;,;,ショートー;ホンブ,ショートーホンブ,松濤本部
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -7712,6 +8042,7 @@
 
 # newdoc id = dev-s334
 # sent_id = dev-s334
+# parallel_id = jagsdluw/dev334
 # text = この日は、被害者の会の14人と弁護士3人が市役所を訪れ、福地直樹弁護士が「真相究明と被害救済のため、必要な措置を講じて欲しい」と述べて要請書を提出。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	日	日	NOUN	名詞-普通名詞-一般	_	14	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ヒ,,,ヒ,ヒ,日
@@ -7754,6 +8085,7 @@
 
 # newdoc id = dev-s335
 # sent_id = dev-s335
+# parallel_id = jagsdluw/dev335
 # text = 魔法使いへの直接干渉に特化した唯一の魔法大系。
 1	魔法使い	魔法使い	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マホウ;ツカイ,魔法;使い,魔法;使い,魔法;使い,マホー;ツカイ,;,;,マホウ;ツカイ,マホウツカイ,魔法使い
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -7769,6 +8101,7 @@
 
 # newdoc id = dev-s336
 # sent_id = dev-s336
+# parallel_id = jagsdluw/dev336
 # text = しかし、国民各層にはその考え方が次第に浸透して行き、自由民権運動の気運が高まるきっかけとなった。
 1	しかし	然し	CCONJ	接続詞	_	21	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7796,6 +8129,7 @@
 
 # newdoc id = dev-s337
 # sent_id = dev-s337
+# parallel_id = jagsdluw/dev337
 # text = また髪型も京風の引き鬢ではなく、江戸風の出し鬢であった。
 1	また	又	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	髪型	髪型	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カミガタ,髪型,髪型,髪型,カミガタ,,,カミガタ,カミガタ,髪型
@@ -7814,6 +8148,7 @@
 
 # newdoc id = dev-s338
 # sent_id = dev-s338
+# parallel_id = jagsdluw/dev338
 # text = 1940年7月、オデッサ軍管区の第35狙撃軍団長となり、ベッサラビアの占領に参加した。
 1	1940年	1940年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;ヨン;ゼロ;ネン,一;九;四;ゼロ;年,1;9;4;0;年,1;9;4;0;年,イチ;キュー;ヨン;ゼロ;ネン,;;;;,;;;;,イチ;キュウ;ヨン;ゼロ;ネン,イチキュウヨンゼロネン,1940年
 2	7月	7月	NUM	名詞-数詞	_	14	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シチ;ガツ,七;月,7;月,7;月,シチ;ガツ,;,;,シチ;ガツ,シチガツ,7月
@@ -7834,6 +8169,7 @@
 
 # newdoc id = dev-s339
 # sent_id = dev-s339
+# parallel_id = jagsdluw/dev339
 # text = スタンディングでわいわいも2Fテーブル席でまったりでも楽しめる泡なドリンク専門のスタンディングバー。
 1	スタンディング	スタンディング	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタンディング,スタンディング,スタンディング,スタンディング,スタンディング,,,スタンディング,スタンディング,スタンディング
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -7854,6 +8190,7 @@
 
 # newdoc id = dev-s340
 # sent_id = dev-s340
+# parallel_id = jagsdluw/dev340
 # text = ところが2ちゃんねるの幸福の科学統合スレッドでは,この“主催者発表数”に疑問の声が挙がりました。
 1	ところが	所が	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トコロ;ガ,所;が,ところ;が,ところ;が,トコロ;ガ,;,;,トコロ;ガ,トコロガ,所が
 2	2ちゃんねる	2ちゃんねる	PROPN	名詞-固有名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;チャンネル,二;チャンネル,2;ちゃんねる,2;ちゃんねる,ニ;チャンネル,;,;,ニ;チャンネル,ニチャンネル,2ちゃんねる
@@ -7878,6 +8215,7 @@
 
 # newdoc id = dev-s341
 # sent_id = dev-s341
+# parallel_id = jagsdluw/dev341
 # text = 実験室を1カ所に集めたオープンラボ方式を採用した。
 1	実験室	実験室	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジッケン;シツ,実験;室,実験;室,実験;室,ジッケン;シツ,;,;,ジッケン;シツ,ジッケンシツ,実験室
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7893,6 +8231,7 @@
 
 # newdoc id = dev-s342
 # sent_id = dev-s342
+# parallel_id = jagsdluw/dev342
 # text = JR東日本のクモハ123-1とは種車が同じで、番号も続番となっているが、外観は大きく異なる。
 1	JR東日本	JR東日本	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェーアール;ヒガシ;ニッポン,ＪＲ;東;日本,JR;東;日本,JR;東;日本,ジェーアール;ヒガシ;ニホン,;;,;;,ジェーアール;ヒガシ;ニホン,ジェーアールヒガシニホン,JR東日本
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7920,6 +8259,7 @@
 
 # newdoc id = dev-s343
 # sent_id = dev-s343
+# parallel_id = jagsdluw/dev343
 # text = 十六日の卒業式が中止になった文教大学越谷校舎の四年生ら学生有志約二百人が越谷市内の駅やスーパーの前などに立ち、被災者救援のために募金を呼び掛けた。
 1	十六日	十六日	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウ;ロク;ニチ,十;六;日,十;六;日,十;六;日,ジュー;ロク;ニチ,;;,;;,ジュウ;ロク;ニチ,ジュウロクニチ,十六日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7958,12 +8298,14 @@
 
 # newdoc id = dev-s344
 # sent_id = dev-s344
+# parallel_id = jagsdluw/dev344
 # text = 東京都生まれ。
 1	東京都生まれ	東京都生まれ	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=トウキョウ;ト;ウマレ,トウキョウ;都;生まれ,東京;都;生まれ,東京;都;生まれ,トーキョー;ト;ウマレ,;;,;;,トウキョウ;ト;ウマレ,トウキョウトウマレ,東京都生まれ
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s345
 # sent_id = dev-s345
+# parallel_id = jagsdluw/dev345
 # text = 幸福の科学の教えを信じお布施をし,さらに今回のデモに参加したにもかかわらず,教団に守ってもらえないのでは,信者が気の毒です。
 1	幸福の科学	幸福の科学	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ノ;カガク,幸福;の;科学,幸福;の;科学,幸福;の;科学,コーフク;ノ;カガク,;;,;;,コウフク;ノ;カガク,コウフクノカガク,幸福の科学
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7999,6 +8341,7 @@
 
 # newdoc id = dev-s346
 # sent_id = dev-s346
+# parallel_id = jagsdluw/dev346
 # text = 大阪駅から徒歩10分圏内のスパホテルで、一人旅行でも利用できるし友達とも利用したカプセルホテルです。
 1	大阪駅	大阪駅	PROPN	名詞-固有名詞-地名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオサカ;エキ,オオサカ;駅,大阪;駅,大阪;駅,オーサカ;エキ,;,;,オオサカ;エキ,オオサカエキ,大阪駅
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -8024,6 +8367,7 @@
 
 # newdoc id = dev-s347
 # sent_id = dev-s347
+# parallel_id = jagsdluw/dev347
 # text = 今回、アメリカ側は6カ国協議の再開に必要な条件を示すための「予備的な米朝協議だ」としていて、北朝鮮の出方を慎重に見極める方針です。
 1	今回	今回	ADV	副詞	_	23	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンカイ,今回,今回,今回,コンカイ,,,コンカイ,コンカイ,今回
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8064,6 +8408,7 @@
 
 # newdoc id = dev-s348
 # sent_id = dev-s348
+# parallel_id = jagsdluw/dev348
 # text = 1985年8月28日生。
 1	1985年	1985年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;ハチ;ゴ;ネン,一;九;八;五;年,1;9;8;5;年,1;9;8;5;年,イチ;キュー;ハチ;ゴ;ネン,;;;;,;;;;,イチ;キュウ;ハチ;ゴ;ネン,イチキュウハチゴネン,1985年
 2	8月	8月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ハチ;ガツ,八;月,8;月,8;月,ハチ;ガツ,;,;,ハチ;ガツ,ハチガツ,8月
@@ -8072,6 +8417,7 @@
 
 # newdoc id = dev-s349
 # sent_id = dev-s349
+# parallel_id = jagsdluw/dev349
 # text = オハイオ州政府のコンピュータにSETI@homeをインストールして使用したために解雇された例がある。
 1	オハイオ州政府	オハイオ州政府	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オハイオ;シュウ;セイフ,オハイオ;州;政府,オハイオ;州;政府,オハイオ;州;政府,オハイオ;シュー;セーフ,;;,;;,オハイオ;シュウ;セイフ,オハイオシュウセイフ,オハイオ州政府
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8094,6 +8440,7 @@
 
 # newdoc id = dev-s350
 # sent_id = dev-s350
+# parallel_id = jagsdluw/dev350
 # text = 大震災に対応した特措法の議論も行っており、しかるべく対応したい」と答えました。
 1	大震災	大震災	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;シンサイ,大;震災,大;震災,大;震災,ダイ;シンサイ,;,;,ダイ;シンサイ,ダイシンサイ,大震災
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8119,6 +8466,7 @@
 
 # newdoc id = dev-s351
 # sent_id = dev-s351
+# parallel_id = jagsdluw/dev351
 # text = それに対し、ヨハンネスの要求は「奴隷500人、牛5万頭、馬1,000頭の貢物と、メネリクを上半身裸にした上で罪人の首枷をつけて謝罪させる」というものだった。
 1	それ	其れ	PRON	代名詞	_	38	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	に対し	に対し	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;タイスル,に;対する,に;対し,に;対する,ニ;タイシ,;,;,ニ;タイスル,ニタイシ,に対し
@@ -8164,6 +8512,7 @@
 
 # newdoc id = dev-s352
 # sent_id = dev-s352
+# parallel_id = jagsdluw/dev352
 # text = 以来、約10カ月ぶりに横田が復活。
 1	以来	以来	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イライ,以来,以来,以来,イライ,,,イライ,イライ,以来
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8176,6 +8525,7 @@
 
 # newdoc id = dev-s353
 # sent_id = dev-s353
+# parallel_id = jagsdluw/dev353
 # text = MTXの適応が無い患者に対する第二選択薬として用いられることが多い。
 1	MTX	MTX	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エムティーエックス,ＭＴＸ,MTX,MTX,エムティーエックス,,,エムティーエックス,エムティーエックス,MTX
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8195,6 +8545,7 @@
 
 # newdoc id = dev-s354
 # sent_id = dev-s354
+# parallel_id = jagsdluw/dev354
 # text = 体力とボールパワーが高いが、素早さが低い。
 1	体力	体力	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイリョク,体力,体力,体力,タイリョク,,,タイリョク,タイリョク,体力
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -8210,6 +8561,7 @@
 
 # newdoc id = dev-s355
 # sent_id = dev-s355
+# parallel_id = jagsdluw/dev355
 # text = しかし彼のホームレス支援活動が悪いことだとは思えません。
 1	しかし	然し	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	彼	彼	PRON	代名詞	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カレ,彼,彼,彼,カレ,,,カレ,カレ,彼
@@ -8228,6 +8580,7 @@
 
 # newdoc id = dev-s356
 # sent_id = dev-s356
+# parallel_id = jagsdluw/dev356
 # text = その日はたまたまサービスで生肉を出して頂いたが、味、食感ともに大した事はなかった。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	日	日	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ヒ,,,ヒ,ヒ,日
@@ -8256,6 +8609,7 @@
 
 # newdoc id = dev-s357
 # sent_id = dev-s357
+# parallel_id = jagsdluw/dev357
 # text = 1967年、アレクサンダーは連邦上院議員ハワード・ベイカーの議会補佐官として勤務した。
 1	1967年	1967年	NUM	名詞-数詞	_	9	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ロク;シチ;ネン,一;九;六;七;年,1;9;6;7;年,1;9;6;7;年,イチ;キュー;ロク;シチ;ネン,;;;;,;;;;,イチ;キュウ;ロク;シチ;ネン,イチキュウロクシチネン,1967年
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8271,6 +8625,7 @@
 
 # newdoc id = dev-s358
 # sent_id = dev-s358
+# parallel_id = jagsdluw/dev358
 # text = 自然を愛するため、同様の性格を持つタイガトロンと共に行動することが多いが、「基地は性に合わない」と零すタイガトロンと違い、特に合わない素振りは見せていない。
 1	自然	自然	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シゼン,自然,自然,自然,シゼン,,,シゼン,シゼン,自然
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8318,12 +8673,14 @@
 
 # newdoc id = dev-s359
 # sent_id = dev-s359
+# parallel_id = jagsdluw/dev359
 # text = 県指定重要文化財・くまもとアートポリス選定既存建造物。
 1	県指定重要文化財・くまもとアートポリス選定既存建造物	県指定重要文化財・くまもとアートポリス選定既存建造物	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ケン;シテイ;ジュウヨウ;ブンカ;ザイ;;クマモト;アート;ポリス;センテイ;キソン;ケンゾウ;ブツ,県;指定;重要;文化;財;・;クマモト;アート;ポリス;選定;既存;建造;物,県;指定;重要;文化;財;・;くまもと;アート;ポリス;選定;既存;建造;物,県;指定;重要;文化;財;・;くまもと;アート;ポリス;選定;既存;建造;物,ケン;シテー;ジューヨー;ブンカ;ザイ;;クマモト;アート;ポリス;センテー;キゾン;ケンゾー;ブツ,;;;;;;;;;;;;,;;;;;;;;;;;;,ケン;シテイ;ジュウヨウ;ブンカ;ザイ;;クマモト;アート;ポリス;センテイ;キゾン;ケンゾウ;ブツ,ケンシテイジュウヨウブンカザイクマモトアートポリスセンテイキソンケンゾウブツ,県指定重要文化財・くまもとアートポリス選定既存建造物
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s360
 # sent_id = dev-s360
+# parallel_id = jagsdluw/dev360
 # text = 病院に行かず治療も受けずになくなっています。
 1	病院	病院	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビョウイン,病院,病院,病院,ビョーイン,,,ビョウイン,ビョウイン,病院
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8341,6 +8698,7 @@
 
 # newdoc id = dev-s361
 # sent_id = dev-s361
+# parallel_id = jagsdluw/dev361
 # text = 同時上映は『・ふ・た・り・ぼ・っ・ち・』。
 1	同時上映	同時上映	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウジ;ジョウエイ,同時;上映,同時;上映,同時;上映,ドージ;ジョーエー,;,;,ドウジ;ジョウエイ,ドウジジョウエイ,同時上映
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8351,6 +8709,7 @@
 
 # newdoc id = dev-s362
 # sent_id = dev-s362
+# parallel_id = jagsdluw/dev362
 # text = 飲んだ後に行きたくなる。
 1	飲ん	飲む	VERB	動詞-一般-五段-マ行	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノム,飲む,飲ん,飲む,ノン,,,ノム,ノム,飲む
 2	だ	だ	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,だ,だ,ダ,,,ダ,ダ,だ
@@ -8363,6 +8722,7 @@
 
 # newdoc id = dev-s363
 # sent_id = dev-s363
+# parallel_id = jagsdluw/dev363
 # text = 官位は従四位上・参議。
 1	官位	官位	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンイ,官位,官位,官位,カンイ,,,カンイ,カンイ,官位
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8371,6 +8731,7 @@
 
 # newdoc id = dev-s364
 # sent_id = dev-s364
+# parallel_id = jagsdluw/dev364
 # text = 日本に馴染み、短い間に日本語を覚えたセルギイは、日露戦争の結果、日本が獲得した樺太で没収された資産を信徒に返還するため、正教徒のスポークスマンとして活動した。
 1	日本	日本	PROPN	名詞-固有名詞-地名-国	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニッポン,,,ニッポン,ニッポン,日本
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8416,6 +8777,7 @@
 
 # newdoc id = dev-s365
 # sent_id = dev-s365
+# parallel_id = jagsdluw/dev365
 # text = ちなみに、大阪市は現在の長居公園に1951年11月、大阪競馬場を利用して、市営の長居オートレース場も開設したが、爆音にかかる周辺環境問題や経営不振を理由に、わずか5ヶ月で廃止した。
 1	ちなみに	因みに	CCONJ	接続詞	_	38	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チナミ;ニ,因み;に,ちなみ;に,ちなみ;に,チナミ;ニ,;,;,チナミ;ニ,チナミニ,因みに
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8460,6 +8822,7 @@
 
 # newdoc id = dev-s366
 # sent_id = dev-s366
+# parallel_id = jagsdluw/dev366
 # text = 幸福実現党では,唯一の国会議員であった大江康弘参議院議員も昨年末に離党しています。
 1	幸福実現党	幸福実現党	PROPN	名詞-固有名詞-一般	_	14	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ジツゲン;トウ,幸福;実現;党,幸福;実現;党,幸福;実現;党,コーフク;ジツゲン;トー,;;,;;,コウフク;ジツゲン;トウ,コウフクジツゲントウ,幸福実現党
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8481,6 +8844,7 @@
 
 # newdoc id = dev-s367
 # sent_id = dev-s367
+# parallel_id = jagsdluw/dev367
 # text = この後結成した「アテナ&ロビケロッツ」「ガーディアンズ4」、また2009年6月にチャンプルユニットとして結成されたタンポポ#・プッチモニV・ZYX-α・続・美勇伝にも選抜参加したメンバーがいる。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	後	後	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アト,後,後,後,アト,,,アト,アト,後
@@ -8514,6 +8878,7 @@
 
 # newdoc id = dev-s368
 # sent_id = dev-s368
+# parallel_id = jagsdluw/dev368
 # text = 玉子チリソースも気になった。
 1	玉子チリソース	卵チリソース	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タマゴ;チリ;ソース,卵;チリ;ソース,玉子;チリ;ソース,玉子;チリ;ソース,タマゴ;チリ;ソース,;;,;;,タマゴ;チリ;ソース,タマゴチリソース,卵チリソース
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -8525,6 +8890,7 @@
 
 # newdoc id = dev-s369
 # sent_id = dev-s369
+# parallel_id = jagsdluw/dev369
 # text = その後、1948年8月25日の代議員選挙によって北朝鮮最高人民会議が設立され、9月3日には北朝鮮憲法が公式採択された。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -8553,6 +8919,7 @@
 
 # newdoc id = dev-s370
 # sent_id = dev-s370
+# parallel_id = jagsdluw/dev370
 # text = 最後に穀物の珈琲とデザートまで付いてくるのです。
 1	最後	最後	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイゴ,最後,最後,最後,サイゴ,,,サイゴ,サイゴ,最後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8569,6 +8936,7 @@
 
 # newdoc id = dev-s371
 # sent_id = dev-s371
+# parallel_id = jagsdluw/dev371
 # text = ディスクを取り外し可能なハードディスクのこと。
 1	ディスク	ディスク	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ディスク,ディスク,ディスク,ディスク,ディスク,,,ディスク,ディスク,ディスク
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8581,6 +8949,7 @@
 
 # newdoc id = dev-s372
 # sent_id = dev-s372
+# parallel_id = jagsdluw/dev372
 # text = NPTLはRed Hat Enterprise Linuxのバージョン3から搭載され、現在ではGNU Cライブラリの一部となっている。
 1	NPTL	NPTL	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エヌピーティーエル,ＮＰＴＬ,NPTL,NPTL,エヌピーティーエル,,,エヌピーティーエル,エヌピーティーエル,NPTL
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8605,6 +8974,7 @@
 
 # newdoc id = dev-s373
 # sent_id = dev-s373
+# parallel_id = jagsdluw/dev373
 # text = フェレット装甲車の設計と形状は前任のダイムラー偵察車との共通点が多いが、フェレット装甲車はダイムラー偵察車よりも戦闘区画が広く小さな機関銃付の砲塔を装備している。
 1	フェレット装甲車	フェレット装甲車	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フェレット;ソウコウ;シャ,フェレット;装甲;車,フェレット;装甲;車,フェレット;装甲;車,フェレット;ソーコー;シャ,;;,;;,フェレット;ソウコウ;シャ,フェレットソウコウシャ,フェレット装甲車
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8641,6 +9011,7 @@
 
 # newdoc id = dev-s374
 # sent_id = dev-s374
+# parallel_id = jagsdluw/dev374
 # text = 作中では、皇一心や率いる集団の社会階級の明確な描写はされていない。
 1	作中	作中	NOUN	名詞-普通名詞-一般	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクチュウ,作中,作中,作中,サクチュー,,,サクチュウ,サクチュウ,作中
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8665,6 +9036,7 @@
 
 # newdoc id = dev-s375
 # sent_id = dev-s375
+# parallel_id = jagsdluw/dev375
 # text = また“名進信徒会”の所在地についても“わかりません”。
 1	また	又	CCONJ	接続詞	_	10	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	“	“	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
@@ -8683,6 +9055,7 @@
 
 # newdoc id = dev-s376
 # sent_id = dev-s376
+# parallel_id = jagsdluw/dev376
 # text = いつも飲み慣れている祖父が、突然、割ってあると言い出したのです。
 1	いつ	何時	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イツ,何時,いつ,いつ,イツ,,,イツ,イツ,何時
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -8703,6 +9076,7 @@
 
 # newdoc id = dev-s377
 # sent_id = dev-s377
+# parallel_id = jagsdluw/dev377
 # text = ポール・ウェラーからセッションやオープニングアクトのオファーを受けるなど、高い評価を得ている。
 1	ポール・ウェラー	ポール・ウェラー	PROPN	名詞-固有名詞-人名-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ポール;;ウェラー,ポール;・;ウェラー,ポール;・;ウェラー,ポール;・;ウェラー,ポール;;ウェラー,;;,;;,ポール;;ウェラー,ポールウェラー,ポール・ウェラー
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -8724,6 +9098,7 @@
 
 # newdoc id = dev-s378
 # sent_id = dev-s378
+# parallel_id = jagsdluw/dev378
 # text = しかし、憲法訴訟という類型自体が存在しないとしても、憲法判断の重要性から、憲法訴訟に特有の理論を考察する学問分野がある。
 1	しかし	然し	CCONJ	接続詞	_	25	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8754,6 +9129,7 @@
 
 # newdoc id = dev-s379
 # sent_id = dev-s379
+# parallel_id = jagsdluw/dev379
 # text = 最も知られた蔵本モデルの形式は次のような支配方程式に従う。
 1	最も	最も	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モットモ,最も,最も,最も,モットモ,,,モットモ,モットモ,最も
 2	知ら	知る	VERB	動詞-一般-五段-ラ行	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シル,知る,知ら,知る,シラ,,,シル,シル,知る
@@ -8774,6 +9150,7 @@
 
 # newdoc id = dev-s380
 # sent_id = dev-s380
+# parallel_id = jagsdluw/dev380
 # text = 彼に関する本を何冊も読みましたし,彼のプレゼンをYou Tubeで見ては興奮していました。
 1	彼	彼	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カレ,彼,彼,彼,カレ,,,カレ,カレ,彼
 2	に関する	に関する	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;カンスル,に;関する,に;関する,に;関する,ニ;カンスル,;,;,ニ;カンスル,ニカンスル,に関する
@@ -8803,6 +9180,7 @@
 
 # newdoc id = dev-s381
 # sent_id = dev-s381
+# parallel_id = jagsdluw/dev381
 # text = アメリカの研究者や中国の臨床試験で,免疫システムの病気であるリューマチにも効果がすぐれているということも証明されました。
 1	アメリカ	アメリカ	PROPN	名詞-固有名詞-地名-国	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アメリカ,アメリカ,アメリカ,アメリカ,アメリカ,,,アメリカ,アメリカ,アメリカ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8835,6 +9213,7 @@
 
 # newdoc id = dev-s382
 # sent_id = dev-s382
+# parallel_id = jagsdluw/dev382
 # text = 新宿の高速バスを利用するときは必ず足を運んでしまう。
 1	新宿	新宿	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンジュク,シンジュク,新宿,新宿,シンジュク,,,シンジュク,シンジュク,新宿
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8852,6 +9231,7 @@
 
 # newdoc id = dev-s383
 # sent_id = dev-s383
+# parallel_id = jagsdluw/dev383
 # text = お店の雰囲気も活気がある感じが気に入っています。
 1	お店	御店	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセ,御;店,お;店,お;店,オ;ミセ,;,;,オ;ミセ,オミセ,御店
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8871,6 +9251,7 @@
 
 # newdoc id = dev-s384
 # sent_id = dev-s384
+# parallel_id = jagsdluw/dev384
 # text = 1979年、DECを辞めて作家専業となり、フロリダ州オーランドに移住した。
 1	1979年	1979年	NUM	名詞-数詞	_	14	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ナナ;キュウ;ネン,一;九;七;九;年,1;9;7;9;年,1;9;7;9;年,イチ;キュー;ナナ;キュー;ネン,;;;;,;;;;,イチ;キュウ;ナナ;キュウ;ネン,イチキュウナナキュウネン,1979年
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8891,6 +9272,7 @@
 
 # newdoc id = dev-s385
 # sent_id = dev-s385
+# parallel_id = jagsdluw/dev385
 # text = 板門店内および共同警備区域においては、韓国軍を中心とした国連軍と、北朝鮮軍の両軍が境界線を隔てて顔を合わせ警備についている。
 1	板門店内	板門店内	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハンモンテン;ナイ,ハンモンテン;内,板門店;内,板門店;内,ハンモンテン;ナイ,;,;,ハンモンテン;ナイ,ハンモンテンナイ,板門店内
 2	および	及び	CCONJ	接続詞	_	3	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オヨビ,及び,および,および,オヨビ,,,オヨビ,オヨビ,及び
@@ -8926,6 +9308,7 @@
 
 # newdoc id = dev-s386
 # sent_id = dev-s386
+# parallel_id = jagsdluw/dev386
 # text = 以上の方面は、当駅は途中バス停である。
 1	以上	以上	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イジョウ,以上,以上,以上,イジョー,,,イジョウ,イジョウ,以上
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8940,6 +9323,7 @@
 
 # newdoc id = dev-s387
 # sent_id = dev-s387
+# parallel_id = jagsdluw/dev387
 # text = 子どもが熱をだしとても親切に診ていただきました。
 1	子ども	子共	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コドモ,子供,子ども,子ども,コドモ,,,コドモ,コドモ,子共
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -8957,6 +9341,7 @@
 
 # newdoc id = dev-s388
 # sent_id = dev-s388
+# parallel_id = jagsdluw/dev388
 # text = そこで今月19日に開かれた“家系のおはなし”講演会に参加した。
 1	そこ	其処	PRON	代名詞	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソコ,其処,そこ,そこ,ソコ,,,ソコ,ソコ,其処
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8979,6 +9364,7 @@
 
 # newdoc id = dev-s389
 # sent_id = dev-s389
+# parallel_id = jagsdluw/dev389
 # text = 当初は2008年4月1日から2011年3月31日までの3年間の契約で命名権が売却されたが、2010年12月-2011年1月にかけて実施された同ホールの命名権募集に穴吹興産1社しか応募がなかったため、同社との間で2011年4月1日から2016年3月31日の5年間の契約で命名権が売却された。
 1	当初	当初	NOUN	名詞-普通名詞-一般	_	18	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9052,6 +9438,7 @@
 
 # newdoc id = dev-s390
 # sent_id = dev-s390
+# parallel_id = jagsdluw/dev390
 # text = 昔話を聞くと興奮して発砲する。
 1	昔話	昔話	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ムカシバナシ,昔話,昔話,昔話,ムカシバナシ,,,ムカシバナシ,ムカシバナシ,昔話
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -9064,6 +9451,7 @@
 
 # newdoc id = dev-s391
 # sent_id = dev-s391
+# parallel_id = jagsdluw/dev391
 # text = 由来はヤコブから。
 1	由来	由来	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユライ,由来,由来,由来,ユライ,,,ユライ,ユライ,由来
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9073,6 +9461,7 @@
 
 # newdoc id = dev-s392
 # sent_id = dev-s392
+# parallel_id = jagsdluw/dev392
 # text = ブルジョア教育を最も推進しているのは,日本共産党である。
 1	ブルジョア教育	ブルジョア教育	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ブルジョア;キョウイク,ブルジョア;教育,ブルジョア;教育,ブルジョア;教育,ブルジョア;キョーイク,;,;,ブルジョア;キョウイク,ブルジョアキョウイク,ブルジョア教育
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -9088,6 +9477,7 @@
 
 # newdoc id = dev-s393
 # sent_id = dev-s393
+# parallel_id = jagsdluw/dev393
 # text = 部屋へ入るとドライヤーや鏡があり、明らかに宿泊用の部屋といった感じでした。
 1	部屋	部屋	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヘヤ,部屋,部屋,部屋,ヘヤ,,,ヘヤ,ヘヤ,部屋
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -9112,6 +9502,7 @@
 
 # newdoc id = dev-s394
 # sent_id = dev-s394
+# parallel_id = jagsdluw/dev394
 # text = それに加えて,毎月の損失を50%以上軽減するための大規模な努力がなされました。
 1	それ	其れ	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9137,6 +9528,7 @@
 
 # newdoc id = dev-s395
 # sent_id = dev-s395
+# parallel_id = jagsdluw/dev395
 # text = そのほかの主要任務としては「レーベンスボルン」と「アーネンエルベ」の実質的な運営があった。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ほか	他	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
@@ -9162,6 +9554,7 @@
 
 # newdoc id = dev-s396
 # sent_id = dev-s396
+# parallel_id = jagsdluw/dev396
 # text = 警視庁や証券取引等監視委員会と合同で一斉捜索する見通し。
 1	警視庁	警視庁	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイシ;チョウ,警視;庁,警視;庁,警視;庁,ケーシ;チョー,;,;,ケイシ;チョウ,ケイシチョウ,警視庁
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -9175,6 +9568,7 @@
 
 # newdoc id = dev-s397
 # sent_id = dev-s397
+# parallel_id = jagsdluw/dev397
 # text = 2005年にオランダのスパルタ・ロッテルダムへ移籍した。
 1	2005年	2005年	NUM	名詞-数詞	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ゴ;ネン,二;ゼロ;ゼロ;五;年,2;0;0;5;年,2;0;0;5;年,ニ;ゼロ;ゼロ;ゴ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ゴ;ネン,ニゼロゼロゴネン,2005年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9188,6 +9582,7 @@
 
 # newdoc id = dev-s398
 # sent_id = dev-s398
+# parallel_id = jagsdluw/dev398
 # text = 2013年、栃木SCのシニアアドバイザーに就任。
 1	2013年	2013年	NUM	名詞-数詞	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;サン;ネン,二;ゼロ;一;三;年,2;0;1;3;年,2;0;1;3;年,ニ;ゼロ;イチ;サン;ネン,;;;;,;;;;,ニ;ゼロ;イチ;サン;ネン,ニゼロイチサンネン,2013年
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9200,6 +9595,7 @@
 
 # newdoc id = dev-s399
 # sent_id = dev-s399
+# parallel_id = jagsdluw/dev399
 # text = 元々は、済美女子高等学校であったが、2004年4月から男女共学部普通科を設置し、名称が済美高等学校となった。
 1	元々	元々	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モトモト,元々,元々,元々,モトモト,,,モトモト,モトモト,元々
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9227,6 +9623,7 @@
 
 # newdoc id = dev-s400
 # sent_id = dev-s400
+# parallel_id = jagsdluw/dev400
 # text = ハーダーは第二次世界大戦の戦功で6個の従軍星章を受章した。
 1	ハーダー	ハーダー	PROPN	名詞-固有名詞-人名-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハーダー,ハーダー,ハーダー,ハーダー,ハーダー,,,ハーダー,ハーダー,ハーダー
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9244,6 +9641,7 @@
 
 # newdoc id = dev-s401
 # sent_id = dev-s401
+# parallel_id = jagsdluw/dev401
 # text = かつては、塩山-丹波-奥多摩駅という形で山梨交通との相互乗り入れを行っていたが、利用客の減少などにより、1972年で廃止になっている。
 1	かつて	嘗て	ADV	副詞	_	13	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カツテ,嘗て,かつて,かつて,カツテ,,,カツテ,カツテ,嘗て
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9278,6 +9676,7 @@
 
 # newdoc id = dev-s402
 # sent_id = dev-s402
+# parallel_id = jagsdluw/dev402
 # text = 所属事務所は米朝事務所。
 1	所属事務所	所属事務所	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショゾク;ジム;ショ,所属;事務;所,所属;事務;所,所属;事務;所,ショゾク;ジム;ショ,;;,;;,ショゾク;ジム;ショ,ショゾクジムショ,所属事務所
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9286,6 +9685,7 @@
 
 # newdoc id = dev-s403
 # sent_id = dev-s403
+# parallel_id = jagsdluw/dev403
 # text = 狭いお店だけど、パンだけじゃなく結構変わったかりんとうなんかも売ってました。
 1	狭い	狭い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セマイ,狭い,狭い,狭い,セマイ,,,セマイ,セマイ,狭い
 2	お店	御店	NOUN	名詞-普通名詞-一般	_	16	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセ,御;店,お;店,お;店,オ;ミセ,;,;,オ;ミセ,オミセ,御店
@@ -9310,6 +9710,7 @@
 
 # newdoc id = dev-s404
 # sent_id = dev-s404
+# parallel_id = jagsdluw/dev404
 # text = 拉致監禁強制改宗は犯罪だ!
 1	拉致監禁強制改宗	拉致監禁強制改宗	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ラチ;カンキン;キョウセイ;カイシュウ,拉致;監禁;強制;改宗,拉致;監禁;強制;改宗,拉致;監禁;強制;改宗,ラチ;カンキン;キョーセー;カイシュー,;;;,;;;,ラチ;カンキン;キョウセイ;カイシュウ,ラチカンキンキョウセイカイシュウ,拉致監禁強制改宗
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9319,6 +9720,7 @@
 
 # newdoc id = dev-s405
 # sent_id = dev-s405
+# parallel_id = jagsdluw/dev405
 # text = 京成本線町屋駅-千住大橋駅の間に存在していた。
 1	京成本線町屋駅-千住大橋駅	京成本線町家駅-千住大橋駅	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイセイ;ホンセン;マチヤ;エキ;;センジュ;オオハシ;エキ,京成;本線;町家;駅;-;センジュ;大橋;駅,京成;本線;町屋;駅;-;千住;大橋;駅,京成;本線;町屋;駅;-;千住;大橋;駅,ケーセー;ホンセン;マチヤ;エキ;;センジュ;オーハシ;エキ,;;;;;;;,;;;;;;;,ケイセイ;ホンセン;マチヤ;エキ;;センジュ;オオハシ;エキ,ケイセイホンセンマチヤエキセンジュオオハシエキ,京成本線町家駅-千住大橋駅
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9331,6 +9733,7 @@
 
 # newdoc id = dev-s406
 # sent_id = dev-s406
+# parallel_id = jagsdluw/dev406
 # text = 製品生産者たちはまだ自らのウェブサイトで広告するという手段を持っておらず、宣伝には「AOL Key words」を利用していた。
 1	製品生産者たち	製品生産者達	NOUN	名詞-普通名詞-一般	_	12	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイヒン;セイサン;シャ;タチ,製品;生産;者;達,製品;生産;者;たち,製品;生産;者;たち,セーヒン;セーサン;シャ;タチ,;;;,;;;,セイヒン;セイサン;シャ;タチ,セイヒンセイサンシャタチ,製品生産者達
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9361,6 +9764,7 @@
 
 # newdoc id = dev-s407
 # sent_id = dev-s407
+# parallel_id = jagsdluw/dev407
 # text = 1819年から1821年までの間にヴィルヘルムス運河が造られ、特にハイルブロンナー製紙によって発展した工業地域の立地に寄与した。
 1	1819年	1819年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;イチ;キュウ;ネン,一;八;一;九;年,1;8;1;9;年,1;8;1;9;年,イチ;ハチ;イチ;キュー;ネン,;;;;,;;;;,イチ;ハチ;イチ;キュウ;ネン,イチハチイチキュウネン,1819年
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -9389,6 +9793,7 @@
 
 # newdoc id = dev-s408
 # sent_id = dev-s408
+# parallel_id = jagsdluw/dev408
 # text = 教団内では“科学技術省次官”の地位にありました。
 1	教団内	教団内	NOUN	名詞-普通名詞-一般	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウダン;ナイ,教団;内,教団;内,教団;内,キョーダン;ナイ,;,;,キョウダン;ナイ,キョウダンナイ,教団内
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9406,6 +9811,7 @@
 
 # newdoc id = dev-s409
 # sent_id = dev-s409
+# parallel_id = jagsdluw/dev409
 # text = 強い香りを持つ植物である。
 1	強い	強い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツヨイ,強い,強い,強い,ツヨイ,,,ツヨイ,ツヨイ,強い
 2	香り	香り	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カオリ,香り,香り,香り,カオリ,,,カオリ,カオリ,香り
@@ -9417,6 +9823,7 @@
 
 # newdoc id = dev-s410
 # sent_id = dev-s410
+# parallel_id = jagsdluw/dev410
 # text = 女性も大丈夫です。
 1	女性	女性	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョセイ,女性,女性,女性,ジョセー,,,ジョセイ,ジョセイ,女性
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -9426,6 +9833,7 @@
 
 # newdoc id = dev-s411
 # sent_id = dev-s411
+# parallel_id = jagsdluw/dev411
 # text = 従来予想は微増の19億円。
 1	従来予想	従来予想	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウライ;ヨソウ,従来;予想,従来;予想,従来;予想,ジューライ;ヨソー,;,;,ジュウライ;ヨソウ,ジュウライヨソウ,従来予想
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9436,6 +9844,7 @@
 
 # newdoc id = dev-s412
 # sent_id = dev-s412
+# parallel_id = jagsdluw/dev412
 # text = この方は,本紙<沖縄知事選めぐり大江議員と幸福実現党が対立>登場された方です。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	方	方	NOUN	名詞-普通名詞-一般	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カタ,方,方,方,カタ,,,カタ,カタ,方
@@ -9460,6 +9869,7 @@
 
 # newdoc id = dev-s413
 # sent_id = dev-s413
+# parallel_id = jagsdluw/dev413
 # text = 1708年にカルロが死ぬと、マントヴァ公位は廃位され、ゴンザーガ家は永久にマントヴァを失い、以後ハプスブルク家支配となった。
 1	1708年	1708年	NUM	名詞-数詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ナナ;ゼロ;ハチ;ネン,一;七;ゼロ;八;年,1;7;0;8;年,1;7;0;8;年,イチ;ナナ;ゼロ;ハチ;ネン,;;;;,;;;;,イチ;ナナ;ゼロ;ハチ;ネン,イチナナゼロハチネン,1708年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9490,6 +9900,7 @@
 
 # newdoc id = dev-s414
 # sent_id = dev-s414
+# parallel_id = jagsdluw/dev414
 # text = ちょっとした遊具もあるので小さな子どもさんもいいと思います。
 1	ちょっとし	一寸する	VERB	動詞-一般-サ行変格	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョット;スル,一寸;為る,ちょっと;し,ちょっと;する,チョット;シ,;,;,チョット;スル,チョットスル,一寸する
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -9508,6 +9919,7 @@
 
 # newdoc id = dev-s415
 # sent_id = dev-s415
+# parallel_id = jagsdluw/dev415
 # text = SEXが強すぎるのかも知れない。
 1	SEX	SEX	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セックス,セックス,SEX,SEX,セックス,,,セックス,セックス,SEX
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9518,6 +9930,7 @@
 
 # newdoc id = dev-s416
 # sent_id = dev-s416
+# parallel_id = jagsdluw/dev416
 # text = 所属事務所はBreath。
 1	所属事務所	所属事務所	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショゾク;ジム;ショ,所属;事務;所,所属;事務;所,所属;事務;所,ショゾク;ジム;ショ,;;,;;,ショゾク;ジム;ショ,ショゾクジムショ,所属事務所
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9526,6 +9939,7 @@
 
 # newdoc id = dev-s417
 # sent_id = dev-s417
+# parallel_id = jagsdluw/dev417
 # text = 紳助さんは、先月23日の引退記者会見で、十数年前にあったトラブルを解決してくれたのが、暴力団関係者だったことを明らかにした。
 1	紳助さん	紳助さん	PROPN	名詞-固有名詞-人名-名	_	29	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンスケ;サン,シンスケ;さん,紳助;さん,紳助;さん,シンスケ;サン,;,;,シンスケ;サン,シンスケサン,紳助さん
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9561,6 +9975,7 @@
 
 # newdoc id = dev-s418
 # sent_id = dev-s418
+# parallel_id = jagsdluw/dev418
 # text = 自分の身は自分で守ろう!
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9573,6 +9988,7 @@
 
 # newdoc id = dev-s419
 # sent_id = dev-s419
+# parallel_id = jagsdluw/dev419
 # text = 清代は湖北省が置かれ、そのまま現代の行政区分になっている。
 1	清代	清代	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンダイ,清代,清代,清代,シンダイ,,,シンダイ,シンダイ,清代
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9593,6 +10009,7 @@
 
 # newdoc id = dev-s420
 # sent_id = dev-s420
+# parallel_id = jagsdluw/dev420
 # text = 戦死後に彼の妻から譲られる「ナイトシールド」は、彼の形見でもある。
 1	戦死後	戦死後	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センシ;ゴ,戦死;後,戦死;後,戦死;後,センシ;ゴ,;,;,センシ;ゴ,センシゴ,戦死後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9615,6 +10032,7 @@
 
 # newdoc id = dev-s421
 # sent_id = dev-s421
+# parallel_id = jagsdluw/dev421
 # text = 建造物も仏像も中国明朝時代を偲ばせています。
 1	建造物	建造物	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケンゾウ;ブツ,建造;物,建造;物,建造;物,ケンゾー;ブツ,;,;,ケンゾウ;ブツ,ケンゾウブツ,建造物
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -9630,6 +10048,7 @@
 
 # newdoc id = dev-s422
 # sent_id = dev-s422
+# parallel_id = jagsdluw/dev422
 # text = これからは花こうさんをずっと利用したいと思っています。
 1	これ	此れ	PRON	代名詞	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -9647,6 +10066,7 @@
 
 # newdoc id = dev-s423
 # sent_id = dev-s423
+# parallel_id = jagsdluw/dev423
 # text = また、この番組は公開録音スタイルがとられており、当初は改装前の第3スタジオでギャラリーも5~6人だったが、その後常時10人以上集まるように更にギャラリーの数が増えたため広い第1スタジオに移って収録するようになった。
 1	また	又	CCONJ	接続詞	_	48	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9701,6 +10121,7 @@
 
 # newdoc id = dev-s424
 # sent_id = dev-s424
+# parallel_id = jagsdluw/dev424
 # text = 同コーナーの放送開始と終了時には、この定点カメラの映像とは別に部屋全体を映す別の固定カメラの映像を使用している。
 1	同コーナー	同コーナー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;コーナー,同;コーナー,同;コーナー,同;コーナー,ドー;コーナー,;,;,ドウ;コーナー,ドウコーナー,同コーナー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9733,6 +10154,7 @@
 
 # newdoc id = dev-s425
 # sent_id = dev-s425
+# parallel_id = jagsdluw/dev425
 # text = この曲は、1964年のテレビドラマ版の主題歌であると誤解されやすいが、ドラマで使用されたのはシンプルなインストルメンタルBGM曲のみで、青山和子が歌うこのレコード企画とは全く別のプロジェクトである。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	曲	曲	NOUN	名詞-普通名詞-一般	_	12	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョク,曲,曲,曲,キョク,,,キョク,キョク,曲
@@ -9777,6 +10199,7 @@
 
 # newdoc id = dev-s426
 # sent_id = dev-s426
+# parallel_id = jagsdluw/dev426
 # text = ローズクランズはイウカでは縮小されたミシシッピ軍を率い、コリンスではテネシー軍からの2個師団の支援を受けた。
 1	ローズクランズ	ローズクランズ	PROPN	名詞-固有名詞-人名-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ローズクランズ,ローズクランズ,ローズクランズ,ローズクランズ,ローズクランズ,,,ローズクランズ,ローズクランズ,ローズクランズ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9806,6 +10229,7 @@
 
 # newdoc id = dev-s427
 # sent_id = dev-s427
+# parallel_id = jagsdluw/dev427
 # text = バニラアイスが大好物。
 1	バニラアイス	バニラアイス	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バニラ;アイス,バニラ;アイス,バニラ;アイス,バニラ;アイス,バニラ;アイス,;,;,バニラ;アイス,バニラアイス,バニラアイス
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9814,6 +10238,7 @@
 
 # newdoc id = dev-s428
 # sent_id = dev-s428
+# parallel_id = jagsdluw/dev428
 # text = インターネットにおける個人の報道活動の意義と実状を全く無視した,あまりに時代錯誤な最高裁の判決を,本紙は強く非難します。
 1	インターネット	インターネット	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=インターネット,インターネット,インターネット,インターネット,インターネット,,,インターネット,インターネット,インターネット
 2	における	における	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;オク;リ,に;於く;り,に;おけ;る,に;おく;り,ニ;オケ;ル,;;,;;,ニ;オク;リ,ニオケル,における
@@ -9847,6 +10272,7 @@
 
 # newdoc id = dev-s429
 # sent_id = dev-s429
+# parallel_id = jagsdluw/dev429
 # text = しかし、正恩氏は軍大将として登場し、活動を部隊視察から始めた。
 1	しかし	然し	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9866,6 +10292,7 @@
 
 # newdoc id = dev-s430
 # sent_id = dev-s430
+# parallel_id = jagsdluw/dev430
 # text = その3分の2近くが統一教会関係者のようでした。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	3分の2近く	3分の2近く	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ブン;ノ;ニ;チカク,三;分;の;二;近く,3;分;の;2;近く,3;分;の;2;近く,サン;ブン;ノ;ニ;チカク,;;;;,;;;;,サン;ブン;ノ;ニ;チカク,サンブンノニチカク,3分の2近く
@@ -9879,6 +10306,7 @@
 
 # newdoc id = dev-s431
 # sent_id = dev-s431
+# parallel_id = jagsdluw/dev431
 # text = 状況によっては統一教会擁護の論陣を張ろうと思っています。
 1	状況	状況	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョウキョウ,状況,状況,状況,ジョーキョー,,,ジョウキョウ,ジョウキョウ,状況
 2	によって	によって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;テ,に;因る;て,に;よっ;て,に;よる;て,ニ;ヨッ;テ,;;,;;,ニ;ヨル;テ,ニヨッテ,によって
@@ -9896,6 +10324,7 @@
 
 # newdoc id = dev-s432
 # sent_id = dev-s432
+# parallel_id = jagsdluw/dev432
 # text = 治療はステロイドの内服が中心だという。
 1	治療	治療	NOUN	名詞-普通名詞-一般	_	7	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チリョウ,治療,治療,治療,チリョー,,,チリョウ,チリョウ,治療
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9911,6 +10340,7 @@
 
 # newdoc id = dev-s433
 # sent_id = dev-s433
+# parallel_id = jagsdluw/dev433
 # text = 彼女は、ロサンゼルスでのより高いステータスを得られる仕事のオファーを受け入れたのだった。
 1	彼女	彼女	PRON	代名詞	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カノジョ,彼女,彼女,彼女,カノジョ,,,カノジョ,カノジョ,彼女
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9936,6 +10366,7 @@
 
 # newdoc id = dev-s434
 # sent_id = dev-s434
+# parallel_id = jagsdluw/dev434
 # text = 「唯識三十頌」では上述の八識説を唱え、部分的に深層心理学的傾向や生物学的傾向を示した。
 1	「	「	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	唯識	唯識	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ユイシキ,唯識,唯識,唯識,ユイシキ,,,ユイシキ,ユイシキ,唯識
@@ -9961,6 +10392,7 @@
 
 # newdoc id = dev-s435
 # sent_id = dev-s435
+# parallel_id = jagsdluw/dev435
 # text = 1928年10月から1929年11月にかけて初代駐トルコ大使である小幡酉吉の帰朝にともない臨時代理大使を務め、この間に参事官へと昇格した。
 1	1928年	1928年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;ニ;ハチ;ネン,一;九;二;八;年,1;9;2;8;年,1;9;2;8;年,イチ;キュー;ニ;ハチ;ネン,;;;;,;;;;,イチ;キュウ;ニ;ハチ;ネン,イチキュウニハチネン,1928年
 2	10月	10月	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウ;ガツ,十;月,10;月,10;月,ジュー;ガツ,;,;,ジュウ;ガツ,ジュウガツ,10月
@@ -9993,6 +10425,7 @@
 
 # newdoc id = dev-s436
 # sent_id = dev-s436
+# parallel_id = jagsdluw/dev436
 # text = 彼女たちは「負け犬」を自称しながら、その実オタクを恋愛対象にしようとせずヒエラルキーの下位におき、自己の精神的安寧を得ているに過ぎず、そのオタクを否定する価値観も「恋愛資本主義」に洗脳されているに過ぎないと主張した。
 1	彼女たち	彼女達	PRON	代名詞	_	49	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カノジョ;タチ,彼女;達,彼女;たち,彼女;たち,カノジョ;タチ,;,;,カノジョ;タチ,カノジョタチ,彼女達
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10048,6 +10481,7 @@
 
 # newdoc id = dev-s437
 # sent_id = dev-s437
+# parallel_id = jagsdluw/dev437
 # text = 民主党公約があてにならないのはまだある。
 1	民主党公約	民主党公約	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミンシュ;トウ;コウヤク,民主;党;公約,民主;党;公約,民主;党;公約,ミンシュ;トー;コーヤク,;;,;;,ミンシュ;トウ;コウヤク,ミンシュトウコウヤク,民主党公約
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -10063,6 +10497,7 @@
 
 # newdoc id = dev-s438
 # sent_id = dev-s438
+# parallel_id = jagsdluw/dev438
 # text = だが、最後は仲間達の願いを受けて復活したメビウスのメビュームシュートとウルトラ兄弟の合体光線を受けて再び消滅した。
 1	だが	だが	CCONJ	接続詞	_	24	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;ガ,だ;が,だ;が,だ;が,ダ;ガ,;,;,ダ;ガ,ダガ,だが
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10093,6 +10528,7 @@
 
 # newdoc id = dev-s439
 # sent_id = dev-s439
+# parallel_id = jagsdluw/dev439
 # text = しかしプラセボ効果は,患者を騙すからこそ生まれる効果です。
 1	しかし	然し	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	プラセボ効果	プラセボ効果	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=プラシーボ;コウカ,プラシーボ;効果,プラセボ;効果,プラセボ;効果,プラセボ;コーカ,;,;,プラセボ;コウカ,プラセボコウカ,プラセボ効果
@@ -10110,6 +10546,7 @@
 
 # newdoc id = dev-s440
 # sent_id = dev-s440
+# parallel_id = jagsdluw/dev440
 # text = 遊学館は県予選会後に3年の亀樋哲生、吉田圭佑の両選手ら主力3人が故障して欠場した。
 1	遊学館	遊学館	PROPN	名詞-固有名詞-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユウガク;カン,遊学;館,遊学;館,遊学;館,ユーガク;カン,;,;,ユウガク;カン,ユウガクカン,遊学館
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10133,6 +10570,7 @@
 
 # newdoc id = dev-s441
 # sent_id = dev-s441
+# parallel_id = jagsdluw/dev441
 # text = 属品として負紐付きの収容嚢が存在し、行軍時などには狙撃眼鏡を銃から外しこれに収容した。
 1	属品	属品	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゾクヒン,属品,属品,属品,ゾクヒン,,,ゾクヒン,ゾクヒン,属品
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -10159,6 +10597,7 @@
 
 # newdoc id = dev-s442
 # sent_id = dev-s442
+# parallel_id = jagsdluw/dev442
 # text = 宇高航路においては、初の車載客船でもあった。
 1	宇高航路	宇高航路	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウコウ;コウロ,宇高;航路,宇高;航路,宇高;航路,ウコー;コーロ,;,;,ウコウ;コウロ,ウコウコウロ,宇高航路
 2	において	において	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;オク;テ,に;於く;て,に;おい;て,に;おく;て,ニ;オイ;テ,;;,;;,ニ;オク;テ,ニオイテ,において
@@ -10173,6 +10612,7 @@
 
 # newdoc id = dev-s443
 # sent_id = dev-s443
+# parallel_id = jagsdluw/dev443
 # text = 車の販売、板金、塗装等を行っています。
 1	車	車	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クルマ,車,車,車,クルマ,,,クルマ,クルマ,車
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10189,6 +10629,7 @@
 
 # newdoc id = dev-s444
 # sent_id = dev-s444
+# parallel_id = jagsdluw/dev444
 # text = 柱の円周は、大人5人が手を伸ばして抱えても届かないくらいの大きさである。
 1	柱	柱	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハシラ,柱,柱,柱,ハシラ,,,ハシラ,ハシラ,柱
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10215,6 +10656,7 @@
 
 # newdoc id = dev-s445
 # sent_id = dev-s445
+# parallel_id = jagsdluw/dev445
 # text = 有名な先生方が講師として来られています。
 1	有名	有名	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユウメイ,有名,有名,有名,ユーメー,,,ユウメイ,ユウメイ,有名
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -10230,6 +10672,7 @@
 
 # newdoc id = dev-s446
 # sent_id = dev-s446
+# parallel_id = jagsdluw/dev446
 # text = 悲観的になるとは,階級的意識がないことであるが,本来敵であるものを味方と思った時,その失望が悲観的にさせる。
 1	悲観的	悲観的	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒカン;テキ,悲観;的,悲観;的,悲観;的,ヒカン;テキ,;,;,ヒカン;テキ,ヒカンテキ,悲観的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -10266,6 +10709,7 @@
 
 # newdoc id = dev-s447
 # sent_id = dev-s447
+# parallel_id = jagsdluw/dev447
 # text = 好物はマシュマロ。
 1	好物	好物	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウブツ,好物,好物,好物,コーブツ,,,コウブツ,コウブツ,好物
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10274,6 +10718,7 @@
 
 # newdoc id = dev-s448
 # sent_id = dev-s448
+# parallel_id = jagsdluw/dev448
 # text = 私は,幸福の施設しか知らなくて恐縮ですが,安心して過ごせる所だと思う。
 1	私	私	PRON	代名詞	_	21	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10300,6 +10745,7 @@
 
 # newdoc id = dev-s449
 # sent_id = dev-s449
+# parallel_id = jagsdluw/dev449
 # text = こじんまりした、アットホームな良い雰囲気で食事が出来ます。
 1	こじんまりし	小ぢんまりする	VERB	動詞-一般-サ行変格	_	7	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コヂンマリ;スル,小ぢんまり;為る,こじんまり;し,こじんまり;する,コジンマリ;シ,;,;,コヂンマリ;スル,コヂンマリスル,小ぢんまりする
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -10317,6 +10763,7 @@
 
 # newdoc id = dev-s450
 # sent_id = dev-s450
+# parallel_id = jagsdluw/dev450
 # text = クアラルンプールで開催されるマラソンはこのほか「KLマラソン」など、複数の大会がある。
 1	クアラルンプール	クアラルンプール	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クアラルンプール,クアラ・ルンプール,クアラルンプール,クアラルンプール,クアラルンプール,,,クアラルンプール,クアラルンプール,クアラルンプール
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -10340,6 +10787,7 @@
 
 # newdoc id = dev-s451
 # sent_id = dev-s451
+# parallel_id = jagsdluw/dev451
 # text = SF作品などで、宇宙船の航行が著しく困難な空間に「サルガッソ」の名が冠されることがある。
 1	SF作品	SF作品	NOUN	名詞-普通名詞-一般	_	20	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エスエフ;サクヒン,ＳＦ;作品,SF;作品,SF;作品,エスエフ;サクヒン,;,;,エスエフ;サクヒン,エスエフサクヒン,SF作品
 2	など	など	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナド,など,など,など,ナド,,,ナド,ナド,など
@@ -10367,6 +10815,7 @@
 
 # newdoc id = dev-s452
 # sent_id = dev-s452
+# parallel_id = jagsdluw/dev452
 # text = 英語の公用語化云々よりも、まずは国際感覚を身につける社員教育の方が優先すべきだろう。
 1	英語	英語	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エイゴ,英語,英語,英語,エーゴ,,,エイゴ,エイゴ,英語
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10392,6 +10841,7 @@
 
 # newdoc id = dev-s453
 # sent_id = dev-s453
+# parallel_id = jagsdluw/dev453
 # text = 本作より昔の話である『ドラゴンクエストIII』の時代では魔物に滅ぼされておらず活気のある町として存在していた。
 1	本作	本作	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンサク,本作,本作,本作,ホンサク,,,ホンサク,ホンサク,本作
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -10424,6 +10874,7 @@
 
 # newdoc id = dev-s454
 # sent_id = dev-s454
+# parallel_id = jagsdluw/dev454
 # text = 2009年11月28日、サードアルバム、『HellChose Me 』のレコーディングを終える。
 1	2009年	2009年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;キュウ;ネン,二;ゼロ;ゼロ;九;年,2;0;0;9;年,2;0;0;9;年,ニ;ゼロ;ゼロ;キュー;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;キュウ;ネン,ニゼロゼロキュウネン,2009年
 2	11月	11月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;イチ;ガツ,一;一;月,1;1;月,1;1;月,イチ;イチ;ガツ,;;,;;,イチ;イチ;ガツ,イチイチガツ,11月
@@ -10442,6 +10893,7 @@
 
 # newdoc id = dev-s455
 # sent_id = dev-s455
+# parallel_id = jagsdluw/dev455
 # text = 今年7月から、宝塚歌劇の専門チャンネル「タカラヅカ・スカイ・ステージ」の案内役スカイ・フェアリーズを務めている。
 1	今年	今年	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=コトシ,今年,今年,今年,コトシ,,,コトシ,コトシ,今年
 2	7月	7月	NUM	名詞-数詞	_	15	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シチ;ガツ,七;月,7;月,7;月,シチ;ガツ,;,;,シチ;ガツ,シチガツ,7月
@@ -10463,6 +10915,7 @@
 
 # newdoc id = dev-s456
 # sent_id = dev-s456
+# parallel_id = jagsdluw/dev456
 # text = 取締機によって撮影されると、数日から遅くとも30日以内に警察から当該車両の所有者に出頭通知が送付される。
 1	取締機	取り締まり機	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トリシマリ;キ,取り締まり;機,取締;機,取締;機,トリシマリ;キ,;,;,トリシマリ;キ,トリシマリキ,取り締まり機
 2	によって	によって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;テ,に;因る;て,に;よっ;て,に;よる;て,ニ;ヨッ;テ,;;,;;,ニ;ヨル;テ,ニヨッテ,によって
@@ -10490,6 +10943,7 @@
 
 # newdoc id = dev-s457
 # sent_id = dev-s457
+# parallel_id = jagsdluw/dev457
 # text = 享年84。
 1	享年	享年	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=キョウネン,享年,享年,享年,キョーネン,,,キョウネン,キョウネン,享年
 2	84	84	NUM	名詞-数詞	_	0	root	_	BunsetuBILabel=I|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ハチ;ヨン,八;四,8;4,8;4,ハチ;ヨン,;,;,ハチ;ヨン,ハチヨン,84
@@ -10497,6 +10951,7 @@
 
 # newdoc id = dev-s458
 # sent_id = dev-s458
+# parallel_id = jagsdluw/dev458
 # text = 当初は熊田の傍若無人ぶりにブーイングの嵐だった観衆も、「まともに戦うのなら」という条件付きで熊田応援に回り、場内は熊田コールと仲本コールに二分された。
 1	当初	当初	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10539,6 +10994,7 @@
 
 # newdoc id = dev-s459
 # sent_id = dev-s459
+# parallel_id = jagsdluw/dev459
 # text = 脳梗塞の症状で入院していた60歳代の男性が、食事で出されたおかゆを喉に詰まらせた。
 1	脳梗塞	脳梗塞	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノウ;コウソク,脳;梗塞,脳;梗塞,脳;梗塞,ノー;コーソク,;,;,ノウ;コウソク,ノウコウソク,脳梗塞
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10568,6 +11024,7 @@
 
 # newdoc id = dev-s460
 # sent_id = dev-s460
+# parallel_id = jagsdluw/dev460
 # text = 幼いゆえか、大人っぽさに憧れている。
 1	幼い	幼い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オサナイ,幼い,幼い,幼い,オサナイ,,,オサナイ,オサナイ,幼い
 2	ゆえ	故	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユエ,故,ゆえ,ゆえ,ユエ,,,ユエ,ユエ,故
@@ -10581,6 +11038,7 @@
 
 # newdoc id = dev-s461
 # sent_id = dev-s461
+# parallel_id = jagsdluw/dev461
 # text = ネタ番組のように、3段オチを考えるコーナーではない。
 1	ネタ番組	ねた番組	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネタ;バングミ,ねた;番組,ネタ;番組,ネタ;番組,ネタ;バングミ,;,;,ネタ;バングミ,ネタバングミ,ねた番組
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10596,6 +11054,7 @@
 
 # newdoc id = dev-s462
 # sent_id = dev-s462
+# parallel_id = jagsdluw/dev462
 # text = バター珈琲の味が好きな方にはお薦めだが、外連味の無い、王道の珈琲を求める方には向かない。
 1	バター珈琲	バターコーヒー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バター;コーヒー,バター;コーヒー,バター;珈琲,バター;珈琲,バター;コーヒー,;,;,バター;コーヒー,バターコーヒー,バターコーヒー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10628,6 +11087,7 @@
 
 # newdoc id = dev-s463
 # sent_id = dev-s463
+# parallel_id = jagsdluw/dev463
 # text = 対称性を評価するパターン、生え際を評価するパターン、鼻や口の大きさを評価するパターンなどがある。
 1	対称性	対称性	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイショウ;セイ,対称;性,対称;性,対称;性,タイショー;セー,;,;,タイショウ;セイ,タイショウセイ,対称性
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -10654,6 +11114,7 @@
 
 # newdoc id = dev-s465
 # sent_id = dev-s465
+# parallel_id = jagsdluw/dev465
 # text = ハムスターの診察をしてくれる病院は少なくとても助かりました。
 1	ハムスター	ハムスター	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハムスター,ハムスター,ハムスター,ハムスター,ハムスター,,,ハムスター,ハムスター,ハムスター
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10672,6 +11133,7 @@
 
 # newdoc id = dev-s466
 # sent_id = dev-s466
+# parallel_id = jagsdluw/dev466
 # text = 休養を挟んで京成杯オータムハンデキャップに出走したが、5着に敗れた。
 1	休養	休養	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウヨウ,休養,休養,休養,キューヨー,,,キュウヨウ,キュウヨウ,休養
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -10691,6 +11153,7 @@
 
 # newdoc id = dev-s467
 # sent_id = dev-s467
+# parallel_id = jagsdluw/dev467
 # text = ファイブブラックの個人武器。
 1	ファイブブラック	ファイブブラック	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ファイブ;ブラック,ファイブ;ブラック,ファイブ;ブラック,ファイブ;ブラック,ファイブ;ブラック,;,;,ファイブ;ブラック,ファイブブラック,ファイブブラック
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10699,6 +11162,7 @@
 
 # newdoc id = dev-s468
 # sent_id = dev-s468
+# parallel_id = jagsdluw/dev468
 # text = 朝まで飲み会コースというのがあり、4品で1500円くらいのようですよ。
 1	朝	朝	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アサ,朝,朝,朝,アサ,,,アサ,アサ,朝
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -10720,6 +11184,7 @@
 
 # newdoc id = dev-s469
 # sent_id = dev-s469
+# parallel_id = jagsdluw/dev469
 # text = 同国の国営テレビは、ムバラク氏が公金横領や反体制デモ参加者殺害などの疑いで検察当局の聴取を受けている最中に心臓発作で倒れ、入院先で集中治療を受けていると報じた。
 1	同国	同国	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウコク,同国,同国,同国,ドーコク,,,ドウコク,ドウコク,同国
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10760,6 +11225,7 @@
 
 # newdoc id = dev-s470
 # sent_id = dev-s470
+# parallel_id = jagsdluw/dev470
 # text = 通称・但馬、和泉、又左衛門。
 1	通称	通称	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツウショウ,通称,通称,通称,ツーショー,,,ツウショウ,ツウショウ,通称
 2	・	・	SYM	補助記号-一般	_	1	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,,・
@@ -10772,6 +11238,7 @@
 
 # newdoc id = dev-s471
 # sent_id = dev-s471
+# parallel_id = jagsdluw/dev471
 # text = 真っ黒のタレだけど美味しいよ。
 1	真っ黒	真っ黒	ADJ	形状詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マックロ,真っ黒,真っ黒,真っ黒,マックロ,,,マックロ,マックロ,真っ黒
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10784,6 +11251,7 @@
 
 # newdoc id = dev-s472
 # sent_id = dev-s472
+# parallel_id = jagsdluw/dev472
 # text = かつて虐めにあっていた大和の中学時代の同級生。
 1	かつて	嘗て	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カツテ,嘗て,かつて,かつて,カツテ,,,カツテ,カツテ,嘗て
 2	虐め	苛め	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イジメ,苛め,虐め,虐め,イジメ,,,イジメ,イジメ,苛め
@@ -10800,6 +11268,7 @@
 
 # newdoc id = dev-s473
 # sent_id = dev-s473
+# parallel_id = jagsdluw/dev473
 # text = すると店内がかわいくて気に入りパ—マとカットをしてもらいました。
 1	すると	すると	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スル;ト,為る;と,する;と,する;と,スル;ト,;,;,スル;ト,スルト,すると
 2	店内	店内	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンナイ,店内,店内,店内,テンナイ,,,テンナイ,テンナイ,店内
@@ -10821,6 +11290,7 @@
 
 # newdoc id = dev-s474
 # sent_id = dev-s474
+# parallel_id = jagsdluw/dev474
 # text = 2010年10月17日にインディアナ州で前立腺がんで亡くなった。
 1	2010年	2010年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;ゼロ;ネン,二;ゼロ;一;ゼロ;年,2;0;1;0;年,2;0;1;0;年,ニ;ゼロ;イチ;ゼロ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;ゼロ;ネン,ニゼロイチゼロネン,2010年
 2	10月	10月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ジュウ;ガツ,十;月,10;月,10;月,ジュー;ガツ,;,;,ジュウ;ガツ,ジュウガツ,10月
@@ -10836,6 +11306,7 @@
 
 # newdoc id = dev-s475
 # sent_id = dev-s475
+# parallel_id = jagsdluw/dev475
 # text = 劉裕の異母弟にあたる。
 1	劉裕	劉裕	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リュウユウ,リュウユウ,劉裕,劉裕,リューユー,,,リュウユウ,リュウユウ,劉裕
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10846,6 +11317,7 @@
 
 # newdoc id = dev-s476
 # sent_id = dev-s476
+# parallel_id = jagsdluw/dev476
 # text = 看護師不足が問題となる中、高梁市が看護師を目指す学生を対象にした看護師養成奨学金制度をつくり、4月から奨学生の募集を始める。
 1	看護師不足	看護師不足	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンゴ;シ;フソク,看護;師;不足,看護;師;不足,看護;師;不足,カンゴ;シ;ブソク,;;,;;,カンゴ;シ;フソク,カンゴシブソク,看護師不足
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -10880,6 +11352,7 @@
 
 # newdoc id = dev-s477
 # sent_id = dev-s477
+# parallel_id = jagsdluw/dev477
 # text = 1821年から1867年までの長きに亘ってモスクワ府主教位にあった。
 1	1821年	1821年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;ニ;イチ;ネン,一;八;二;一;年,1;8;2;1;年,1;8;2;1;年,イチ;ハチ;ニ;イチ;ネン,;;;;,;;;;,イチ;ハチ;ニ;イチ;ネン,イチハチニイチネン,1821年
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -10896,6 +11369,7 @@
 
 # newdoc id = dev-s478
 # sent_id = dev-s478
+# parallel_id = jagsdluw/dev478
 # text = でも重症じゃないので絶対に治ると信じて治療に専念し、きれいな女性になりたいとの想いを込め、決断しました。
 1	でも	でも	CCONJ	接続詞	_	27	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;モ,で;も,で;も,で;も,デ;モ,;,;,デ;モ,デモ,でも
 2	重症	重症	NOUN	名詞-普通名詞-一般	_	7	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウショウ,重症,重症,重症,ジューショー,,,ジュウショウ,ジュウショウ,重症
@@ -10930,6 +11404,7 @@
 
 # newdoc id = dev-s479
 # sent_id = dev-s479
+# parallel_id = jagsdluw/dev479
 # text = この風景を学生が見たら大喜びをするに違いない。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	風景	風景	NOUN	名詞-普通名詞-一般	_	6	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フウケイ,風景,風景,風景,フーケー,,,フウケイ,フウケイ,風景
@@ -10946,6 +11421,7 @@
 
 # newdoc id = dev-s480
 # sent_id = dev-s480
+# parallel_id = jagsdluw/dev480
 # text = 現在の書店「丸善」だ。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10958,6 +11434,7 @@
 
 # newdoc id = dev-s481
 # sent_id = dev-s481
+# parallel_id = jagsdluw/dev481
 # text = ここの居酒屋のメニューで目を引いたのは、やっぱりコラーゲン鍋でしょ!
 1	ここ	此処	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10979,6 +11456,7 @@
 
 # newdoc id = dev-s482
 # sent_id = dev-s482
+# parallel_id = jagsdluw/dev482
 # text = 大きな一つ目に小さな胴体、細い手足、とんがり帽子という異形だが何処かコミカルにも見える姿をとる。
 1	大きな	大きな	ADJ	連体詞	_	3	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキナ,大きな,大きな,大きな,オーキナ,,,オオキナ,オオキナ,大きな
 2	一つ	一つ	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ヒト;ツ,一;つ,一;つ,一;つ,ヒト;ツ,;,;,ヒト;ツ,ヒトツ,一つ
@@ -11008,6 +11486,7 @@
 
 # newdoc id = dev-s483
 # sent_id = dev-s483
+# parallel_id = jagsdluw/dev483
 # text = ここから、単なる文字列よりも高機能なクラスなどをロープと呼ぶことがある。
 1	ここ	此処	PRON	代名詞	_	15	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -11029,6 +11508,7 @@
 
 # newdoc id = dev-s484
 # sent_id = dev-s484
+# parallel_id = jagsdluw/dev484
 # text = 柔道人生は終わるまで安心できない。
 1	柔道人生	柔道人生	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウドウ;ジンセイ,柔道;人生,柔道;人生,柔道;人生,ジュードー;ジンセー,;,;,ジュウドウ;ジンセイ,ジュウドウジンセイ,柔道人生
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11040,6 +11520,7 @@
 
 # newdoc id = dev-s485
 # sent_id = dev-s485
+# parallel_id = jagsdluw/dev485
 # text = 雪に足をとられないようにするために足裏に取り付けられるミニスキー。
 1	雪	雪	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユキ,雪,雪,雪,ユキ,,,ユキ,ユキ,雪
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11061,6 +11542,7 @@
 
 # newdoc id = dev-s486
 # sent_id = dev-s486
+# parallel_id = jagsdluw/dev486
 # text = 作品にはオペラ、バレエ、映画音楽、劇場音楽があり、リトアニア・ソビエト社会主義共和国の国歌も作曲している。
 1	作品	作品	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サクヒン,作品,作品,作品,サクヒン,,,サクヒン,サクヒン,作品
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11085,12 +11567,14 @@
 
 # newdoc id = dev-s487
 # sent_id = dev-s487
+# parallel_id = jagsdluw/dev487
 # text = 静岡県出身。
 1	静岡県出身	静岡県出身	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=シズオカ;ケン;シュッシン,シズオカ;県;出身,静岡;県;出身,静岡;県;出身,シズオカ;ケン;シュッシン,;;,;;,シズオカ;ケン;シュッシン,シズオカケンシュッシン,静岡県出身
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s488
 # sent_id = dev-s488
+# parallel_id = jagsdluw/dev488
 # text = あと、びっくりなのが、玄関前にペンギンが3羽。
 1	あと	後	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アト,後,あと,あと,アト,,,アト,アト,後
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -11108,6 +11592,7 @@
 
 # newdoc id = dev-s489
 # sent_id = dev-s489
+# parallel_id = jagsdluw/dev489
 # text = 鉄郎の同僚でドーテーズの初期メンバー。
 1	鉄郎	鉄郎	PROPN	名詞-固有名詞-人名-名	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テツオ,テツオ,鉄郎,鉄郎,テツオ,,,テツオ,テツオ,鉄郎
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11120,6 +11605,7 @@
 
 # newdoc id = dev-s490
 # sent_id = dev-s490
+# parallel_id = jagsdluw/dev490
 # text = X線新星の特徴である、数ヶ月かけて暗くなる性質と一致している。
 1	X線新星	X線新星	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エックス;セン;シンセイ,Ｘ;線;新星,X;線;新星,X;線;新星,エックス;セン;シンセー,;;,;;,エックス;セン;シンセイ,エックスセンシンセイ,X線新星
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11139,6 +11625,7 @@
 
 # newdoc id = dev-s491
 # sent_id = dev-s491
+# parallel_id = jagsdluw/dev491
 # text = 地区予選で敗者復活戦に回った雪辱を果たせるか。
 1	地区予選	地区予選	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チク;ヨセン,地区;予選,地区;予選,地区;予選,チク;ヨセン,;,;,チク;ヨセン,チクヨセン,地区予選
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11154,6 +11641,7 @@
 
 # newdoc id = dev-s492
 # sent_id = dev-s492
+# parallel_id = jagsdluw/dev492
 # text = ノルウェーの劇作家ヘンリック・イプセンの劇詩『ペール・ギュント』の登場人物に因んで命名された。
 1	ノルウェー	ノルウェー	PROPN	名詞-固有名詞-地名-国	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノルウェー,ノルウェー,ノルウェー,ノルウェー,ノルウェー,,,ノルウェー,ノルウェー,ノルウェー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11175,6 +11663,7 @@
 
 # newdoc id = dev-s493
 # sent_id = dev-s493
+# parallel_id = jagsdluw/dev493
 # text = 3月20日に発売開始。
 1	3月	3月	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=サン;ガツ,三;月,3;月,3;月,サン;ガツ,;,;,サン;ガツ,サンガツ,3月
 2	20日	20日	NUM	名詞-数詞	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハツ;カ,二十;日,20;日,20;日,ハツ;カ,;,;,ハツ;カ,ハツカ,20日
@@ -11184,6 +11673,7 @@
 
 # newdoc id = dev-s494
 # sent_id = dev-s494
+# parallel_id = jagsdluw/dev494
 # text = 今上大岡に住んでいて、毎週行っています。
 1	今	今	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イマ,今,今,今,イマ,,,イマ,イマ,今
 2	上大岡	上大岡	PROPN	名詞-固有名詞-地名-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カミオオオカ,カミオオオカ,上大岡,上大岡,カミオーオカ,,,カミオオオカ,カミオオオカ,上大岡
@@ -11200,6 +11690,7 @@
 
 # newdoc id = dev-s495
 # sent_id = dev-s495
+# parallel_id = jagsdluw/dev495
 # text = 千月学園に通いつつ弥勒院をサポートする有能な助手ではあるが、謎も多い不思議な少女。
 1	千月学園	千月学園	PROPN	名詞-固有名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センゲツ;ガクエン,千月;学園,千月;学園,千月;学園,センゲツ;ガクエン,;,;,センゲツ;ガクエン,センゲツガクエン,千月学園
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11226,6 +11717,7 @@
 
 # newdoc id = dev-s496
 # sent_id = dev-s496
+# parallel_id = jagsdluw/dev496
 # text = 旧松山藩領東部に当たる西条6万8600石は、伊勢国神戸藩主一柳直盛に与えられたが、加増のうえ転封することとなった直盛は、采地に赴く途中の大坂で没した。
 1	旧松山藩領東部	旧松山藩領東部	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キュウ;マツヤマ;ハンリョウ;トウブ,旧;マツヤマ;藩領;東部,旧;松山;藩領;東部,旧;松山;藩領;東部,キュー;マツヤマ;ハンリョー;トーブ,;;;,;;;,キュウ;マツヤマ;ハンリョウ;トウブ,キュウマツヤマハンリョウトウブ,旧松山藩領東部
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11263,6 +11755,7 @@
 
 # newdoc id = dev-s497
 # sent_id = dev-s497
+# parallel_id = jagsdluw/dev497
 # text = 霊芝には毛細血管の血液循環を促進する働きがあります。
 1	霊芝	霊芝	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レイシ,霊芝,霊芝,霊芝,レーシ,,,レイシ,レイシ,霊芝
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11280,6 +11773,7 @@
 
 # newdoc id = dev-s498
 # sent_id = dev-s498
+# parallel_id = jagsdluw/dev498
 # text = 『第2次OG』でコウタと共に帰還し、海上でヒリュウ改を襲撃したイグニスを撃破後に鋼龍戦隊に合流。
 1	『	『	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
 2	第2次OG	第2次OG	PROPN	名詞-固有名詞-一般	_	9	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;ニ;ジ;オー;ジー,第;二;次;Ｏ;Ｇ,第;2;次;O;G,第;2;次;O;G,ダイ;ニ;ジ;オー;ジー,;;;;,;;;;,ダイ;ニ;ジ;オー;ジー,ダイニジオージー,第2次OG
@@ -11308,6 +11802,7 @@
 
 # newdoc id = dev-s499
 # sent_id = dev-s499
+# parallel_id = jagsdluw/dev499
 # text = 2位の天草本渡クラブと3位の菊池クラブは10月に宮崎県で行われる九州大会に出場する。
 1	2位	2位	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;イ,二;位,2;位,2;位,ニ;イ,;,;,ニ;イ,ニイ,2位
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11330,6 +11825,7 @@
 
 # newdoc id = dev-s500
 # sent_id = dev-s500
+# parallel_id = jagsdluw/dev500
 # text = 財務相のヘルムート・シュミットに連邦首相の座を譲った。
 1	財務相	財務相	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ザイム;ショウ,財務;相,財務;相,財務;相,ザイム;ショー,;,;,ザイム;ショウ,ザイムショウ,財務相
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11345,6 +11841,7 @@
 
 # newdoc id = dev-s501
 # sent_id = dev-s501
+# parallel_id = jagsdluw/dev501
 # text = 2008年4月6日午前11時に子供が生まれるとします。
 1	2008年	2008年	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ハチ;ネン,二;ゼロ;ゼロ;八;年,2;0;0;8;年,2;0;0;8;年,ニ;ゼロ;ゼロ;ハチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ハチ;ネン,ニゼロゼロハチネン,2008年
 2	4月	4月	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=シ;ガツ,四;月,4;月,4;月,シ;ガツ,;,;,シ;ガツ,シガツ,4月
@@ -11362,6 +11859,7 @@
 
 # newdoc id = dev-s502
 # sent_id = dev-s502
+# parallel_id = jagsdluw/dev502
 # text = スターフェリーやヨーマティフェリーが創業すると、非常に重要であることを証明することになった。
 1	スターフェリー	スターフェリー	PROPN	名詞-固有名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スター;フェリー,スター;フェリー,スター;フェリー,スター;フェリー,スター;フェリー,;,;,スター;フェリー,スターフェリー,スターフェリー
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -11383,6 +11881,7 @@
 
 # newdoc id = dev-s503
 # sent_id = dev-s503
+# parallel_id = jagsdluw/dev503
 # text = 横柄な女医の婆さんといい加減な受付。
 1	横柄	横柄	ADJ	形状詞-一般	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オウヘイ,横柄,横柄,横柄,オーヘー,,,オウヘイ,オウヘイ,横柄
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -11397,6 +11896,7 @@
 
 # newdoc id = dev-s504
 # sent_id = dev-s504
+# parallel_id = jagsdluw/dev504
 # text = この荻野氏,自らクラシカルホメオパシー京都という団体を主宰し,ホメオパシー講座を開催しています。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	荻野氏	荻野氏	PROPN	名詞-固有名詞-人名-姓	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オギノ;シ,オギノ;氏,荻野;氏,荻野;氏,オギノ;シ,;,;,オギノ;シ,オギノシ,荻野氏
@@ -11417,6 +11917,7 @@
 
 # newdoc id = dev-s505
 # sent_id = dev-s505
+# parallel_id = jagsdluw/dev505
 # text = メソポタミア南部は文字による記録が残される最初期からシュメール語とセム語のバイリンガル地帯であった。
 1	メソポタミア南部	メソポタミア南部	NOUN	名詞-普通名詞-一般	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メソポタミア;ナンブ,メソポタミア;南部,メソポタミア;南部,メソポタミア;南部,メソポタミア;ナンブ,;,;,メソポタミア;ナンブ,メソポタミアナンブ,メソポタミア南部
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11439,6 +11940,7 @@
 
 # newdoc id = dev-s506
 # sent_id = dev-s506
+# parallel_id = jagsdluw/dev506
 # text = また日本語学者の寺村秀夫も自著では「名容詞」という用語を用いている。
 1	また	又	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	日本語学者	日本語学者	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッポン;ゴ;ガク;シャ,日本;語;学;者,日本;語;学;者,日本;語;学;者,ニホン;ゴ;ガク;シャ,;;;,;;;,ニホン;ゴ;ガク;シャ,ニホンゴガクシャ,日本語学者
@@ -11460,6 +11962,7 @@
 
 # newdoc id = dev-s507
 # sent_id = dev-s507
+# parallel_id = jagsdluw/dev507
 # text = お風呂大きくはないけれどお湯はきれい。
 1	お風呂	御風呂	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=オ;フロ,御;風呂,お;風呂,お;風呂,オ;フロ,;,;,オ;フロ,オフロ,御風呂
 2	大きく	大きい	ADJ	形容詞-一般-形容詞	_	4	advcl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキイ,大きい,大きく,大きい,オーキク,,,オオキイ,オオキイ,大きい
@@ -11473,12 +11976,14 @@
 
 # newdoc id = dev-s508
 # sent_id = dev-s508
+# parallel_id = jagsdluw/dev508
 # text = 新生闇軍団頭領。
 1	新生闇軍団頭領	新生闇軍団頭領	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=シンセイ;ヤミ;グンダン;トウリョウ,新生;闇;軍団;頭領,新生;闇;軍団;頭領,新生;闇;軍団;頭領,シンセー;ヤミ;グンダン;トーリョー,;;;,;;;,シンセイ;ヤミ;グンダン;トウリョウ,シンセイヤミグンダントウリョウ,新生闇軍団頭領
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s509
 # sent_id = dev-s509
+# parallel_id = jagsdluw/dev509
 # text = 当初の説明と実際の施設の状態が違うという点も,川島町の住民の証言とよく似ています。
 1	当初	当初	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11509,6 +12014,7 @@
 
 # newdoc id = dev-s510
 # sent_id = dev-s510
+# parallel_id = jagsdluw/dev510
 # text = それでいてこの対応である。
 1	それ	其れ	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11521,6 +12027,7 @@
 
 # newdoc id = dev-s511
 # sent_id = dev-s511
+# parallel_id = jagsdluw/dev511
 # text = 児童生徒が犠牲になる事態も多く、同市にある京田幼児園では園舎が倒壊し園児3名が圧死、園児14名と保育士1名が生き埋めとなった。
 1	児童生徒	児童生徒	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジドウ;セイト,児童;生徒,児童;生徒,児童;生徒,ジドー;セート,;,;,ジドウ;セイト,ジドウセイト,児童生徒
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が

--- a/ja_gsdluw-ud-test.conllu
+++ b/ja_gsdluw-ud-test.conllu
@@ -1,5 +1,6 @@
 # newdoc id = test-s1
 # sent_id = test-s1
+# parallel_id = jagsdluw/test1
 # text = これに不快感を示す住民はいましたが,現在,表立って反対や抗議の声を挙げている住民はいないようです。
 1	これ	此れ	PRON	代名詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -35,6 +36,7 @@
 
 # newdoc id = test-s2
 # sent_id = test-s2
+# parallel_id = jagsdluw/test2
 # text = 幸福の科学側からは,特にどうしてほしいという要望はいただいていません。
 1	幸福の科学側	幸福の科学側	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ノ;カガク;ガワ,幸福;の;科学;側,幸福;の;科学;側,幸福;の;科学;側,コーフク;ノ;カガク;ガワ,;;;,;;;,コウフク;ノ;カガク;ガワ,コウフクノカガクガワ,幸福の科学側
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -54,6 +56,7 @@
 
 # newdoc id = test-s3
 # sent_id = test-s3
+# parallel_id = jagsdluw/test3
 # text = 星取り参加は当然とされ,不参加は白眼視される。
 1	星取り参加	星取り参加	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホシトリ;サンカ,星取り;参加,星取り;参加,星取り;参加,ホシトリ;サンカ,;,;,ホシトリ;サンカ,ホシトリサンカ,星取り参加
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -70,6 +73,7 @@
 
 # newdoc id = test-s4
 # sent_id = test-s4
+# parallel_id = jagsdluw/test4
 # text = 室長の対応には終始誠実さが感じられた。
 1	室長	室長	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シツチョウ,室長,室長,室長,シツチョー,,,シツチョウ,シツチョウ,室長
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -86,6 +90,7 @@
 
 # newdoc id = test-s5
 # sent_id = test-s5
+# parallel_id = jagsdluw/test5
 # text = 多くの女性が生理のことで悩んでいます。
 1	多く	多く	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオク,多く,多く,多く,オーク,,,オオク,オオク,多く
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -102,6 +107,7 @@
 
 # newdoc id = test-s6
 # sent_id = test-s6
+# parallel_id = jagsdluw/test6
 # text = 先生の理想は限りなく高い。
 1	先生	先生	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センセイ,先生,先生,先生,センセー,,,センセイ,センセイ,先生
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -113,6 +119,7 @@
 
 # newdoc id = test-s7
 # sent_id = test-s7
+# parallel_id = jagsdluw/test7
 # text = それは兎も角,私も明日の社説を楽しみにしております。
 1	それ	其れ	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -133,6 +140,7 @@
 
 # newdoc id = test-s8
 # sent_id = test-s8
+# parallel_id = jagsdluw/test8
 # text = そうだったらいいなあとは思いますが,日本学術会議の会長談話について“当会では,標記の件について,以下のように考えます。”
 1	そう	そう	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソウ,そう,そう,そう,ソー,,,ソウ,ソウ,そう
 2	だっ	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だっ,だ,ダッ,,,ダ,ダ,だ
@@ -170,6 +178,7 @@
 
 # newdoc id = test-s9
 # sent_id = test-s9
+# parallel_id = jagsdluw/test9
 # text = 教団にとっては存続が厳しくなると思う。
 1	教団	教団	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウダン,教団,教団,教団,キョーダン,,,キョウダン,キョウダン,教団
 2	にとって	にとって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;トル;テ,に;取る;て,に;とっ;て,に;とる;て,ニ;トッ;テ,;;,;;,ニ;トル;テ,ニトッテ,にとって
@@ -184,6 +193,7 @@
 
 # newdoc id = test-s10
 # sent_id = test-s10
+# parallel_id = jagsdluw/test10
 # text = しかし強制していなくても問題です
 1	しかし	然し	CCONJ	接続詞	_	7	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	強制し	強制する	VERB	動詞-一般-サ行変格	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウセイ;スル,強制;為る,強制;し,強制;する,キョーセー;シ,;,;,キョウセイ;スル,キョウセイスル,強制する
@@ -196,6 +206,7 @@
 
 # newdoc id = test-s11
 # sent_id = test-s11
+# parallel_id = jagsdluw/test11
 # text = 民族派のみなさんにとって陛下はいちばん大切な方ですから,その霊言について“あり得ない”という前提でお話をされる。
 1	民族派	民族派	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミンゾク;ハ,民族;派,民族;派,民族;派,ミンゾク;ハ,;,;,ミンゾク;ハ,ミンゾクハ,民族派
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -228,6 +239,7 @@
 
 # newdoc id = test-s12
 # sent_id = test-s12
+# parallel_id = jagsdluw/test12
 # text = 新しい産業構造を作らなければいけない。
 1	新しい	新しい	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アタラシイ,新しい,新しい,新しい,アタラシー,,,アタラシイ,アタラシイ,新しい
 2	産業構造	産業構造	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サンギョウ;コウゾウ,産業;構造,産業;構造,産業;構造,サンギョー;コーゾー,;,;,サンギョウ;コウゾウ,サンギョウコウゾウ,産業構造
@@ -241,6 +253,7 @@
 
 # newdoc id = test-s13
 # sent_id = test-s13
+# parallel_id = jagsdluw/test13
 # text = 心がないんだ。
 1	心	心	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココロ,心,心,心,ココロ,,,ココロ,ココロ,心
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -250,6 +263,7 @@
 
 # newdoc id = test-s14
 # sent_id = test-s14
+# parallel_id = jagsdluw/test14
 # text = そのモサは今何をしているか。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	モサ	モサ	PROPN	名詞-固有名詞-人名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モサ,モサ,モサ,モサ,モサ,,,モサ,モサ,モサ
@@ -264,6 +278,7 @@
 
 # newdoc id = test-s15
 # sent_id = test-s15
+# parallel_id = jagsdluw/test15
 # text = 本音としてはこの火に油を注ぎたいけれど。
 1	本音	本音	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンネ,本音,本音,本音,ホンネ,,,ホンネ,ホンネ,本音
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -280,6 +295,7 @@
 
 # newdoc id = test-s16
 # sent_id = test-s16
+# parallel_id = jagsdluw/test16
 # text = 25日も楽しみにされてください。
 1	25日	25日	NUM	名詞-数詞	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゴ;ニチ,二;五;日,2;5;日,2;5;日,ニ;ゴ;ニチ,;;,;;,ニ;ゴ;ニチ,ニゴニチ,25日
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -292,6 +308,7 @@
 
 # newdoc id = test-s17
 # sent_id = test-s17
+# parallel_id = jagsdluw/test17
 # text = なんだよなんだよぉ~,わが署に来たのなら教えてくれよぉ~。
 1	なん	何	PRON	代名詞	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナニ,何,なん,なん,ナン,,,ナン,ナニ,何
 2	だ	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダ,だ
@@ -316,6 +333,7 @@
 
 # newdoc id = test-s18
 # sent_id = test-s18
+# parallel_id = jagsdluw/test18
 # text = どの本もツッコミどころが山ほどあり,会場内が爆笑の連続でした。
 1	どの	何の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドノ,何の,どの,どの,ドノ,,,ドノ,ドノ,何の
 2	本	本	NOUN	名詞-普通名詞-一般	_	8	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホン,本,本,本,ホン,,,ホン,ホン,本
@@ -337,6 +355,7 @@
 
 # newdoc id = test-s19
 # sent_id = test-s19
+# parallel_id = jagsdluw/test19
 # text = 社会への恨みと,破滅させたいという恐ろしいほどの煩悩。
 1	社会	社会	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シャカイ,社会,社会,社会,シャカイ,,,シャカイ,シャカイ,社会
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -356,6 +375,7 @@
 
 # newdoc id = test-s20
 # sent_id = test-s20
+# parallel_id = jagsdluw/test20
 # text = とんでもない。
 1	とんでも	とんでも	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トンデモ,とんでも,とんでも,とんでも,トンデモ,,,トンデモ,トンデモ,とんでも
 2	ない	無い	ADJ	形容詞-一般-形容詞	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|PrevUDLemma=ない|SpaceAfter=No|UnidicInfo=ナイ,無い,ない,ない,ナイ,,,ナイ,ナイ,無い
@@ -363,6 +383,7 @@
 
 # newdoc id = test-s21
 # sent_id = test-s21
+# parallel_id = jagsdluw/test21
 # text = 抗議デモの継続を宣言した統一教会,日本でも韓国東亜日報の様に襲撃事件が起こる惧れはないのか?
 1	抗議デモ	抗議デモ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウギ;デモ,抗議;デモ,抗議;デモ,抗議;デモ,コーギ;デモ,;,;,コウギ;デモ,コウギデモ,抗議デモ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -391,6 +412,7 @@
 
 # newdoc id = test-s22
 # sent_id = test-s22
+# parallel_id = jagsdluw/test22
 # text = ついつい言葉だけで机上の空論をこねがちな自分は,ここは激しく自戒ですね...
 1	ついつい	ついつい	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツイツイ,ついつい,ついつい,ついつい,ツイツイ,,,ツイツイ,ツイツイ,ついつい
 2	言葉	言葉	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コトバ,言葉,言葉,言葉,コトバ,,,コトバ,コトバ,言葉
@@ -417,6 +439,7 @@
 
 # newdoc id = test-s23
 # sent_id = test-s23
+# parallel_id = jagsdluw/test23
 # text = 当選して市長になってもなお,摂理との関係を明らかにしようとしないのは,とても残念。
 1	当選し	当選する	VERB	動詞-一般-サ行変格	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウセン;スル,当選;為る,当選;し,当選;する,トーセン;シ,;,;,トウセン;スル,トウセンスル,当選する
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -447,6 +470,7 @@
 
 # newdoc id = test-s24
 # sent_id = test-s24
+# parallel_id = jagsdluw/test24
 # text = この夏が実は最大の山場になります。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	夏	夏	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナツ,夏,夏,夏,ナツ,,,ナツ,ナツ,夏
@@ -462,6 +486,7 @@
 
 # newdoc id = test-s25
 # sent_id = test-s25
+# parallel_id = jagsdluw/test25
 # text = 政府がもっと宗教法人の定義を厳しくし,こういう団体は排除すべき。
 1	政府	政府	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイフ,政府,政府,政府,セーフ,,,セイフ,セイフ,政府
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -483,6 +508,7 @@
 
 # newdoc id = test-s26
 # sent_id = test-s26
+# parallel_id = jagsdluw/test26
 # text = まあ,それが親心だ。
 1	まあ	まあ	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マア,まあ,まあ,まあ,マー,,,マア,マア,まあ
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -494,6 +520,7 @@
 
 # newdoc id = test-s27
 # sent_id = test-s27
+# parallel_id = jagsdluw/test27
 # text = 大川隆法氏を支持する人が挙げた主な理由は,以下のとおり。
 1	大川隆法氏	大川隆法氏	PROPN	名詞-固有名詞-人名-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオカワ;リュウホウ;シ,オオカワ;リュウホウ;氏,大川;隆法;氏,大川;隆法;氏,オーカワ;リューホー;シ,;;,;;,オオカワ;リュウホウ;シ,オオカワリュウホウシ,大川隆法氏
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -513,6 +540,7 @@
 
 # newdoc id = test-s28
 # sent_id = test-s28
+# parallel_id = jagsdluw/test28
 # text = すごくそういうところを引っかかる感じですか?
 1	すごく	凄い	ADJ	形容詞-一般-形容詞	_	6	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごく,すごい,スゴク,,,スゴイ,スゴイ,凄い
 2	そう	そう	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソウ,そう,そう,そう,ソー,,,ソウ,ソウ,そう
@@ -527,6 +555,7 @@
 
 # newdoc id = test-s29
 # sent_id = test-s29
+# parallel_id = jagsdluw/test29
 # text = この記事が本当ならいくつかの問題がはっきり見えてきます。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	記事	記事	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キジ,記事,記事,記事,キジ,,,キジ,キジ,記事
@@ -546,6 +575,7 @@
 
 # newdoc id = test-s30
 # sent_id = test-s30
+# parallel_id = jagsdluw/test30
 # text = 今,何もそれは達成されていない。
 1	今	今	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イマ,今,今,今,イマ,,,イマ,イマ,今
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -561,12 +591,14 @@
 
 # newdoc id = test-s31
 # sent_id = test-s31
+# parallel_id = jagsdluw/test31
 # text = 身勝手すぎる。
 1	身勝手すぎる	身勝手過ぎる	VERB	動詞-一般-上一段-ガ行	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ミガッテ;スギル,身勝手;過ぎる,身勝手;すぎる,身勝手;すぎる,ミガッテ;スギル,;,;,ミガッテ;スギル,ミガッテスギル,身勝手過ぎる
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s32
 # sent_id = test-s32
+# parallel_id = jagsdluw/test32
 # text = 大人と子供では体質が違うので,“大人に良いものが子供にもいい”とは必ずしもいえません。
 1	大人	大人	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オトナ,大人,大人,大人,オトナ,,,オトナ,オトナ,大人
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -599,6 +631,7 @@
 
 # newdoc id = test-s33
 # sent_id = test-s33
+# parallel_id = jagsdluw/test33
 # text = 愛人がいたら怒るでしょ。
 1	愛人	愛人	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アイジン,愛人,愛人,愛人,アイジン,,,アイジン,アイジン,愛人
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -610,6 +643,7 @@
 
 # newdoc id = test-s34
 # sent_id = test-s34
+# parallel_id = jagsdluw/test34
 # text = キリスト教世界でも,たとえばアメリカでは大統領は宣誓式で聖書に手を置くし,共和党の選挙運動ではキリスト教会が力を持っている。
 1	キリスト教世界	キリスト教世界	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キリスト;キョウ;セカイ,キリスト;教;世界,キリスト;教;世界,キリスト;教;世界,キリスト;キョー;セカイ,;;,;;,キリスト;キョウ;セカイ,キリストキョウセカイ,キリスト教世界
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -645,6 +679,7 @@
 
 # newdoc id = test-s35
 # sent_id = test-s35
+# parallel_id = jagsdluw/test35
 # text = “カンボジア三百万人大量虐殺をほめたたえ,カンパ集める”
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	カンボジア三百万人大量虐殺	カンボジア三百万人大量虐殺	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンボジア;サンビャク;マン;ニン;タイリョウ;ギャクサツ,カンボジア;三百;万;人;大量;虐殺,カンボジア;三百;万;人;大量;虐殺,カンボジア;三百;万;人;大量;虐殺,カンボジア;サンビャク;マン;ニン;タイリョー;ギャクサツ,;;;;;,;;;;;,カンボジア;サンビャク;マン;ニン;タイリョウ;ギャクサツ,カンボジアサンビャクマンニンタイリョウギャクサツ,カンボジア三百万人大量虐殺
@@ -657,6 +692,7 @@
 
 # newdoc id = test-s36
 # sent_id = test-s36
+# parallel_id = jagsdluw/test36
 # text = 奇しくも,今年1月付けの最新号です。
 1	奇しくも	奇しくも	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クシクモ,奇しくも,奇しくも,奇しくも,クシクモ,,,クシクモ,クシクモ,奇しくも
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -668,6 +704,7 @@
 
 # newdoc id = test-s37
 # sent_id = test-s37
+# parallel_id = jagsdluw/test37
 # text = 一番の方法は煎じることです。
 1	一番	一番	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチバン,一番,一番,一番,イチバン,,,イチバン,イチバン,一番
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -680,6 +717,7 @@
 
 # newdoc id = test-s38
 # sent_id = test-s38
+# parallel_id = jagsdluw/test38
 # text = それでも,くり返しくり返し,人民に侵略反対を訴え続けて十年がたった。
 1	それでも	其れでも	CCONJ	接続詞	_	10	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ;デ;モ,其れ;で;も,それ;で;も,それ;で;も,ソレ;デ;モ,;;,;;,ソレ;デ;モ,ソレデモ,其れでも
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -700,6 +738,7 @@
 
 # newdoc id = test-s39
 # sent_id = test-s39
+# parallel_id = jagsdluw/test39
 # text = 説教というか,アジテーションが始まります。
 1	説教	説教	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セッキョウ,説教,説教,説教,セッキョー,,,セッキョウ,セッキョウ,説教
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -714,6 +753,7 @@
 
 # newdoc id = test-s40
 # sent_id = test-s40
+# parallel_id = jagsdluw/test40
 # text = 参考文献リストを見る限りでは,本を書くにあたって読んだのかはわからないが,広範囲に亘って本を読んでいて勉強していることはわかった。
 1	参考文献リスト	参考文献リスト	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サンコウ;ブンケン;リスト,参考;文献;リスト,参考;文献;リスト,参考;文献;リスト,サンコー;ブンケン;リスト,;;,;;,サンコウ;ブンケン;リスト,サンコウブンケンリスト,参考文献リスト
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -754,6 +794,7 @@
 
 # newdoc id = test-s41
 # sent_id = test-s41
+# parallel_id = jagsdluw/test41
 # text = 文殊菩薩私が幸福になっていない以上,世界伝道などはありえない!
 1	文殊菩薩	文殊菩薩	PROPN	名詞-固有名詞-人名-一般	_	14	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モンジュ;ボサツ,文殊;菩薩,文殊;菩薩,文殊;菩薩,モンジュ;ボサツ,;,;,モンジュ;ボサツ,モンジュボサツ,文殊菩薩
 2	私	私	PRON	代名詞	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
@@ -774,6 +815,7 @@
 
 # newdoc id = test-s42
 # sent_id = test-s42
+# parallel_id = jagsdluw/test42
 # text = しばらくの完全休養とリハビリが必要とのことでした。
 1	しばらく	暫く	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シバラク,暫く,しばらく,しばらく,シバラク,,,シバラク,シバラク,暫く
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -791,6 +833,7 @@
 
 # newdoc id = test-s43
 # sent_id = test-s43
+# parallel_id = jagsdluw/test43
 # text = いまのところ,訴訟沙汰になったとか,米・中・朝の軍が幸福の科学を襲撃したといった話は聞きません。
 1	いま	今	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イマ,今,いま,いま,イマ,,,イマ,イマ,今
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -821,6 +864,7 @@
 
 # newdoc id = test-s44
 # sent_id = test-s44
+# parallel_id = jagsdluw/test44
 # text = バームクーヘンでも周りにお砂糖がたっぷり付いているもの。
 1	バームクーヘン	バームクーヘン	NOUN	名詞-普通名詞-一般	_	9	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バウムクーヘン,バウムクーヘン,バームクーヘン,バームクーヘン,バームクーヘン,,,バームクーヘン,バームクーヘン,バームクーヘン
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -837,6 +881,7 @@
 
 # newdoc id = test-s45
 # sent_id = test-s45
+# parallel_id = jagsdluw/test45
 # text = しかし,心配には及ばないようです。
 1	しかし	然し	CCONJ	接続詞	_	6	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -851,6 +896,7 @@
 
 # newdoc id = test-s46
 # sent_id = test-s46
+# parallel_id = jagsdluw/test46
 # text = いったい,“次世紀ファーム研究所”とは何なのか。
 1	いったい	一体	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッタイ,一体,いったい,いったい,イッタイ,,,イッタイ,イッタイ,一体
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -867,6 +913,7 @@
 
 # newdoc id = test-s47
 # sent_id = test-s47
+# parallel_id = jagsdluw/test47
 # text = その後,一部の会員に渡すための賞状にサインしてくださいと頼まれ,サインをいたしました。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-一般	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -895,6 +942,7 @@
 
 # newdoc id = test-s48
 # sent_id = test-s48
+# parallel_id = jagsdluw/test48
 # text = 事前に海老澤代表からは“40歳くらいとお若いけれど,とても家系のことに詳しい先生”と聞かされていた。
 1	事前	事前	NOUN	名詞-普通名詞-一般	_	22	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジゼン,事前,事前,事前,ジゼン,,,ジゼン,ジゼン,事前
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -925,6 +973,7 @@
 
 # newdoc id = test-s49
 # sent_id = test-s49
+# parallel_id = jagsdluw/test49
 # text = “1000万円当たりますように”というのもありました。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	1000万円	1000万円	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッセン;マン;エン,一千;万;円,1000;万;円,1000;万;円,イッセン;マン;エン,;;,;;,イッセン;マン;エン,イッセンマンエン,1000万円
@@ -943,6 +992,7 @@
 
 # newdoc id = test-s50
 # sent_id = test-s50
+# parallel_id = jagsdluw/test50
 # text = いつもどおりなので,たぶん何も問題ありません。
 1	いつもどおり	何時も通り	NOUN	名詞-普通名詞-一般	_	9	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イツ;モ;トオリ,何時;も;通り,いつ;も;どおり,いつ;も;どおり,イツ;モ;ドーリ,;;,;;,イツ;モ;トオリ,イツモドオリ,何時も通り
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -959,6 +1009,7 @@
 
 # newdoc id = test-s51
 # sent_id = test-s51
+# parallel_id = jagsdluw/test51
 # text = 震災に乗じて末端信者から献金を集めようとの意図が判る。
 1	震災	震災	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンサイ,震災,震災,震災,シンサイ,,,シンサイ,シンサイ,震災
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -978,6 +1029,7 @@
 
 # newdoc id = test-s52
 # sent_id = test-s52
+# parallel_id = jagsdluw/test52
 # text = Ad Plannerもサイトの月間利用者の推定データだと思うので,Twitterアカウント数でも,Twitter利用者数でもないだろう。
 1	Ad Planner	Ad Planner	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アド;プランナー,アド;プランナー,Ad;Planner,Ad;Planner,アド;プランナー,;,;,アド;プランナー,アドプランナー,AdPlanner
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -1004,6 +1056,7 @@
 
 # newdoc id = test-s53
 # sent_id = test-s53
+# parallel_id = jagsdluw/test53
 # text = “天聖稲荷大権現神社”を出て,“箱根大天狗山神社”へ向かう。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	天聖稲荷大権現神社	天聖稲荷大権現神社	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンセイ;イナリ;ダイ;ゴンゲン;ジンジャ,天聖;稲荷;大;権現;神社,天聖;稲荷;大;権現;神社,天聖;稲荷;大;権現;神社,テンセー;イナリ;ダイ;ゴンゲン;ジンジャ,;;;;,;;;;,テンセイ;イナリ;ダイ;ゴンゲン;ジンジャ,テンセイイナリダイゴンゲンジンジャ,天聖稲荷大権現神社
@@ -1021,6 +1074,7 @@
 
 # newdoc id = test-s54
 # sent_id = test-s54
+# parallel_id = jagsdluw/test54
 # text = みんな自分の立場から主張しています。
 1	みんな	皆	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミナ,皆,みんな,みんな,ミンナ,,,ミンナ,ミナ,皆
 2	自分	自分	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
@@ -1034,6 +1088,7 @@
 
 # newdoc id = test-s55
 # sent_id = test-s55
+# parallel_id = jagsdluw/test55
 # text = “鶴”は統一教会教祖・文鮮明の妻,韓鶴子が由来か。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	鶴	鶴	NOUN	名詞-普通名詞-一般	_	11	nsubj:outer	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツル,鶴,鶴,鶴,ツル,,,ツル,ツル,鶴
@@ -1051,6 +1106,7 @@
 
 # newdoc id = test-s56
 # sent_id = test-s56
+# parallel_id = jagsdluw/test56
 # text = “心筋梗塞になったが神様に命を救っていただいた”
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	心筋梗塞	心筋梗塞	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンキン;コウソク,心筋;梗塞,心筋;梗塞,心筋;梗塞,シンキン;コーソク,;,;,シンキン;コウソク,シンキンコウソク,心筋梗塞
@@ -1069,6 +1125,7 @@
 
 # newdoc id = test-s57
 # sent_id = test-s57
+# parallel_id = jagsdluw/test57
 # text = 広告審査部への取り次ぎは読者センターの判断に委ねるとのこと。
 1	広告審査部	広告審査部	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウコク;シンサ;ブ,広告;審査;部,広告;審査;部,広告;審査;部,コーコク;シンサ;ブ,;;,;;,コウコク;シンサ;ブ,コウコクシンサブ,広告審査部
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -1087,6 +1144,7 @@
 
 # newdoc id = test-s58
 # sent_id = test-s58
+# parallel_id = jagsdluw/test58
 # text = ビデオセンタースタッフも参加。
 1	ビデオセンタースタッフ	ビデオセンタースタッフ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビデオ;センター;スタッフ,ビデオ;センター;スタッフ,ビデオ;センター;スタッフ,ビデオ;センター;スタッフ,ビデオ;センター;スタッフ,;;,;;,ビデオ;センター;スタッフ,ビデオセンタースタッフ,ビデオセンタースタッフ
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -1095,6 +1153,7 @@
 
 # newdoc id = test-s59
 # sent_id = test-s59
+# parallel_id = jagsdluw/test59
 # text = 空気を読もうとする姿勢が見られ,不思議な気持ちになりました。
 1	空気	空気	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クウキ,空気,空気,空気,クーキ,,,クウキ,クウキ,空気
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -1117,6 +1176,7 @@
 
 # newdoc id = test-s60
 # sent_id = test-s60
+# parallel_id = jagsdluw/test60
 # text = だが,生真面目な彼は少し困った顔をしてこう言った。
 1	だが	だが	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;ガ,だ;が,だ;が,だ;が,ダ;ガ,;,;,ダ;ガ,ダガ,だが
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1138,6 +1198,7 @@
 
 # newdoc id = test-s61
 # sent_id = test-s61
+# parallel_id = jagsdluw/test61
 # text = どうぞ取材に来てください。
 1	どうぞ	どうぞ	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウゾ,どうぞ,どうぞ,どうぞ,ドーゾ,,,ドウゾ,ドウゾ,どうぞ
 2	取材	取材	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュザイ,取材,取材,取材,シュザイ,,,シュザイ,シュザイ,取材
@@ -1148,6 +1209,7 @@
 
 # newdoc id = test-s62
 # sent_id = test-s62
+# parallel_id = jagsdluw/test62
 # text = でも党が結成されたときは,けっこう報道されていましたよ。
 1	でも	でも	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;モ,で;も,で;も,で;も,デ;モ,;,;,デ;モ,デモ,でも
 2	党	党	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウ,党,党,党,トー,,,トウ,トウ,党
@@ -1169,6 +1231,7 @@
 
 # newdoc id = test-s63
 # sent_id = test-s63
+# parallel_id = jagsdluw/test63
 # text = 陳述書に“現在も通っている”と書いてあるが?
 1	陳述書	陳述書	NOUN	名詞-普通名詞-一般	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チンジュツ;ショ,陳述;書,陳述;書,陳述;書,チンジュツ;ショ,;,;,チンジュツ;ショ,チンジュツショ,陳述書
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1186,6 +1249,7 @@
 
 # newdoc id = test-s64
 # sent_id = test-s64
+# parallel_id = jagsdluw/test64
 # text = ファンの皆様には混乱を招いてしまい,誠に申し訳ございません。
 1	ファン	ファン	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ファン,ファン,ファン,ファン,ファン,,,ファン,ファン,ファン
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1207,6 +1271,7 @@
 
 # newdoc id = test-s65
 # sent_id = test-s65
+# parallel_id = jagsdluw/test65
 # text = 教祖の浮気性,あくなき欲望。
 1	教祖	教祖	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウソ,教祖,教祖,教祖,キョーソ,,,キョウソ,キョウソ,教祖
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1219,6 +1284,7 @@
 
 # newdoc id = test-s66
 # sent_id = test-s66
+# parallel_id = jagsdluw/test66
 # text = さっぱり意味がわかりません。
 1	さっぱり	さっぱり	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サッパリ,さっぱり,さっぱり,さっぱり,サッパリ,,,サッパリ,サッパリ,さっぱり
 2	意味	意味	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イミ,意味,意味,意味,イミ,,,イミ,イミ,意味
@@ -1230,6 +1296,7 @@
 
 # newdoc id = test-s67
 # sent_id = test-s67
+# parallel_id = jagsdluw/test67
 # text = 心よりお悔やみ申し上げます。
 1	心	心	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココロ,心,心,心,ココロ,,,ココロ,ココロ,心
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -1239,6 +1306,7 @@
 
 # newdoc id = test-s68
 # sent_id = test-s68
+# parallel_id = jagsdluw/test68
 # text = そんな俗世の快楽を楽しむ彼も,インタビューには“洗礼を受けるつもり”と答えている。
 1	そんな	そんな	PRON	連体詞	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソンナ,そんな,そんな,そんな,ソンナ,,,ソンナ,ソンナ,そんな
 2	俗世	俗世	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゾクセ,俗世,俗世,俗世,ゾクセ,,,ゾクセ,ゾクセ,俗世
@@ -1265,6 +1333,7 @@
 
 # newdoc id = test-s69
 # sent_id = test-s69
+# parallel_id = jagsdluw/test69
 # text = 記者はその勝手な言い分に対し,“暑い中,わざわざ来てくれた警官に失礼だろう!”
 1	記者	記者	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キシャ,記者,記者,記者,キシャ,,,キシャ,キシャ,記者
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1291,6 +1360,7 @@
 
 # newdoc id = test-s70
 # sent_id = test-s70
+# parallel_id = jagsdluw/test70
 # text = というか,返す刀で互いを批判し合っています。
 1	と	と	ADP	助詞-格助詞	_	2	case	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
 2	いう	言う	VERB	動詞-一般-五段-ワア行	_	10	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イウ,言う,いう,いう,イウ,,,イウ,イウ,言う
@@ -1308,6 +1378,7 @@
 
 # newdoc id = test-s71
 # sent_id = test-s71
+# parallel_id = jagsdluw/test71
 # text = みな,事実に基づいて恐怖と憎悪と嘲りを込めてぼくをカルトくんと呼んでくれています。
 1	みな	皆	ADV	副詞	_	19	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミナ,皆,みな,みな,ミナ,,,ミナ,ミナ,皆
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1335,6 +1406,7 @@
 
 # newdoc id = test-s72
 # sent_id = test-s72
+# parallel_id = jagsdluw/test72
 # text = そうだろ?
 1	そう	そう	ADV	副詞	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ソウ,そう,そう,そう,ソー,,,ソウ,ソウ,そう
 2	だろ	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だろ,だ,ダロ,,,ダ,ダ,だ
@@ -1342,6 +1414,7 @@
 
 # newdoc id = test-s73
 # sent_id = test-s73
+# parallel_id = jagsdluw/test73
 # text = すごいすごい。
 1	すごい	凄い	ADJ	形容詞-一般-形容詞	_	2	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごい,すごい,スゴイ,,,スゴイ,スゴイ,凄い
 2	すごい	凄い	ADJ	形容詞-一般-形容詞	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごい,すごい,スゴイ,,,スゴイ,スゴイ,凄い
@@ -1349,6 +1422,7 @@
 
 # newdoc id = test-s74
 # sent_id = test-s74
+# parallel_id = jagsdluw/test74
 # text = もちろん,まじめにやっている宗教法人もあるとは思いますが,やりたい放題やろうと思えばできてしまう構造は変える必要があるように思います。
 1	もちろん	勿論	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モチロン,勿論,もちろん,もちろん,モチロン,,,モチロン,モチロン,勿論
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1388,6 +1462,7 @@
 
 # newdoc id = test-s75
 # sent_id = test-s75
+# parallel_id = jagsdluw/test75
 # text = きっと,地上天国の中にいるのでしょう。
 1	きっと	急度	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キット,急度,きっと,きっと,キット,,,キット,キット,急度
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1401,6 +1476,7 @@
 
 # newdoc id = test-s76
 # sent_id = test-s76
+# parallel_id = jagsdluw/test76
 # text = 過去に自らが主催した飯田氏の講演の映像もYou Tubeから削除しました。
 1	過去	過去	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カコ,過去,過去,過去,カコ,,,カコ,カコ,過去
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1423,6 +1499,7 @@
 
 # newdoc id = test-s77
 # sent_id = test-s77
+# parallel_id = jagsdluw/test77
 # text = もう一つびっくりしたことと言えば,公立学校の中には保育所が併設されているところがあるということです。
 1	もう	もう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モウ,もう,もう,もう,モー,,,モウ,モウ,もう
 2	一つ	一つ	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒト;ツ,一;つ,一;つ,一;つ,ヒト;ツ,;,;,ヒト;ツ,ヒトツ,一つ
@@ -1453,6 +1530,7 @@
 
 # newdoc id = test-s78
 # sent_id = test-s78
+# parallel_id = jagsdluw/test78
 # text = おかしな販売をしているといっても,それはあくまでも刑事事件の話であって,公安部が出てくる筋ではありません。
 1	おかしな	可笑しな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オカシナ,可笑しな,おかしな,おかしな,オカシナ,,,オカシナ,オカシナ,可笑しな
 2	販売	販売	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハンバイ,販売,販売,販売,ハンバイ,,,ハンバイ,ハンバイ,販売
@@ -1481,6 +1559,7 @@
 
 # newdoc id = test-s79
 # sent_id = test-s79
+# parallel_id = jagsdluw/test79
 # text = 地方に住む知人の僧侶によると,こんな話もありました。
 1	地方	地方	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チホウ,地方,地方,地方,チホー,,,チホウ,チホウ,地方
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1500,6 +1579,7 @@
 
 # newdoc id = test-s80
 # sent_id = test-s80
+# parallel_id = jagsdluw/test80
 # text = だからまあ,もう,“殺ってくれ”とは言っておいたから。
 1	だから	だから	CCONJ	接続詞	_	12	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;カラ,だ;から,だ;から,だ;から,ダ;カラ,;,;,ダ;カラ,ダカラ,だから
 2	まあ	まあ	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マア,まあ,まあ,まあ,マー,,,マア,マア,まあ
@@ -1520,6 +1600,7 @@
 
 # newdoc id = test-s81
 # sent_id = test-s81
+# parallel_id = jagsdluw/test81
 # text = 右奥に見える重機が,我々に何かを物語っている気がしないでもありません。
 1	右奥	右奥	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミギオク,右奥,右奥,右奥,ミギオク,,,ミギオク,ミギオク,右奥
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1547,6 +1628,7 @@
 
 # newdoc id = test-s82
 # sent_id = test-s82
+# parallel_id = jagsdluw/test82
 # text = とても賢い生徒さんです。
 1	とても	迚も	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トテモ,迚も,とても,とても,トテモ,,,トテモ,トテモ,迚も
 2	賢い	賢い	ADJ	形容詞-一般-形容詞	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カシコイ,賢い,賢い,賢い,カシコイ,,,カシコイ,カシコイ,賢い
@@ -1556,6 +1638,7 @@
 
 # newdoc id = test-s83
 # sent_id = test-s83
+# parallel_id = jagsdluw/test83
 # text = たまたま,お互いに潜入取材の最中だった。
 1	たまたま	偶々	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タマタマ,偶々,たまたま,たまたま,タマタマ,,,タマタマ,タマタマ,偶々
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1570,6 +1653,7 @@
 
 # newdoc id = test-s84
 # sent_id = test-s84
+# parallel_id = jagsdluw/test84
 # text = ホメオパシーのレメディは毒にも薬にもならない“ただの水”と砂糖玉なので,司法解剖によってわかる類の因果関係なんてあるはずもありません。
 1	ホメオパシー	ホメオパシー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホメオパチー,ホメオパチー,ホメオパシー,ホメオパシー,ホメオパシー,,,ホメオパシー,ホメオパシー,ホメオパシー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1610,6 +1694,7 @@
 
 # newdoc id = test-s85
 # sent_id = test-s85
+# parallel_id = jagsdluw/test85
 # text = まさか松田氏は,男性が倒れる前から消防に通報していたとでもいうつもりだったのでしょうか。
 1	まさか	まさか	ADV	副詞	_	18	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マサカ,まさか,まさか,まさか,マサカ,,,マサカ,マサカ,まさか
 2	松田氏	松田氏	PROPN	名詞-固有名詞-人名-姓	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マツダ;シ,マツダ;氏,松田;氏,松田;氏,マツダ;シ,;,;,マツダ;シ,マツダシ,松田氏
@@ -1638,6 +1723,7 @@
 
 # newdoc id = test-s86
 # sent_id = test-s86
+# parallel_id = jagsdluw/test86
 # text = 是非書けるようになってみたい。
 1	是非	是非	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼヒ,是非,是非,是非,ゼヒ,,,ゼヒ,ゼヒ,是非
 2	書ける	書ける	VERB	動詞-一般-下一段-カ行	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カク,書く,書ける,書ける,カケル,,,カケル,カケル,書ける
@@ -1650,6 +1736,7 @@
 
 # newdoc id = test-s87
 # sent_id = test-s87
+# parallel_id = jagsdluw/test87
 # text = どう見ても幸福の科学出版の広告です。
 1	どう	どう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ,どう,どう,どう,ドー,,,ドウ,ドウ,どう
 2	見	見る	VERB	動詞-一般-上一段-マ行	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=みる|SpaceAfter=No|UnidicInfo=ミル,見る,見,見る,ミ,,,ミル,ミル,見る
@@ -1663,6 +1750,7 @@
 
 # newdoc id = test-s88
 # sent_id = test-s88
+# parallel_id = jagsdluw/test88
 # text = おおつた氏は数年前に勧誘され足立教会の通教組織である【びぎん】に所属,前線での違法な勧誘や霊感商法には関わっていなかったらしい。
 1	おおつた氏	おおつた氏	PROPN	名詞-固有名詞-人名-姓	_	27	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオツタ;シ,オオツタ;氏,おおつた;氏,おおつた;氏,オーツタ;シ,;,;,オオツタ;シ,オオツタシ,おおつた氏
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1699,6 +1787,7 @@
 
 # newdoc id = test-s89
 # sent_id = test-s89
+# parallel_id = jagsdluw/test89
 # text = 昔,阪神淡路大震災の時は,駅から重いリックを背負って,片道3時間歩いて仮設トイレ等の設置のボランティアに行きましたが,被災地の大変さは,想像以上でした。
 1	昔	昔	ADV	副詞	_	26	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ムカシ,昔,昔,昔,ムカシ,,,ムカシ,ムカシ,昔
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1742,6 +1831,7 @@
 
 # newdoc id = test-s90
 # sent_id = test-s90
+# parallel_id = jagsdluw/test90
 # text = かなりの長文になりますが,どうかご了解をお願いします。
 1	かなり	可成	ADJ	形状詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カナリ,可成,かなり,かなり,カナリ,,,カナリ,カナリ,可成
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1761,6 +1851,7 @@
 
 # newdoc id = test-s91
 # sent_id = test-s91
+# parallel_id = jagsdluw/test91
 # text = 政党と柴犬を同列に扱うというのも,なかなかです。
 1	政党	政党	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイトウ,政党,政党,政党,セートー,,,セイトウ,セイトウ,政党
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -1779,6 +1870,7 @@
 
 # newdoc id = test-s92
 # sent_id = test-s92
+# parallel_id = jagsdluw/test92
 # text = ですから,もろもろ客観的解説やツッコミも入ります。
 1	ですから	ですから	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デス;カラ,です;から,です;から,です;から,デス;カラ,;,;,デス;カラ,デスカラ,ですから
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1793,6 +1885,7 @@
 
 # newdoc id = test-s93
 # sent_id = test-s93
+# parallel_id = jagsdluw/test93
 # text = その後一行は,池袋駅に移動。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-一般	_	8	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -1806,6 +1899,7 @@
 
 # newdoc id = test-s94
 # sent_id = test-s94
+# parallel_id = jagsdluw/test94
 # text = 学校法人幸福の科学学園が2013年に関西校を開校するため土地を購入した滋賀県大津市内で,学園開校に反対する声が地元住民から挙がっています。
 1	学校法人幸福の科学学園	学校法人幸福の科学学園	PROPN	名詞-固有名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガッコウ;ホウジン;コウフク;ノ;カガク;ガクエン,学校;法人;幸福;の;科学;学園,学校;法人;幸福;の;科学;学園,学校;法人;幸福;の;科学;学園,ガッコー;ホージン;コーフク;ノ;カガク;ガクエン,;;;;;,;;;;;,ガッコウ;ホウジン;コウフク;ノ;カガク;ガクエン,ガッコウホウジンコウフクノカガクガクエン,学校法人幸福の科学学園
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1837,6 +1931,7 @@
 
 # newdoc id = test-s95
 # sent_id = test-s95
+# parallel_id = jagsdluw/test95
 # text = では,同じくメディアとしての品性のかけらもない“やや日刊カルト新聞”が,品性のかけらもない宗教者たちの過去のエロ事件を調べてみました。
 1	では	では	CCONJ	接続詞	_	28	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;ハ,で;は,で;は,で;は,デ;ワ,;,;,デ;ハ,デハ,では
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1873,6 +1968,7 @@
 
 # newdoc id = test-s96
 # sent_id = test-s96
+# parallel_id = jagsdluw/test96
 # text = 宗教は怖い?
 1	宗教	宗教	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウキョウ,宗教,宗教,宗教,シューキョー,,,シュウキョウ,シュウキョウ,宗教
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1881,6 +1977,7 @@
 
 # newdoc id = test-s97
 # sent_id = test-s97
+# parallel_id = jagsdluw/test97
 # text = また渡辺弁護士は,こうも指摘します。
 1	また	又	CCONJ	接続詞	_	7	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	渡辺弁護士	渡辺弁護士	PROPN	名詞-固有名詞-人名-姓	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタナベ;ベンゴ;シ,ワタナベ;弁護;士,渡辺;弁護;士,渡辺;弁護;士,ワタナベ;ベンゴ;シ,;;,;;,ワタナベ;ベンゴ;シ,ワタナベベンゴシ,渡辺弁護士
@@ -1894,6 +1991,7 @@
 
 # newdoc id = test-s98
 # sent_id = test-s98
+# parallel_id = jagsdluw/test98
 # text = その流れというのもあるので???。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	流れ	流れ	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナガレ,流れ,流れ,流れ,ナガレ,,,ナガレ,ナガレ,流れ
@@ -1909,6 +2007,7 @@
 
 # newdoc id = test-s99
 # sent_id = test-s99
+# parallel_id = jagsdluw/test99
 # text = 勝利の女神がどちらにほほ笑むか全く分からない展開。
 1	勝利	勝利	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウリ,勝利,勝利,勝利,ショーリ,,,ショウリ,ショウリ,勝利
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1926,6 +2025,7 @@
 
 # newdoc id = test-s100
 # sent_id = test-s100
+# parallel_id = jagsdluw/test100
 # text = ストイコビッチ監督は「浦和は最後まで目を覚ますことがなかった」と、ジョークを交えながら「柏さんにはおめでとうと言いたい」と新王者を称えた。
 1	ストイコビッチ監督	ストイコビッチ監督	PROPN	名詞-固有名詞-人名-一般	_	34	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ストイコビッチ;カントク,ストイコビッチ;監督,ストイコビッチ;監督,ストイコビッチ;監督,ストイコビッチ;カントク,;,;,ストイコビッチ;カントク,ストイコビッチカントク,ストイコビッチ監督
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1966,6 +2066,7 @@
 
 # newdoc id = test-s101
 # sent_id = test-s101
+# parallel_id = jagsdluw/test101
 # text = 一団の脇をレスキューボードでライフセーバーが泳ぎ、さらにカヌー、水上バイクもその外に待機する。
 1	一団	一団	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチダン,一団,一団,一団,イチダン,,,イチダン,イチダン,一団
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1990,6 +2091,7 @@
 
 # newdoc id = test-s102
 # sent_id = test-s102
+# parallel_id = jagsdluw/test102
 # text = ...あなたが涙を流した「SATC」のエピソードは?
 1	.	.	PUNCT	補助記号-句点	_	14	punct	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=,．,.,.,,,,,,．
 2	.	.	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,．,.,.,,,,,,．
@@ -2010,6 +2112,7 @@
 
 # newdoc id = test-s103
 # sent_id = test-s103
+# parallel_id = jagsdluw/test103
 # text = ジャンボ機の愛称で知られるボーイング747のうち、約20年にわたって日航で活躍してきた国内線仕様の「400D型」の引退フライトツアーが19日あり、参加した約450人が乗り込み別れを惜しんだ。
 1	ジャンボ機	ジャンボ機	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジャンボ;キ,ジャンボ;機,ジャンボ;機,ジャンボ;機,ジャンボ;キ,;,;,ジャンボ;キ,ジャンボキ,ジャンボ機
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2053,6 +2156,7 @@
 
 # newdoc id = test-s104
 # sent_id = test-s104
+# parallel_id = jagsdluw/test104
 # text = センター街の片隅で、撮影の準備を始める大島優子さんとスタッフ。
 1	センター街	センター街	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センター;ガイ,センター;街,センター;街,センター;街,センター;ガイ,;,;,センター;ガイ,センターガイ,センター街
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2071,6 +2175,7 @@
 
 # newdoc id = test-s105
 # sent_id = test-s105
+# parallel_id = jagsdluw/test105
 # text = この背景には、アメリカの金融緩和の影響で多額の資金が原油の先物市場に流れ込んでいることや、新興国の需要の拡大で国際的な原油取引の価格が上昇していることがあります。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	背景	背景	NOUN	名詞-普通名詞-一般	_	37	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハイケイ,背景,背景,背景,ハイケー,,,ハイケイ,ハイケイ,背景
@@ -2118,6 +2223,7 @@
 
 # newdoc id = test-s106
 # sent_id = test-s106
+# parallel_id = jagsdluw/test106
 # text = 本格的だし、絶対に効くと思うので、いろいろな人に覚えてもらいたいです。
 1	本格的	本格的	ADJ	形状詞-一般	_	7	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンカク;テキ,本格;的,本格;的,本格;的,ホンカク;テキ,;,;,ホンカク;テキ,ホンカクテキ,本格的
 2	だ	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダ,だ
@@ -2142,6 +2248,7 @@
 
 # newdoc id = test-s107
 # sent_id = test-s107
+# parallel_id = jagsdluw/test107
 # text = 仮設を出た後に住みたい場所では、岩手、宮城の約6割が「以前住んでいた場所に近い高台」「同じ市町村」、福島の7割が「以前住んでいた場所」と答えた。
 1	仮設	仮設	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カセツ,仮設,仮設,仮設,カセツ,,,カセツ,カセツ,仮設
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -2194,6 +2301,7 @@
 
 # newdoc id = test-s108
 # sent_id = test-s108
+# parallel_id = jagsdluw/test108
 # text = 当初、アメリカ映画として作る発想から始まったので英語映画にしたが、舞台にニューヨークを選ばなかったのは、東京を壊すべきだと思ったから。
 1	当初	当初	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2234,6 +2342,7 @@
 
 # newdoc id = test-s109
 # sent_id = test-s109
+# parallel_id = jagsdluw/test109
 # text = このページに掲載されている記事・写真・図表などの無断転載を禁じます。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	ページ	ページ	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ページ,ページ,ページ,ページ,ページ,,,ページ,ページ,ページ
@@ -2252,6 +2361,7 @@
 
 # newdoc id = test-s110
 # sent_id = test-s110
+# parallel_id = jagsdluw/test110
 # text = 記者がアジアを飛び回っているせいか、やはりアジアの方が多いです。
 1	記者	記者	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キシャ,記者,記者,記者,キシャ,,,キシャ,キシャ,記者
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -2273,6 +2383,7 @@
 
 # newdoc id = test-s111
 # sent_id = test-s111
+# parallel_id = jagsdluw/test111
 # text = 警視庁は今後、役員らから事情を聴くなど、検査妨害の全容を解明する方針。
 1	警視庁	警視庁	PROPN	名詞-固有名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイシ;チョウ,警視;庁,警視;庁,警視;庁,ケーシ;チョー,;,;,ケイシ;チョウ,ケイシチョウ,警視庁
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2295,6 +2406,7 @@
 
 # newdoc id = test-s112
 # sent_id = test-s112
+# parallel_id = jagsdluw/test112
 # text = 70年ぶりに生息が確認されたクニマスの保護に向け、西湖で地元の漁業協同組合が、禁漁区を自主的に設定しました。
 1	70年ぶり	70年ぶり	NUM	名詞-数詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナナジュウ;ネン;ブリ,七十;年;振り,70;年;ぶり,70;年;ぶり,ナナジュー;ネン;ブリ,;;,;;,ナナジュウ;ネン;ブリ,ナナジュウネンブリ,70年ぶり
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2327,6 +2439,7 @@
 
 # newdoc id = test-s113
 # sent_id = test-s113
+# parallel_id = jagsdluw/test113
 # text = 谷川容疑者は政治団体の構成員を名乗っていて、当時、団体の車両が中国に対する批判を繰り返す街宣活動を行っていたという。
 1	谷川容疑者	谷川容疑者	PROPN	名詞-固有名詞-人名-姓	_	28	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タニガワ;ヨウギ;シャ,タニガワ;容疑;者,谷川;容疑;者,谷川;容疑;者,タニガワ;ヨーギ;シャ,;;,;;,タニガワ;ヨウギ;シャ,タニガワヨウギシャ,谷川容疑者
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2360,6 +2473,7 @@
 
 # newdoc id = test-s114
 # sent_id = test-s114
+# parallel_id = jagsdluw/test114
 # text = やがて、書きためた曲を携え、「ウクレレわらべうた」として児童館などでライブを始め、そこで出会った絵本の読み聞かせをする父親たちのグループ「パパ’S絵本プロジェクト」の活動に合流。
 1	やがて	軈て	ADV	副詞	_	18	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤガテ,軈て,やがて,やがて,ヤガテ,,,ヤガテ,ヤガテ,軈て
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2401,6 +2515,7 @@
 
 # newdoc id = test-s115
 # sent_id = test-s115
+# parallel_id = jagsdluw/test115
 # text = 昨年4月、オバマ米大統領が「核兵器のない世界を目指す」と訴えたプラハ演説以降、潮目が変わってきているのかなと、かすかな期待を抱く。
 1	昨年	昨年	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=サクネン,昨年,昨年,昨年,サクネン,,,サクネン,サクネン,昨年
 2	4月	4月	NUM	名詞-数詞	_	15	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シ;ガツ,四;月,4;月,4;月,シ;ガツ,;,;,シ;ガツ,シガツ,4月
@@ -2439,6 +2554,7 @@
 
 # newdoc id = test-s116
 # sent_id = test-s116
+# parallel_id = jagsdluw/test116
 # text = だが08年4月、あごを骨折し3つ目の王座から陥落。
 1	だが	だが	CCONJ	接続詞	_	12	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;ガ,だ;が,だ;が,だ;が,ダ;ガ,;,;,ダ;ガ,ダガ,だが
 2	08年	08年	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ゼロ;ハチ;ネン,ゼロ;八;年,0;8;年,0;8;年,ゼロ;ハチ;ネン,;;,;;,ゼロ;ハチ;ネン,ゼロハチネン,08年
@@ -2456,6 +2572,7 @@
 
 # newdoc id = test-s117
 # sent_id = test-s117
+# parallel_id = jagsdluw/test117
 # text = 今期の経常利益は急回復する見通しだが、中期的に見れば、震災の影響はジワジワ効いてくる。
 1	今期	今期	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンキ,今期,今期,今期,コンキ,,,コンキ,コンキ,今期
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2482,6 +2599,7 @@
 
 # newdoc id = test-s118
 # sent_id = test-s118
+# parallel_id = jagsdluw/test118
 # text = 鋭い眼光でこちらを睨み付けるニノ、ヴィジュアル系のように自分を抱きしめるニノ、壁にへばり付き何かに怯えるニノ......。
 1	鋭い	鋭い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スルドイ,鋭い,鋭い,鋭い,スルドイ,,,スルドイ,スルドイ,鋭い
 2	眼光	眼光	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガンコウ,眼光,眼光,眼光,ガンコー,,,ガンコウ,ガンコウ,眼光
@@ -2518,6 +2636,7 @@
 
 # newdoc id = test-s119
 # sent_id = test-s119
+# parallel_id = jagsdluw/test119
 # text = パク・チウォン代表は「25人の将軍級を懲戒するというが、こうした重大な問題を監査院の監査で懲戒程度で終わらせることはありえない」、「軍法会議に回付して、軍検察が徹底した調査をするように要求する」と述べた。
 1	パク・チウォン代表	パク・チウォン代表	PROPN	名詞-固有名詞-人名-一般	_	52	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=パク;;チオン;ダイヒョウ,パク;・;チオン;代表,パク;・;チウォン;代表,パク;・;チウォン;代表,パク;;チオン;ダイヒョー,;;;,;;;,パク;;チオン;ダイヒョウ,パクチオンダイヒョウ,パク・チウォン代表
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2576,6 +2695,7 @@
 
 # newdoc id = test-s120
 # sent_id = test-s120
+# parallel_id = jagsdluw/test120
 # text = SMBC日興証券は2012年秋をめどにシンガポール拠点を開設する。
 1	SMBC日興証券	SMBC日興証券	PROPN	名詞-固有名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エスエムビーシー;ニッコウ;ショウケン,ＳＭＢＣ;日興;証券,SMBC;日興;証券,SMBC;日興;証券,エスエムビーシー;ニッコー;ショーケン,;;,;;,エスエムビーシー;ニッコウ;ショウケン,エスエムビーシーニッコウショウケン,SMBC日興証券
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2590,6 +2710,7 @@
 
 # newdoc id = test-s121
 # sent_id = test-s121
+# parallel_id = jagsdluw/test121
 # text = 3年ぶりにボランチでプレーしたので自己評価は出来ない。
 1	3年ぶり	3年ぶり	NUM	名詞-数詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ネン;ブリ,三;年;振り,3;年;ぶり,3;年;ぶり,サン;ネン;ブリ,;;,;;,サン;ネン;ブリ,サンネンブリ,3年ぶり
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2606,6 +2727,7 @@
 
 # newdoc id = test-s122
 # sent_id = test-s122
+# parallel_id = jagsdluw/test122
 # text = わずか半年間に重賞を3勝し、血統馬にふさわしい活躍を見せてきた。
 1	わずか	僅か	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワズカ,僅か,わずか,わずか,ワズカ,,,ワズカ,ワズカ,僅か
 2	半年間	半年間	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハントシ;カン,半年;間,半年;間,半年;間,ハントシ;カン,;,;,ハントシ;カン,ハントシカン,半年間
@@ -2626,6 +2748,7 @@
 
 # newdoc id = test-s123
 # sent_id = test-s123
+# parallel_id = jagsdluw/test123
 # text = 伏兵の一発を含む11安打9得点で静岡県勢として春通算50勝を達成。
 1	伏兵	伏兵	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フクヘイ,伏兵,伏兵,伏兵,フクヘー,,,フクヘイ,フクヘイ,伏兵
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2646,6 +2769,7 @@
 
 # newdoc id = test-s124
 # sent_id = test-s124
+# parallel_id = jagsdluw/test124
 # text = メディアから「45年の歴史を持つメジャーリーグのドラフト史上で『最高の選手』」と言われていたストラスバーグだが、この契約金は各方面で話題になった。
 1	メディア	メディア	NOUN	名詞-普通名詞-一般	_	20	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メディア,メディア,メディア,メディア,メディア,,,メディア,メディア,メディア
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -2687,6 +2811,7 @@
 
 # newdoc id = test-s125
 # sent_id = test-s125
+# parallel_id = jagsdluw/test125
 # text = 私たち去る大戦の悲惨な教訓から戦後「命どぅ宝」、基地のない平和で安全な沖縄を希求してきました。
 1	私たち	私達	PRON	代名詞	_	23	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ;タチ,私;達,私;たち,私;たち,ワタシ;タチ,;,;,ワタシ;タチ,ワタシタチ,私達
 2	去る	然る	ADJ	連体詞	_	3	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サル,然る,去る,去る,サル,,,サル,サル,然る
@@ -2718,6 +2843,7 @@
 
 # newdoc id = test-s126
 # sent_id = test-s126
+# parallel_id = jagsdluw/test126
 # text = 5/13に放送されるフジテレビ系「僕らの音楽」にて、福原美穂とAIという豪華共演が決定した。
 1	5/13	5/13	NUM	名詞-数詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ;;イチ;サン,五;/;一;三,5;/;1;3,5;/;1;3,ゴ;;イチ;サン,;;;,;;;,ゴ;;イチ;サン,ゴイチサン,5/13
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2743,6 +2869,7 @@
 
 # newdoc id = test-s127
 # sent_id = test-s127
+# parallel_id = jagsdluw/test127
 # text = そして次巻「約束の地で」では一気に時間が20年後へと飛ぶ。
 1	そして	そして	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	次巻	次巻	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジカン,次巻,次巻,次巻,ジカン,,,ジカン,ジカン,次巻
@@ -2766,6 +2893,7 @@
 
 # newdoc id = test-s128
 # sent_id = test-s128
+# parallel_id = jagsdluw/test128
 # text = もちろん、運転可能!
 1	もちろん	勿論	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モチロン,勿論,もちろん,もちろん,モチロン,,,モチロン,モチロン,勿論
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2774,6 +2902,7 @@
 
 # newdoc id = test-s129
 # sent_id = test-s129
+# parallel_id = jagsdluw/test129
 # text = ビーチや公園、家やオフィスなど様々な場所に持ち運んで楽しむことができます。
 1	ビーチ	ビーチ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビーチ,ビーチ,ビーチ,ビーチ,ビーチ,,,ビーチ,ビーチ,ビーチ
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -2796,6 +2925,7 @@
 
 # newdoc id = test-s130
 # sent_id = test-s130
+# parallel_id = jagsdluw/test130
 # text = 2人は以前、男性に向かって石を投げた際に投げ返されたり、喫煙していてとがめられたりしたことがあり、恨みを募らせていたという。
 1	2人	2人	NOUN	名詞-普通名詞-一般	_	30	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フタリ,二人,2人,2人,フタリ,,,フタリ,フタリ,2人
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2836,6 +2966,7 @@
 
 # newdoc id = test-s131
 # sent_id = test-s131
+# parallel_id = jagsdluw/test131
 # text = 深刻度がもっとも高い「緊急」とされるのは、「Windows」に関するプログラム4件。
 1	深刻度	深刻度	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンコク;ド,深刻;度,深刻;度,深刻;度,シンコク;ド,;,;,シンコク;ド,シンコクド,深刻度
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -2860,6 +2991,7 @@
 
 # newdoc id = test-s132
 # sent_id = test-s132
+# parallel_id = jagsdluw/test132
 # text = ただ、この質問に対する回答は、誰かに回答が固まることなく、1位の木村拓哉さんでも獲得率が5%以下と幅広くいろいろな人の名前が挙がる結果となりました。
 1	ただ	唯	CCONJ	接続詞	_	37	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダ,唯,ただ,ただ,タダ,,,タダ,タダ,唯
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2904,6 +3036,7 @@
 
 # newdoc id = test-s133
 # sent_id = test-s133
+# parallel_id = jagsdluw/test133
 # text = 早ければ2010年度から行う方向となった。
 1	早けれ	早い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハヤイ,早い,早けれ,早い,ハヤケレ,,,ハヤイ,ハヤイ,早い
 2	ば	ば	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=バ,ば,ば,ば,バ,,,バ,バ,ば
@@ -2918,6 +3051,7 @@
 
 # newdoc id = test-s134
 # sent_id = test-s134
+# parallel_id = jagsdluw/test134
 # text = 車を所有する人の割合は前回平成13年度調査の71・2%から11・9ポイント減少した。
 1	車	車	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クルマ,車,車,車,クルマ,,,クルマ,クルマ,車
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -2939,6 +3073,7 @@
 
 # newdoc id = test-s135
 # sent_id = test-s135
+# parallel_id = jagsdluw/test135
 # text = 大宮は終盤、攻勢を仕掛けるも得点は奪えず。
 1	大宮	大宮	PROPN	名詞-固有名詞-地名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオミヤ,オオミヤ,大宮,大宮,オーミヤ,,,オオミヤ,オオミヤ,大宮
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2956,6 +3091,7 @@
 
 # newdoc id = test-s136
 # sent_id = test-s136
+# parallel_id = jagsdluw/test136
 # text = 本当に申し訳ない。
 1	本当	本当	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホントウ,本当,本当,本当,ホント,,,ホント,ホントウ,本当
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2964,6 +3100,7 @@
 
 # newdoc id = test-s137
 # sent_id = test-s137
+# parallel_id = jagsdluw/test137
 # text = 独立型チャペルは、本格的なヨーロピアンテイスト。
 1	独立型チャペル	独立型チャペル	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドクリツ;ガタ;チャペル,独立;型;チャペル,独立;型;チャペル,独立;型;チャペル,ドクリツ;ガタ;チャペル,;;,;;,ドクリツ;ガタ;チャペル,ドクリツガタチャペル,独立型チャペル
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2975,6 +3112,7 @@
 
 # newdoc id = test-s138
 # sent_id = test-s138
+# parallel_id = jagsdluw/test138
 # text = 教室に火の気はなく、白河署と矢吹消防署は30日、実況見分し原因を調べる。
 1	教室	教室	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウシツ,教室,教室,教室,キョーシツ,,,キョウシツ,キョウシツ,教室
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2996,6 +3134,7 @@
 
 # newdoc id = test-s139
 # sent_id = test-s139
+# parallel_id = jagsdluw/test139
 # text = 一方で、西側の政治家や専門家の多くは、ノーベル賞委員会の決定は非常に理にかなったものであるとの評価を与えている。
 1	一方	一方	NOUN	名詞-普通名詞-一般	_	29	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3031,6 +3170,7 @@
 
 # newdoc id = test-s140
 # sent_id = test-s140
+# parallel_id = jagsdluw/test140
 # text = 午後に入ると139円80銭付近での推移となり、結局は14銭高の139円78銭で引けた。
 1	午後	午後	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴゴ,午後,午後,午後,ゴゴ,,,ゴゴ,ゴゴ,午後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3057,6 +3197,7 @@
 
 # newdoc id = test-s141
 # sent_id = test-s141
+# parallel_id = jagsdluw/test141
 # text = ゴールドマン・サックス証券は257社、日本最大手の野村証券は608社。
 1	ゴールドマン・サックス証券	ゴールドマン・サックス証券	PROPN	名詞-固有名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴールドマン;;サックス;ショウケン,ゴールドマン;・;サックス;証券,ゴールドマン;・;サックス;証券,ゴールドマン;・;サックス;証券,ゴールドマン;;サックス;ショーケン,;;;,;;;,ゴールドマン;;サックス;ショウケン,ゴールドマンサックスショウケン,ゴールドマン・サックス証券
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3071,6 +3212,7 @@
 
 # newdoc id = test-s142
 # sent_id = test-s142
+# parallel_id = jagsdluw/test142
 # text = 知床半島も、はじめて訪れた1971年から大きく変わり、羅臼の漁師の家も番屋も立派になり、ウトロには無数のホテルが建ち、「地の果て」とは言えない様変わりをしています。
 1	知床半島	知床半島	PROPN	名詞-固有名詞-地名-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シレトコ;ハントウ,シレトコ;半島,知床;半島,知床;半島,シレトコ;ハントー,;,;,シレトコ;ハントウ,シレトコハントウ,知床半島
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -3122,6 +3264,7 @@
 
 # newdoc id = test-s143
 # sent_id = test-s143
+# parallel_id = jagsdluw/test143
 # text = 企業経営者の、そして企業人一人ひとりの意識改革ではないだろうか。
 1	企業経営者	企業経営者	NOUN	名詞-普通名詞-一般	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キギョウ;ケイエイ;シャ,企業;経営;者,企業;経営;者,企業;経営;者,キギョー;ケーエー;シャ,;;,;;,キギョウ;ケイエイ;シャ,キギョウケイエイシャ,企業経営者
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3137,6 +3280,7 @@
 
 # newdoc id = test-s144
 # sent_id = test-s144
+# parallel_id = jagsdluw/test144
 # text = ※世帯ごとに保険料の上限が決まっている。
 1	※	※	SYM	補助記号-一般	_	8	dep	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=,※,※,※,,,,,,※
 2	世帯ごと	世帯毎	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セタイ;ゴト,世帯;毎,世帯;ごと,世帯;ごと,セタイ;ゴト,;,;,セタイ;ゴト,セタイゴト,世帯毎
@@ -3151,6 +3295,7 @@
 
 # newdoc id = test-s145
 # sent_id = test-s145
+# parallel_id = jagsdluw/test145
 # text = 県では「風評被害を防ぐため」として店舗名を公表していない。
 1	県	県	NOUN	名詞-普通名詞-一般	_	13	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケン,県,県,県,ケン,,,ケン,ケン,県
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3171,6 +3316,7 @@
 
 # newdoc id = test-s146
 # sent_id = test-s146
+# parallel_id = jagsdluw/test146
 # text = 先が気になるストーリー展開や、3人の演技に引き込まれてしまうこと間違いナシだ!
 1	先	先	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サキ,先,先,先,サキ,,,サキ,サキ,先
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3193,6 +3339,7 @@
 
 # newdoc id = test-s149
 # sent_id = test-s149
+# parallel_id = jagsdluw/test149
 # text = 法案が上院を通過すれば、昨年12月に下院を通過した法案と統合する必要があり、アナリストによると、その時期は5月下旬になると見込まれている。
 1	法案	法案	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホウアン,法案,法案,法案,ホーアン,,,ホウアン,ホウアン,法案
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3232,6 +3379,7 @@
 
 # newdoc id = test-s150
 # sent_id = test-s150
+# parallel_id = jagsdluw/test150
 # text = 来場者は熱心に見入っていた。
 1	来場者	来場者	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ライジョウ;シャ,来場;者,来場;者,来場;者,ライジョー;シャ,;,;,ライジョウ;シャ,ライジョウシャ,来場者
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3244,12 +3392,14 @@
 
 # newdoc id = test-s151
 # sent_id = test-s151
+# parallel_id = jagsdluw/test151
 # text = 入場無料。
 1	入場無料	入場無料	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ニュウジョウ;ムリョウ,入場;無料,入場;無料,入場;無料,ニュージョー;ムリョー,;,;,ニュウジョウ;ムリョウ,ニュウジョウムリョウ,入場無料
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s152
 # sent_id = test-s152
+# parallel_id = jagsdluw/test152
 # text = 当面は同省職員2人を派遣。
 1	当面	当面	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウメン,当面,当面,当面,トーメン,,,トウメン,トウメン,当面
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3261,6 +3411,7 @@
 
 # newdoc id = test-s153
 # sent_id = test-s153
+# parallel_id = jagsdluw/test153
 # text = 株式会社GCIキャピタルは、信頼できる情報をもとに本資料を作成しておりますが、正確性・完全性について株式会社GCIキャピタルが責任を負うものではありません。
 1	株式会社GCIキャピタル	株式会社GCIキャピタル	PROPN	名詞-固有名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カブシキ;カイシャ;ジーシーアイ;キャピタル,株式;会社;ＧＣＩ;キャピタル,株式;会社;GCI;キャピタル,株式;会社;GCI;キャピタル,カブシキ;ガイシャ;ジーシーアイ;キャピタル,;;;,;;;,カブシキ;カイシャ;ジーシーアイ;キャピタル,カブシキガイシャジーシーアイキャピタル,株式会社GCIキャピタル
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3290,6 +3441,7 @@
 
 # newdoc id = test-s154
 # sent_id = test-s154
+# parallel_id = jagsdluw/test154
 # text = そのあだ名の通り、女性を見ると口説き、襲おうとするリョウちゃん。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	あだ名	渾名	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アダナ,渾名,あだ名,あだ名,アダナ,,,アダナ,アダナ,渾名
@@ -3310,6 +3462,7 @@
 
 # newdoc id = test-s155
 # sent_id = test-s155
+# parallel_id = jagsdluw/test155
 # text = 男女が親交を深めやすいようにと、ピザ作り体験などを企画の柱にしたところ大好評となった。
 1	男女	男女	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダンジョ,男女,男女,男女,ダンジョ,,,ダンジョ,ダンジョ,男女
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3337,6 +3490,7 @@
 
 # newdoc id = test-s156
 # sent_id = test-s156
+# parallel_id = jagsdluw/test156
 # text = 恵まれた身体能力を生かした守備はもちろん、闘争心をむき出しに前線へと駆け上がるプレーで相手を翻弄。
 1	恵まれ	恵まれる	VERB	動詞-一般-下一段-ラ行	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メグマレル,恵まれる,恵まれ,恵まれる,メグマレ,,,メグマレル,メグマレル,恵まれる
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -3365,6 +3519,7 @@
 
 # newdoc id = test-s157
 # sent_id = test-s157
+# parallel_id = jagsdluw/test157
 # text = ベストアルバム『BAD TIMES』をリリースすることが明らかになりました!
 1	ベストアルバム	ベストアルバム	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベスト;アルバム,ベスト;アルバム,ベスト;アルバム,ベスト;アルバム,ベスト;アルバム,;,;,ベスト;アルバム,ベストアルバム,ベストアルバム
 2	『	『	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
@@ -3383,6 +3538,7 @@
 
 # newdoc id = test-s158
 # sent_id = test-s158
+# parallel_id = jagsdluw/test158
 # text = 震災を考慮して街頭運動が一部異例の選挙戦がスタートした。
 1	震災	震災	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンサイ,震災,震災,震災,シンサイ,,,シンサイ,シンサイ,震災
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -3400,6 +3556,7 @@
 
 # newdoc id = test-s159
 # sent_id = test-s159
+# parallel_id = jagsdluw/test159
 # text = トッティは試合後に「この記録を誇りに思うが、ここで止まることはない」とコメント。
 1	トッティ	トッティ	PROPN	名詞-固有名詞-人名-一般	_	20	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トッティ,トッティ,トッティ,トッティ,トッティ,,,トッティ,トッティ,トッティ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3425,6 +3582,7 @@
 
 # newdoc id = test-s160
 # sent_id = test-s160
+# parallel_id = jagsdluw/test160
 # text = 尾崎淳介校長は「水筒を持たせ、帽子をかぶるように指導していた。
 1	尾崎淳介校長	尾崎淳介校長	PROPN	名詞-固有名詞-人名-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オザキ;ジュンスケ;コウチョウ,オザキ;ジュンスケ;校長,尾崎;淳介;校長,尾崎;淳介;校長,オザキ;ジュンスケ;コーチョー,;;,;;,オザキ;ジュンスケ;コウチョウ,オザキジュンスケコウチョウ,尾崎淳介校長
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3446,6 +3604,7 @@
 
 # newdoc id = test-s161
 # sent_id = test-s161
+# parallel_id = jagsdluw/test161
 # text = 自由で不思議でキュートな女の子、AKB48チームBのメンバーメンバー小林香菜。
 1	自由	自由	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジユウ,自由,自由,自由,ジユー,,,ジユウ,ジユウ,自由
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -3462,6 +3621,7 @@
 
 # newdoc id = test-s162
 # sent_id = test-s162
+# parallel_id = jagsdluw/test162
 # text = 景観・社会・文化・報道・文化遺産・近代史写真等、豊富なジャンルでご対応!
 1	景観・社会・文化・報道・文化遺産・近代史写真等	景観・社会・文化・報道・文化遺産・近代史写真等	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイカン;;シャカイ;;ブンカ;;ホウドウ;;ブンカ;イサン;;キンダイ;シ;シャシン;トウ,景観;・;社会;・;文化;・;報道;・;文化;遺産;・;近代;史;写真;等,景観;・;社会;・;文化;・;報道;・;文化;遺産;・;近代;史;写真;等,景観;・;社会;・;文化;・;報道;・;文化;遺産;・;近代;史;写真;等,ケーカン;;シャカイ;;ブンカ;;ホードー;;ブンカ;イサン;;キンダイ;シ;シャシン;トー,;;;;;;;;;;;;;;,;;;;;;;;;;;;;;,ケイカン;;シャカイ;;ブンカ;;ホウドウ;;ブンカ;イサン;;キンダイ;シ;シャシン;トウ,ケイカンシャカイブンカホウドウブンカイサンキンダイシシャシントウ,景観・社会・文化・報道・文化遺産・近代史写真等
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3474,6 +3634,7 @@
 
 # newdoc id = test-s163
 # sent_id = test-s163
+# parallel_id = jagsdluw/test163
 # text = 過去に記者会見で歌を歌った選手などがいたが競技外のパフォーマンスがどうであったとしても競技で結果を残せなければ何の意味もない事をトリノ以降、協会が選手に伝えきれていない。
 1	過去	過去	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カコ,過去,過去,過去,カコ,,,カコ,カコ,過去
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3524,6 +3685,7 @@
 
 # newdoc id = test-s164
 # sent_id = test-s164
+# parallel_id = jagsdluw/test164
 # text = 18分以降、SAGAWAがボールをキープする時間が増え出し行くのだが、これはペースを握っているのではなく、前からのプレッシャーが厳しいため、一旦下げて後ろで回し、なんとか穴を探ろうとしたためにポゼッションする時間が増えただけのこと。
 1	18分以降	18分以降	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;フン;イコウ,一;八;分;以降,1;8;分;以降,1;8;分;以降,イチ;ハッ;プン;イコー,;;;,;;;,イチ;ハチ;フン;イコウ,イチハップンイコウ,18分以降
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3582,6 +3744,7 @@
 
 # newdoc id = test-s165
 # sent_id = test-s165
+# parallel_id = jagsdluw/test165
 # text = 通路を使って移動し、ホーム上の混雑を回避する。
 1	通路	通路	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツウロ,通路,通路,通路,ツーロ,,,ツウロ,ツウロ,通路
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -3598,6 +3761,7 @@
 
 # newdoc id = test-s166
 # sent_id = test-s166
+# parallel_id = jagsdluw/test166
 # text = 2号機の西1・1キロにある西門付近で、17日午前0時半に毎時351・4マイクロシーベルトだった放射線量が、18日午前8時には270・5マイクロシーベルトに下がった。
 1	2号機	2号機	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゴウ;キ,二;号;機,2;号;機,2;号;機,ニ;ゴー;キ,;;,;;,ニ;ゴウ;キ,ニゴウキ,2号機
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3632,6 +3796,7 @@
 
 # newdoc id = test-s167
 # sent_id = test-s167
+# parallel_id = jagsdluw/test167
 # text = 簡単でおいしい上に、栄養のバランスがいいとなれば言うことなしです。
 1	簡単	簡単	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンタン,簡単,簡単,簡単,カンタン,,,カンタン,カンタン,簡単
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -3653,6 +3818,7 @@
 
 # newdoc id = test-s168
 # sent_id = test-s168
+# parallel_id = jagsdluw/test168
 # text = また、レートにより金額が多少左右されます。
 1	また	又	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3668,6 +3834,7 @@
 
 # newdoc id = test-s169
 # sent_id = test-s169
+# parallel_id = jagsdluw/test169
 # text = 立件に消極的だったという。
 1	立件	立件	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リッケン,立件,立件,立件,リッケン,,,リッケン,リッケン,立件
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3680,6 +3847,7 @@
 
 # newdoc id = test-s170
 # sent_id = test-s170
+# parallel_id = jagsdluw/test170
 # text = わが外相が「重要な進展だ」と胸を張っているように見えたのは、きっと気のせいだ。
 1	わが	我が	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワガ,我が,わが,わが,ワガ,,,ワガ,ワガ,我が
 2	外相	外相	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガイショウ,外相,外相,外相,ガイショー,,,ガイショウ,ガイショウ,外相
@@ -3711,6 +3879,7 @@
 
 # newdoc id = test-s171
 # sent_id = test-s171
+# parallel_id = jagsdluw/test171
 # text = オバマ大統領は、雇用対策の恩恵を受ける教師や警官、建設労働者らを背に演説に臨み、「この法案が、人々を職場に戻していくことにつながる」とアピール。
 1	オバマ大統領	オバマ大統領	PROPN	名詞-固有名詞-人名-一般	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オバマ;ダイトウリョウ,オバマ;大統領,オバマ;大統領,オバマ;大統領,オバマ;ダイトーリョー,;,;,オバマ;ダイトウリョウ,オバマダイトウリョウ,オバマ大統領
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3753,6 +3922,7 @@
 
 # newdoc id = test-s172
 # sent_id = test-s172
+# parallel_id = jagsdluw/test172
 # text = オーストラリア、カナダ、メキシコでも、それぞれの国の労働者が転職先を見つけることができるとの回答が高いことがわかりました
 1	オーストラリア	オーストラリア	PROPN	名詞-固有名詞-地名-国	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オーストラリア,オーストラリア,オーストラリア,オーストラリア,オーストラリア,,,オーストラリア,オーストラリア,オーストラリア
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3785,6 +3955,7 @@
 
 # newdoc id = test-s173
 # sent_id = test-s173
+# parallel_id = jagsdluw/test173
 # text = 橋下知事は立候補を明言こそしなかったが、「大都市、大阪の市長に平松市長はふさわしくない。
 1	橋下知事	橋下知事	PROPN	名詞-固有名詞-人名-姓	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハシモト;チジ,ハシモト;知事,橋下;知事,橋下;知事,ハシモト;チジ,;,;,ハシモト;チジ,ハシモトチジ,橋下知事
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3812,6 +3983,7 @@
 
 # newdoc id = test-s174
 # sent_id = test-s174
+# parallel_id = jagsdluw/test174
 # text = 米中戦略・経済対話初日の米側は中国の反体制派への弾圧を厳しく批判したが、世界の経済成長については協調的な姿勢を示した。
 1	米中戦略・経済対話初日	米中戦略・経済対話初日	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベイチュウ;センリャク;;ケイザイ;タイワ;ショニチ,米中;戦略;・;経済;対話;初日,米中;戦略;・;経済;対話;初日,米中;戦略;・;経済;対話;初日,ベーチュー;センリャク;;ケーザイ;タイワ;ショニチ,;;;;;,;;;;;,ベイチュウ;センリャク;;ケイザイ;タイワ;ショニチ,ベイチュウセンリャクケイザイタイワショニチ,米中戦略・経済対話初日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3844,6 +4016,7 @@
 
 # newdoc id = test-s175
 # sent_id = test-s175
+# parallel_id = jagsdluw/test175
 # text = ジャカルタの街中で自転車を利用する人が増えたように思う。
 1	ジャカルタ	ジャカルタ	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジャカルタ,ジャカルタ,ジャカルタ,ジャカルタ,ジャカルタ,,,ジャカルタ,ジャカルタ,ジャカルタ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3863,6 +4036,7 @@
 
 # newdoc id = test-s176
 # sent_id = test-s176
+# parallel_id = jagsdluw/test176
 # text = サイトの新しい楽しみ方「屋上会議室」好評公開中!
 1	サイト	サイト	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイト,サイト,サイト,サイト,サイト,,,サイト,サイト,サイト
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3876,6 +4050,7 @@
 
 # newdoc id = test-s177
 # sent_id = test-s177
+# parallel_id = jagsdluw/test177
 # text = その名の通り、スライド全面にグラフィックを配置。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	名	名	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナ,名,名,名,ナ,,,ナ,ナ,名
@@ -3891,6 +4066,7 @@
 
 # newdoc id = test-s178
 # sent_id = test-s178
+# parallel_id = jagsdluw/test178
 # text = 高校時代の同級生とあって合宿中も、不安を打ち明け合っているという。
 1	高校時代	高校時代	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウコウ;ジダイ,高校;時代,高校;時代,高校;時代,コーコー;ジダイ,;,;,コウコウ;ジダイ,コウコウジダイ,高校時代
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3911,6 +4087,7 @@
 
 # newdoc id = test-s179
 # sent_id = test-s179
+# parallel_id = jagsdluw/test179
 # text = あるいは、試練に挑もうとしない逃避癖だ。
 1	あるいは	或いは	CCONJ	接続詞	_	9	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アルイハ,或いは,あるいは,あるいは,アルイワ,,,アルイハ,アルイハ,或いは
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3926,6 +4103,7 @@
 
 # newdoc id = test-s180
 # sent_id = test-s180
+# parallel_id = jagsdluw/test180
 # text = イランが、IEF国際エネルギー・フォーラム実行委員会の常任メンバー国に選出されました。
 1	イラン	イラン	PROPN	名詞-固有名詞-地名-国	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イラン,イラン,イラン,イラン,イラン,,,イラン,イラン,イラン
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3942,6 +4120,7 @@
 
 # newdoc id = test-s181
 # sent_id = test-s181
+# parallel_id = jagsdluw/test181
 # text = 信号変換効率を向上するとともに、超低域の歪みを改善し、低域から高域まで、すぐれた周波数特性を実現している。
 1	信号変換効率	信号変換効率	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンゴウ;ヘンカン;コウリツ,信号;変換;効率,信号;変換;効率,信号;変換;効率,シンゴー;ヘンカン;コーリツ,;;,;;,シンゴウ;ヘンカン;コウリツ,シンゴウヘンカンコウリツ,信号変換効率
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -3969,6 +4148,7 @@
 
 # newdoc id = test-s182
 # sent_id = test-s182
+# parallel_id = jagsdluw/test182
 # text = 初期投資のいくらか全ての損失を被る可能性が存在します、
 1	初期投資	初期投資	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショキ;トウシ,初期;投資,初期;投資,初期;投資,ショキ;トーシ,;,;,ショキ;トウシ,ショキトウシ,初期投資
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3987,6 +4167,7 @@
 
 # newdoc id = test-s183
 # sent_id = test-s183
+# parallel_id = jagsdluw/test183
 # text = 最初の仕切りで芳東に待ったをかけられた宝智山は、仕切り直しの立ち合いで得意の右四つとなり左上手を取ると、相手に構うことなく前に出てそのまま寄り倒した。
 1	最初	最初	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイショ,最初,最初,最初,サイショ,,,サイショ,サイショ,最初
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4035,6 +4216,7 @@
 
 # newdoc id = test-s184
 # sent_id = test-s184
+# parallel_id = jagsdluw/test184
 # text = 父から「おまえが決意して、そこまでやるなら応援する」と思いもよらない言葉で激励された。
 1	父	父	NOUN	名詞-普通名詞-一般	_	22	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チチ,父,父,父,チチ,,,チチ,チチ,父
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -4064,6 +4246,7 @@
 
 # newdoc id = test-s185
 # sent_id = test-s185
+# parallel_id = jagsdluw/test185
 # text = 西宮市は活動を大規模災害に限っているため、日常的に活動する機能別消防団員は県内初。
 1	西宮市	西宮市	PROPN	名詞-固有名詞-地名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニシノミヤ;シ,ニシノミヤ;市,西宮;市,西宮;市,ニシノミヤ;シ,;,;,ニシノミヤ;シ,ニシノミヤシ,西宮市
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4085,6 +4268,7 @@
 
 # newdoc id = test-s186
 # sent_id = test-s186
+# parallel_id = jagsdluw/test186
 # text = 東中本運動場まで徒歩5分一日600円/5台
 1	東中本運動場	東中本運動場	NOUN	名詞-普通名詞-一般	_	8	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒガシ;ナカモト;ウンドウ;ジョウ,東;ナカモト;運動;場,東;中本;運動;場,東;中本;運動;場,ヒガシ;ナカモト;ウンドー;ジョー,;;;,;;;,ヒガシ;ナカモト;ウンドウ;ジョウ,ヒガシナカモトウンドウジョウ,東中本運動場
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -4097,6 +4281,7 @@
 
 # newdoc id = test-s187
 # sent_id = test-s187
+# parallel_id = jagsdluw/test187
 # text = って言ってる年齢不詳?
 1	って	つう	PART	助詞-副助詞	_	2	mark	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ッテ,って,って,って,ッテ,,,ッテ,ツウ,つう
 2	言っ	言う	VERB	動詞-一般-五段-ワア行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イウ,言う,言っ,言う,イッ,,,イウ,イウ,言う
@@ -4106,6 +4291,7 @@
 
 # newdoc id = test-s188
 # sent_id = test-s188
+# parallel_id = jagsdluw/test188
 # text = キレイでオシャレな店内はずっといてもいいぐらいですね。
 1	キレイ	奇麗	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キレイ,奇麗,キレイ,キレイ,キレー,,,キレイ,キレイ,奇麗
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -4123,6 +4309,7 @@
 
 # newdoc id = test-s189
 # sent_id = test-s189
+# parallel_id = jagsdluw/test189
 # text = 自分は希望スタイルをいつも複数抱えて来店しますが、センスの良いスタッフの意見が役に立っていつも満足のいく仕上がりを施してくださいます。
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4162,6 +4349,7 @@
 
 # newdoc id = test-s190
 # sent_id = test-s190
+# parallel_id = jagsdluw/test190
 # text = あれじゃ客は来ないね、
 1	あれ	彼れ	PRON	代名詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アレ,彼れ,あれ,あれ,アレ,,,アレ,アレ,彼れ
 2	じゃ	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,じゃ,じゃ,ジャ,,,ジャ,デ,で
@@ -4174,6 +4362,7 @@
 
 # newdoc id = test-s191
 # sent_id = test-s191
+# parallel_id = jagsdluw/test191
 # text = 診察は予約制なのに1時間まちはざらです。
 1	診察	診察	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンサツ,診察,診察,診察,シンサツ,,,シンサツ,シンサツ,診察
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4189,6 +4378,7 @@
 
 # newdoc id = test-s192
 # sent_id = test-s192
+# parallel_id = jagsdluw/test192
 # text = “シールド工法”が良くわかります。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	シールド工法	シールド工法	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シールド;コウホウ,シールド;工法,シールド;工法,シールド;工法,シールド;コーホー,;,;,シールド;コウホウ,シールドコウホウ,シールド工法
@@ -4201,6 +4391,7 @@
 
 # newdoc id = test-s193
 # sent_id = test-s193
+# parallel_id = jagsdluw/test193
 # text = エステは受けたことが無いので相場はわかりませんでしたが、まぁ、これなら妥当かな、という感じでした。
 1	エステ	エステ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エステ,エステ,エステ,エステ,エステ,,,エステ,エステ,エステ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4235,6 +4426,7 @@
 
 # newdoc id = test-s194
 # sent_id = test-s194
+# parallel_id = jagsdluw/test194
 # text = 父には90分コースをセレクトしましたが、新規価格ということで少しお得になっていました。
 1	父	父	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チチ,父,父,父,チチ,,,チチ,チチ,父
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4261,6 +4453,7 @@
 
 # newdoc id = test-s195
 # sent_id = test-s195
+# parallel_id = jagsdluw/test195
 # text = 友人の紹介で東京の出張マッサージを利用。
 1	友人	友人	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユウジン,友人,友人,友人,ユージン,,,ユウジン,ユウジン,友人
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4275,6 +4468,7 @@
 
 # newdoc id = test-s196
 # sent_id = test-s196
+# parallel_id = jagsdluw/test196
 # text = スタッフがフレンドリー。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフ,スタッフ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4283,6 +4477,7 @@
 
 # newdoc id = test-s197
 # sent_id = test-s197
+# parallel_id = jagsdluw/test197
 # text = お皿は全て重ねてたのですが、しばらくすると女性の従業員が来て、こちらのトロ刺身のお皿はお取りになられましたか?
 1	お皿	御皿	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;サラ,御;皿,お;皿,お;皿,オ;サラ,;,;,オ;サラ,オサラ,御皿
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4318,6 +4513,7 @@
 
 # newdoc id = test-s198
 # sent_id = test-s198
+# parallel_id = jagsdluw/test198
 # text = 営業時間は朝9時~夜7時までみたいですが、人気のあるパンはすぐなくなってしまいます。
 1	営業時間	営業時間	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エイギョウ;ジカン,営業;時間,営業;時間,営業;時間,エーギョー;ジカン,;,;,エイギョウ;ジカン,エイギョウジカン,営業時間
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4344,6 +4540,7 @@
 
 # newdoc id = test-s199
 # sent_id = test-s199
+# parallel_id = jagsdluw/test199
 # text = 大門側から高野山に入って最初の信号にある出光興産系のガソリンスタンド。
 1	大門側	大門側	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイモン;ガワ,大門;側,大門;側,大門;側,ダイモン;ガワ,;,;,ダイモン;ガワ,ダイモンガワ,大門側
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -4363,6 +4560,7 @@
 
 # newdoc id = test-s200
 # sent_id = test-s200
+# parallel_id = jagsdluw/test200
 # text = テレビにて、こちらの店を知りましたが、こだわりの店と認識していたので正直がっかりさせられました。
 1	テレビ	テレビ	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テレビ,テレビ,テレビ,テレビ,テレビ,,,テレビ,テレビ,テレビ
 2	にて	にて	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニテ,にて,にて,にて,ニテ,,,ニテ,ニテ,にて
@@ -4394,6 +4592,7 @@
 
 # newdoc id = test-s201
 # sent_id = test-s201
+# parallel_id = jagsdluw/test201
 # text = アアルトさんのコーヒー豆を使ったコーヒーは文句のつけようなし!
 1	アアルトさん	アアルトさん	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アールト;サン,アールト;さん,アアルト;さん,アアルト;さん,アールト;サン,;,;,アールト;サン,アールトサン,アアルトさん
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4411,6 +4610,7 @@
 
 # newdoc id = test-s202
 # sent_id = test-s202
+# parallel_id = jagsdluw/test202
 # text = 値段も普通くらいかな。
 1	値段	値段	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネダン,値段,値段,値段,ネダン,,,ネダン,ネダン,値段
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4422,6 +4622,7 @@
 
 # newdoc id = test-s203
 # sent_id = test-s203
+# parallel_id = jagsdluw/test203
 # text = いつも割りと混んでる。
 1	いつ	何時	PRON	代名詞	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イツ,何時,いつ,いつ,イツ,,,イツ,イツ,何時
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4432,6 +4633,7 @@
 
 # newdoc id = test-s204
 # sent_id = test-s204
+# parallel_id = jagsdluw/test204
 # text = 宴会が入って忙しかったのかも知れないが、接客は最悪、味も最低、刺身の盛り合わせは水っぽく、町のスーパーで売っている最低ランクの刺身と同じ味。
 1	宴会	宴会	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エンカイ,宴会,宴会,宴会,エンカイ,,,エンカイ,エンカイ,宴会
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4473,6 +4675,7 @@
 
 # newdoc id = test-s205
 # sent_id = test-s205
+# parallel_id = jagsdluw/test205
 # text = 夜は5時に行くのが1番です。
 1	夜	夜	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨル,夜,夜,夜,ヨル,,,ヨル,ヨル,夜
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4487,6 +4690,7 @@
 
 # newdoc id = test-s206
 # sent_id = test-s206
+# parallel_id = jagsdluw/test206
 # text = 治療やケアの方も素晴らしく、待合室もここが歯医者だと忘れてしまうくらい立派です。
 1	治療	治療	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チリョウ,治療,治療,治療,チリョー,,,チリョウ,チリョウ,治療
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -4512,6 +4716,7 @@
 
 # newdoc id = test-s207
 # sent_id = test-s207
+# parallel_id = jagsdluw/test207
 # text = 料理も美味しいし、女将・スタッフの皆さんよい感じでしたよ!
 1	料理	料理	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リョウリ,料理,料理,料理,リョーリ,,,リョウリ,リョウリ,料理
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4530,6 +4735,7 @@
 
 # newdoc id = test-s211
 # sent_id = test-s211
+# parallel_id = jagsdluw/test211
 # text = この様な担当者の姿勢、とても良いと思います。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	様	様	NOUN	形状詞-助動詞語幹	_	6	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=ヨウ,様,様,様,ヨー,,,ヨウ,ヨウ,様
@@ -4547,6 +4753,7 @@
 
 # newdoc id = test-s212
 # sent_id = test-s212
+# parallel_id = jagsdluw/test212
 # text = 他社と比べても初めての見積もりの内容が非常に具体的でイメージがわきやすく好印象でした。
 1	他社	他社	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タシャ,他社,他社,他社,タシャ,,,タシャ,タシャ,他社
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -4573,6 +4780,7 @@
 
 # newdoc id = test-s213
 # sent_id = test-s213
+# parallel_id = jagsdluw/test213
 # text = 持ってきてくれるのはいいのですが、他のメニューは食べ終わってしまって「おあずけ」状態です。
 1	持っ	持つ	VERB	動詞-一般-五段-タ行	_	6	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モツ,持つ,持っ,持つ,モッ,,,モツ,モツ,持つ
 2	てき	てく	AUX	助動詞-五段-カ行	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ;クル,て;来る,て;き,て;くる,テ;キ,;,;,テ;クル,テク,てく
@@ -4599,6 +4807,7 @@
 
 # newdoc id = test-s214
 # sent_id = test-s214
+# parallel_id = jagsdluw/test214
 # text = また、この店は、土日になるとドライブスルー渋滞ができます。
 1	また	又	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4618,6 +4827,7 @@
 
 # newdoc id = test-s215
 # sent_id = test-s215
+# parallel_id = jagsdluw/test215
 # text = 料理は美味しい、雰囲気も良い、なによりお酒が美味しい。
 1	料理	料理	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リョウリ,料理,料理,料理,リョーリ,,,リョウリ,リョウリ,料理
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4635,6 +4845,7 @@
 
 # newdoc id = test-s216
 # sent_id = test-s216
+# parallel_id = jagsdluw/test216
 # text = 最近かなり混んで来ましたが先生は相変わらずマイペースでしっかり診療してくれるので予約が遅くなっても不満はありません。
 1	最近	最近	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイキン,最近,最近,最近,サイキン,,,サイキン,サイキン,最近
 2	かなり	可成	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カナリ,可成,かなり,かなり,カナリ,,,カナリ,カナリ,可成
@@ -4668,6 +4879,7 @@
 
 # newdoc id = test-s217
 # sent_id = test-s217
+# parallel_id = jagsdluw/test217
 # text = 参ったなぁ、と途方にくれた時ふと最初に「あれではないよな」と思っていた不動明王の像があるお墓。
 1	参っ	参る	VERB	動詞-一般-五段-ラ行	_	8	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マイル,参る,参っ,参る,マイッ,,,マイル,マイル,参る
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -4702,6 +4914,7 @@
 
 # newdoc id = test-s218
 # sent_id = test-s218
+# parallel_id = jagsdluw/test218
 # text = バッティングセンターとビリヤード台もあって、仕出しをとれる会議室もあり、小さいながらも施設機能は充実してます。
 1	バッティングセンター	バッティングセンター	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バッティング;センター,バッティング;センター,バッティング;センター,バッティング;センター,バッティング;センター,;,;,バッティング;センター,バッティングセンター,バッティングセンター
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -4729,6 +4942,7 @@
 
 # newdoc id = test-s219
 # sent_id = test-s219
+# parallel_id = jagsdluw/test219
 # text = 子供お祝い返しに買ったロールケーキがカビていたので、本当に怒りしんとうでした
 1	子供お祝い返し	子供御祝い返し	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コドモ;オ;イワイガエシ,子供;御;祝い返し,子供;お;祝い返し,子供;お;祝い返し,コドモ;オ;イワイガエシ,;;,;;,コドモ;オ;イワイガエシ,コドモオイワイガエシ,子供御祝い返し
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4749,6 +4963,7 @@
 
 # newdoc id = test-s220
 # sent_id = test-s220
+# parallel_id = jagsdluw/test220
 # text = すごく親身にお世話してくれました。
 1	すごく	凄い	ADJ	形容詞-一般-形容詞	_	2	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごく,すごい,スゴク,,,スゴイ,スゴイ,凄い
 2	親身	親身	ADJ	形状詞-一般	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンミ,親身,親身,親身,シンミ,,,シンミ,シンミ,親身
@@ -4761,6 +4976,7 @@
 
 # newdoc id = test-s221
 # sent_id = test-s221
+# parallel_id = jagsdluw/test221
 # text = 最近出来た新しい産婦人科と悩みましたが、こちらの病院を選び正解だったと感じてます。
 1	最近	最近	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイキン,最近,最近,最近,サイキン,,,サイキン,サイキン,最近
 2	出来	出来る	VERB	動詞-一般-上一段-カ行	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=できる|SpaceAfter=No|UnidicInfo=デキル,出来る,出来,出来る,デキ,,,デキル,デキル,出来る
@@ -4789,6 +5005,7 @@
 
 # newdoc id = test-s222
 # sent_id = test-s222
+# parallel_id = jagsdluw/test222
 # text = その時からのだから?
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	時	時	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=トキ,時,時,時,トキ,,,トキ,トキ,時
@@ -4799,6 +5016,7 @@
 
 # newdoc id = test-s223
 # sent_id = test-s223
+# parallel_id = jagsdluw/test223
 # text = 美味しいおせんべいの他、ワッフルやゼリーなどもオススメです。
 1	美味しい	美味しい	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オイシイ,美味しい,美味しい,美味しい,オイシー,,,オイシイ,オイシイ,美味しい
 2	おせんべい	御煎餅	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;センベイ,御;煎餅,お;せんべい,お;せんべい,オ;センベー,;,;,オ;センベイ,オセンベイ,御煎餅
@@ -4816,6 +5034,7 @@
 
 # newdoc id = test-s224
 # sent_id = test-s224
+# parallel_id = jagsdluw/test224
 # text = ずっとコンプレックスだったので、キレイにしていただけて本当に良かったです。
 1	ずっと	ずっと	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ズット,ずっと,ずっと,ずっと,ズット,,,ズット,ズット,ずっと
 2	コンプレックス	コンプレックス	NOUN	名詞-普通名詞-一般	_	14	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンプレックス,コンプレックス,コンプレックス,コンプレックス,コンプレックス,,,コンプレックス,コンプレックス,コンプレックス
@@ -4837,6 +5056,7 @@
 
 # newdoc id = test-s226
 # sent_id = test-s226
+# parallel_id = jagsdluw/test226
 # text = とりあえず生ビールから始め、華のれんさんのサイトで気になってた「ばくだん」という名物料理でまずは一杯。
 1	とりあえず	取り敢えず	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トリアエズ,取り敢えず,とりあえず,とりあえず,トリアエズ,,,トリアエズ,トリアエズ,取り敢えず
 2	生ビール	生ビール	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナマ;ビール,生;ビール,生;ビール,生;ビール,ナマ;ビール,;,;,ナマ;ビール,ナマビール,生ビール
@@ -4865,6 +5085,7 @@
 
 # newdoc id = test-s227
 # sent_id = test-s227
+# parallel_id = jagsdluw/test227
 # text = Tacoは1つ3ドルぐらい。
 1	Taco	Taco	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タコ,Taco,Taco,Taco,タコ,,,タコ,タコ,Taco
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4875,6 +5096,7 @@
 
 # newdoc id = test-s228
 # sent_id = test-s228
+# parallel_id = jagsdluw/test228
 # text = ゼクシィを見て、いろいろなお店に体験に行きましたが、このお店が圧倒的によかったので、通うことにしました。
 1	ゼクシィ	ゼクシィ	PROPN	名詞-固有名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼクシー,ゼクシー,ゼクシィ,ゼクシィ,ゼクシー,,,ゼクシー,ゼクシー,ゼクシー
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4909,6 +5131,7 @@
 
 # newdoc id = test-s229
 # sent_id = test-s229
+# parallel_id = jagsdluw/test229
 # text = 私はあまりエステにお金をかけれないと思い色々なエステサロンに相談にすごく親身になって下さり他のエステさんより安心できました。
 1	私	私	PRON	代名詞	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4943,6 +5166,7 @@
 
 # newdoc id = test-s230
 # sent_id = test-s230
+# parallel_id = jagsdluw/test230
 # text = 着付けや和装ヘアスタイルが得意。
 1	着付け	着付け	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キツケ,着付け,着付け,着付け,キツケ,,,キツケ,キツケ,着付け
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -4953,6 +5177,7 @@
 
 # newdoc id = test-s231
 # sent_id = test-s231
+# parallel_id = jagsdluw/test231
 # text = スタッフの皆さんが笑顔で接してくれて、全然緊張することなく過ごせました。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフ,スタッフ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4975,6 +5200,7 @@
 
 # newdoc id = test-s232
 # sent_id = test-s232
+# parallel_id = jagsdluw/test232
 # text = デスクワークで固まった肩や背中を、アロママッサージで気持ちよくほぐしていただいて助かります。
 1	デスクワーク	デスクワーク	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デスク;ワーク,デスク;ワーク,デスク;ワーク,デスク;ワーク,デスク;ワーク,;,;,デスク;ワーク,デスクワーク,デスクワーク
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -4998,6 +5224,7 @@
 
 # newdoc id = test-s233
 # sent_id = test-s233
+# parallel_id = jagsdluw/test233
 # text = 最後まで熱々で食べれる温度管理白馬近辺でラーメンと言ったらここですかね。
 1	最後	最後	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイゴ,最後,最後,最後,サイゴ,,,サイゴ,サイゴ,最後
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -5019,6 +5246,7 @@
 
 # newdoc id = test-s234
 # sent_id = test-s234
+# parallel_id = jagsdluw/test234
 # text = 声もほとんど筒抜け状態であった。
 1	声	声	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コエ,声,声,声,コエ,,,コエ,コエ,声
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -5030,6 +5258,7 @@
 
 # newdoc id = test-s235
 # sent_id = test-s235
+# parallel_id = jagsdluw/test235
 # text = 隠れ家居酒屋という名前にぴったり。
 1	隠れ家居酒屋	隠れ家居酒屋	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カクレガ;イザカヤ,隠れ家;居酒屋,隠れ家;居酒屋,隠れ家;居酒屋,カクレガ;イザカヤ,;,;,カクレガ;イザカヤ,カクレガイザカヤ,隠れ家居酒屋
 2	という	という	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;イウ,と;言う,と;いう,と;いう,ト;イウ,;,;,ト;イウ,トイウ,という
@@ -5040,6 +5269,7 @@
 
 # newdoc id = test-s236
 # sent_id = test-s236
+# parallel_id = jagsdluw/test236
 # text = 私たちの場合、金銭に絡んだ多重債務の処理等たくさん手がけているとのことで安心して相談できました。
 1	私たち	私達	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ;タチ,私;達,私;たち,私;たち,ワタシ;タチ,;,;,ワタシ;タチ,ワタシタチ,私達
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5068,6 +5298,7 @@
 
 # newdoc id = test-s237
 # sent_id = test-s237
+# parallel_id = jagsdluw/test237
 # text = 在庫の様子がよくわからないけど、デパートの中なのでたぶん小さい。
 1	在庫	在庫	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ザイコ,在庫,在庫,在庫,ザイコ,,,ザイコ,ザイコ,在庫
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5089,6 +5320,7 @@
 
 # newdoc id = test-s238
 # sent_id = test-s238
+# parallel_id = jagsdluw/test238
 # text = 若いお客さんよりそれ相応の年代のお客が多く、落ち着いて飲めるBarです。
 1	若い	若い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワカイ,若い,若い,若い,ワカイ,,,ワカイ,ワカイ,若い
 2	お客さん	御客さん	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;キャク;サン,御;客;さん,お;客;さん,お;客;さん,オ;キャク;サン,;;,;;,オ;キャク;サン,オキャクサン,御客さん
@@ -5111,6 +5343,7 @@
 
 # newdoc id = test-s239
 # sent_id = test-s239
+# parallel_id = jagsdluw/test239
 # text = 出入り口の交差点はもともと歩行者や自転車が多いので、かなり混雑しています。
 1	出入り口	出入り口	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デイリ;クチ,出入り;口,出入り;口,出入り;口,デイリ;グチ,;,;,デイリ;クチ,デイリグチ,出入り口
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5132,6 +5365,7 @@
 
 # newdoc id = test-s240
 # sent_id = test-s240
+# parallel_id = jagsdluw/test240
 # text = 食べきれないくらい出てきました。
 1	食べきれ	食べ切れる	VERB	動詞-一般-下一段-ラ行	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タベル;キル,食べる;切る,食べ;きれ,食べる;きれる,タベ;キレ,;,;,タベル;キレル,タベキレル,食べ切れる
 2	ない	ない	AUX	助動詞-助動詞-ナイ	Polarity=Neg	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナイ,ない,ない,ない,ナイ,,,ナイ,ナイ,ない
@@ -5144,6 +5378,7 @@
 
 # newdoc id = test-s241
 # sent_id = test-s241
+# parallel_id = jagsdluw/test241
 # text = 小さいお子さんがいるお母さんには最高のお店です。
 1	小さい	小さい	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チイサイ,小さい,小さい,小さい,チーサイ,,,チイサイ,チイサイ,小さい
 2	お子さん	御子さん	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;コ;サン,御;子;さん,お;子;さん,お;子;さん,オ;コ;サン,;;,;;,オ;コ;サン,オコサン,御子さん
@@ -5160,6 +5395,7 @@
 
 # newdoc id = test-s243
 # sent_id = test-s243
+# parallel_id = jagsdluw/test243
 # text = 値段は間違えてぼられるし刺身は最悪でした
 1	値段	値段	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネダン,値段,値段,値段,ネダン,,,ネダン,ネダン,値段
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5176,6 +5412,7 @@
 
 # newdoc id = test-s244
 # sent_id = test-s244
+# parallel_id = jagsdluw/test244
 # text = ソフトバンク直営店より高く売っています
 1	ソフトバンク直営店	ソフトバンク直営店	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソフト;バンク;チョクエイ;テン,ソフト;バンク;直営;店,ソフト;バンク;直営;店,ソフト;バンク;直営;店,ソフト;バンク;チョクエー;テン,;;;,;;;,ソフト;バンク;チョクエイ;テン,ソフトバンクチョクエイテン,ソフトバンク直営店
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -5186,6 +5423,7 @@
 
 # newdoc id = test-s245
 # sent_id = test-s245
+# parallel_id = jagsdluw/test245
 # text = しかしこのフロントの女性は、結局エレベーターに乗れずに階段を下りてきた私たちに向かって、「タクシーがずーーーっと待ってますので、急いでください」と言ってきました。
 1	しかし	然し	CCONJ	接続詞	_	37	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	この	此の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
@@ -5231,6 +5469,7 @@
 
 # newdoc id = test-s246
 # sent_id = test-s246
+# parallel_id = jagsdluw/test246
 # text = ビンや缶に入っているのは糀が死んでいるのですね。
 1	ビン	瓶	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビン,瓶,ビン,ビン,ビン,,,ビン,ビン,瓶
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -5250,6 +5489,7 @@
 
 # newdoc id = test-s247
 # sent_id = test-s247
+# parallel_id = jagsdluw/test247
 # text = 大きなお店は苦手なので私にとってはアットホームな感じで楽しい時間を過ごすことができ大満足です。
 1	大きな	大きな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキナ,大きな,大きな,大きな,オーキナ,,,オオキナ,オオキナ,大きな
 2	お店	御店	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセ,御;店,お;店,お;店,オ;ミセ,;,;,オ;ミセ,オミセ,御店
@@ -5275,6 +5515,7 @@
 
 # newdoc id = test-s249
 # sent_id = test-s249
+# parallel_id = jagsdluw/test249
 # text = まだまだ聞きとれない単語もいっぱいですが、最近は英語を聞いてもビクッと構えることなくどんどん質問しちゃってます、
 1	まだまだ	未だ未だ	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マダマダ,未だ未だ,まだまだ,まだまだ,マダマダ,,,マダマダ,マダマダ,未だ未だ
 2	聞きとれ	聞き取れる	VERB	動詞-一般-下一段-ラ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キキトル,聞き取る,聞きとれ,聞きとれる,キキトレ,,,キキトレル,キキトレル,聞き取れる
@@ -5305,6 +5546,7 @@
 
 # newdoc id = test-s250
 # sent_id = test-s250
+# parallel_id = jagsdluw/test250
 # text = レッスンが楽しみで、何をしても長続きしない私でも、週1回きっちり通えています。
 1	レッスン	レッスン	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レッスン,レッスン,レッスン,レッスン,レッスン,,,レッスン,レッスン,レッスン
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5332,6 +5574,7 @@
 
 # newdoc id = test-s251
 # sent_id = test-s251
+# parallel_id = jagsdluw/test251
 # text = また問診についてですが、他所受診にて原因不明のままの痛みについてしばらくの間レントゲンではなくMRI検査を検討していた為、やはり検査手段について医師と相談したかったです。
 1	また	又	CCONJ	接続詞	_	32	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	問診	問診	NOUN	名詞-普通名詞-一般	_	32	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モンシン,問診,問診,問診,モンシン,,,モンシン,モンシン,問診
@@ -5372,6 +5615,7 @@
 
 # newdoc id = test-s252
 # sent_id = test-s252
+# parallel_id = jagsdluw/test252
 # text = なかなか、女性一人で、ゆっくり、休める宿は少ない、
 1	なかなか	中々	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナカナカ,中々,なかなか,なかなか,ナカナカ,,,ナカナカ,ナカナカ,中々
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5389,6 +5633,7 @@
 
 # newdoc id = test-s253
 # sent_id = test-s253
+# parallel_id = jagsdluw/test253
 # text = 高松以外のホテルエリアワンを利用したことがあり、その際にサービス、ホテルの施設などが気に入って、今回も利用させていただくことにしました。
 1	高松以外	高松以外	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タカマツ;イガイ,タカマツ;以外,高松;以外,高松;以外,タカマツ;イガイ,;,;,タカマツ;イガイ,タカマツイガイ,高松以外
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5425,6 +5670,7 @@
 
 # newdoc id = test-s254
 # sent_id = test-s254
+# parallel_id = jagsdluw/test254
 # text = 色々な飲食店が乱立する中、老舗の安定感と手軽さを兼ね揃えています。
 1	色々	色々	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イロイロ,色々,色々,色々,イロイロ,,,イロイロ,イロイロ,色々
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -5446,6 +5692,7 @@
 
 # newdoc id = test-s256
 # sent_id = test-s256
+# parallel_id = jagsdluw/test256
 # text = ただ、自分で同じような柔軟やマッサージをしてみてもうまくできないようだ。
 1	ただ	唯	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダ,唯,ただ,ただ,タダ,,,タダ,タダ,唯
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5471,6 +5718,7 @@
 
 # newdoc id = test-s257
 # sent_id = test-s257
+# parallel_id = jagsdluw/test257
 # text = 席数はあまり多くないお店だが、食事の内容には満足出来る。
 1	席数	席数	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セキスウ,席数,席数,席数,セキスー,,,セキスウ,セキスウ,席数
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5491,6 +5739,7 @@
 
 # newdoc id = test-s258
 # sent_id = test-s258
+# parallel_id = jagsdluw/test258
 # text = 整体やマッサージで良くならなかった人にもオススメします。
 1	整体	整体	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイタイ,整体,整体,整体,セータイ,,,セイタイ,セイタイ,整体
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -5509,6 +5758,7 @@
 
 # newdoc id = test-s259
 # sent_id = test-s259
+# parallel_id = jagsdluw/test259
 # text = こちらのホテルは多少の設備の古さは感じなくも無いものの、スタッフさんのサービスが普通のホテルのように行き届いています。
 1	こちら	此方	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コチラ,此方,こちら,こちら,コチラ,,,コチラ,コチラ,此方
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5543,6 +5793,7 @@
 
 # newdoc id = test-s260
 # sent_id = test-s260
+# parallel_id = jagsdluw/test260
 # text = この低料金でこの設備を提供してくれるのはありがたいですね。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	低料金	低料金	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テイ;リョウキン,低;料金,低;料金,低;料金,テー;リョーキン,;,;,テイ;リョウキン,テイリョウキン,低料金
@@ -5561,6 +5812,7 @@
 
 # newdoc id = test-s261
 # sent_id = test-s261
+# parallel_id = jagsdluw/test261
 # text = 仕事に疲れてフラフラでチェックインしても、フロントの方をはじめホテルのスタッフの方々が気持ちのいい対応をしてくれるので、泊まりに行きたくなります。
 1	仕事	仕事	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シゴト,仕事,仕事,仕事,シゴト,,,シゴト,シゴト,仕事
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -5601,6 +5853,7 @@
 
 # newdoc id = test-s262
 # sent_id = test-s262
+# parallel_id = jagsdluw/test262
 # text = 値段相応といえばそれまでですが、風呂が狭いことだけが残念。
 1	値段相応	値段相応	ADJ	形状詞-一般	_	3	ccomp	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネダン;ソウオウ,値段;相応,値段;相応,値段;相応,ネダン;ソーオー,;,;,ネダン;ソウオウ,ネダンソウオウ,値段相応
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -5622,6 +5875,7 @@
 
 # newdoc id = test-s263
 # sent_id = test-s263
+# parallel_id = jagsdluw/test263
 # text = 従業員の方々もいつも暖かく送り出してくれるので、私が千葉で宿泊するホテルはここできまりです。
 1	従業員	従業員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウギョウ;イン,従業;員,従業;員,従業;員,ジューギョー;イン,;,;,ジュウギョウ;イン,ジュウギョウイン,従業員
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5649,6 +5903,7 @@
 
 # newdoc id = test-s264
 # sent_id = test-s264
+# parallel_id = jagsdluw/test264
 # text = ビジネスマンに対しての細かいところにまで気を配ったサービスがありがたく、ネットにキッチンにランドリーまで使えてこのお値段というのは安いと思います。
 1	ビジネスマン	ビジネスマン	NOUN	名詞-普通名詞-一般	_	12	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビジネスマン,ビジネスマン,ビジネスマン,ビジネスマン,ビジネスマン,,,ビジネスマン,ビジネスマン,ビジネスマン
 2	に対して	に対して	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;タイスル;テ,に;対する;て,に;対し;て,に;対する;て,ニ;タイシ;テ,;;,;;,ニ;タイスル;テ,ニタイシテ,に対して
@@ -5686,6 +5941,7 @@
 
 # newdoc id = test-s265
 # sent_id = test-s265
+# parallel_id = jagsdluw/test265
 # text = 初めて宿泊したのですが、はじめてに感じない、そんなアットホームな雰囲気もあるホテルでした。
 1	初めて	初めて	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハジメテ,初めて,初めて,初めて,ハジメテ,,,ハジメテ,ハジメテ,初めて
 2	宿泊し	宿泊する	VERB	動詞-一般-サ行変格	_	18	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュクハク;スル,宿泊;為る,宿泊;し,宿泊;する,シュクハク;シ,;,;,シュクハク;スル,シュクハクスル,宿泊する
@@ -5711,6 +5967,7 @@
 
 # newdoc id = test-s266
 # sent_id = test-s266
+# parallel_id = jagsdluw/test266
 # text = ですがほかのブックオフの中型店では多くの店員を雇うと教育がされておらず、私語がうるさいと店員はそちらを向くと、なんと店員がおしゃべりしていた。
 1	ですが	ですが	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デス;ガ,です;が,です;が,です;が,デス;ガ,;,;,デス;ガ,デスガ,ですが
 2	ほか	他	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
@@ -5754,6 +6011,7 @@
 
 # newdoc id = test-s267
 # sent_id = test-s267
+# parallel_id = jagsdluw/test267
 # text = もう少し早い時間に営業していると嬉しいですが、お店のスタンスはgoodです。
 1	もう	もう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モウ,もう,もう,もう,モー,,,モウ,モウ,もう
 2	少し	少し	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スコシ,少し,少し,少し,スコシ,,,スコシ,スコシ,少し
@@ -5777,6 +6035,7 @@
 
 # newdoc id = test-s269
 # sent_id = test-s269
+# parallel_id = jagsdluw/test269
 # text = あまり期待していなかったのに結構な額になったのでとてもうれしかったです。
 1	あまり	余り	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アマリ,余り,あまり,あまり,アマリ,,,アマリ,アマリ,余り
 2	期待し	期待する	VERB	動詞-一般-サ行変格	_	12	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キタイ;スル,期待;為る,期待;し,期待;する,キタイ;シ,;,;,キタイ;スル,キタイスル,期待する
@@ -5800,6 +6059,7 @@
 
 # newdoc id = test-s270
 # sent_id = test-s270
+# parallel_id = jagsdluw/test270
 # text = 西友の中にあり、入りやすい雰囲気なので、初めての方にもオススメできます。
 1	西友	西友	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイユウ,西友,西友,西友,セーユー,,,セイユウ,セイユウ,西友
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5823,6 +6083,7 @@
 
 # newdoc id = test-s271
 # sent_id = test-s271
+# parallel_id = jagsdluw/test271
 # text = リーズナブルな価格、味は勿論のこと、若いマスター夫婦の温かい雰囲気についつい長居してしまいます。
 1	リーズナブル	リーズナブル	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リーズナブル,リーズナブル,リーズナブル,リーズナブル,リーズナブル,,,リーズナブル,リーズナブル,リーズナブル
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -5848,6 +6109,7 @@
 
 # newdoc id = test-s272
 # sent_id = test-s272
+# parallel_id = jagsdluw/test272
 # text = 姫路の良く行く美容室でしたっ
 1	姫路	姫路	PROPN	名詞-固有名詞-地名-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒメジ,ヒメジ,姫路,姫路,ヒメジ,,,ヒメジ,ヒメジ,姫路
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5860,6 +6122,7 @@
 
 # newdoc id = test-s273
 # sent_id = test-s273
+# parallel_id = jagsdluw/test273
 # text = 感じのいいスタッフさんなので安心して通えます。
 1	感じ	感じ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンジ,感じ,感じ,感じ,カンジ,,,カンジ,カンジ,感じ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5875,6 +6138,7 @@
 
 # newdoc id = test-s274
 # sent_id = test-s274
+# parallel_id = jagsdluw/test274
 # text = 駐車場はあるものの立体駐車場で出入りに時間がかかり、6号と14号の交差点前で交通量が多くかつ駅前直結なため常に混雑しており、事実上地元の人以外のアクセスは辛いです。
 1	駐車場	駐車場	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウシャ;ジョウ,駐車;場,駐車;場,駐車;場,チューシャ;ジョー,;,;,チュウシャ;ジョウ,チュウシャジョウ,駐車場
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5919,6 +6183,7 @@
 
 # newdoc id = test-s275
 # sent_id = test-s275
+# parallel_id = jagsdluw/test275
 # text = テキストもとても分かりやすいですし、旅行やホームステイに使える英語を勉強、練習できるので大変気に入っております。
 1	テキスト	テキスト	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テキスト,テキスト,テキスト,テキスト,テキスト,,,テキスト,テキスト,テキスト
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -5948,6 +6213,7 @@
 
 # newdoc id = test-s276
 # sent_id = test-s276
+# parallel_id = jagsdluw/test276
 # text = 小さいお店なので常連さん優先なのは仕方がないですね。
 1	小さい	小さい	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チイサイ,小さい,小さい,小さい,チーサイ,,,チイサイ,チイサイ,小さい
 2	お店	御店	NOUN	名詞-普通名詞-一般	_	9	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセ,御;店,お;店,お;店,オ;ミセ,;,;,オ;ミセ,オミセ,御店
@@ -5966,6 +6232,7 @@
 
 # newdoc id = test-s277
 # sent_id = test-s277
+# parallel_id = jagsdluw/test277
 # text = 振袖はかなり豊富で流行りのトレンド着物からベーシックなものまで色々とありました。
 1	振袖	振り袖	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フリソデ,振り袖,振袖,振袖,フリソデ,,,フリソデ,フリソデ,振り袖
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5989,6 +6256,7 @@
 
 # newdoc id = test-s278
 # sent_id = test-s278
+# parallel_id = jagsdluw/test278
 # text = つけ麺の王様は間違いなくここ。
 1	つけ麺	付け麺	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツケメン,付け麺,つけ麺,つけ麺,ツケメン,,,ツケメン,ツケメン,付け麺
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6000,6 +6268,7 @@
 
 # newdoc id = test-s279
 # sent_id = test-s279
+# parallel_id = jagsdluw/test279
 # text = 袋や箱が、簡素で格好いいと思います。
 1	袋	袋	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フクロ,袋,袋,袋,フクロ,,,フクロ,フクロ,袋
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -6016,6 +6285,7 @@
 
 # newdoc id = test-s280
 # sent_id = test-s280
+# parallel_id = jagsdluw/test280
 # text = 味が少し濃いかなぁ。
 1	味	味	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アジ,味,味,味,アジ,,,アジ,アジ,味
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6027,6 +6297,7 @@
 
 # newdoc id = test-s281
 # sent_id = test-s281
+# parallel_id = jagsdluw/test281
 # text = 院長と話をしたところ、腰痛治療も得意なようです。
 1	院長	院長	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=インチョウ,院長,院長,院長,インチョー,,,インチョウ,インチョウ,院長
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -6045,6 +6316,7 @@
 
 # newdoc id = test-s282
 # sent_id = test-s282
+# parallel_id = jagsdluw/test282
 # text = お客さんはガヤガヤしたところがイヤな方はいいかもしれません。
 1	お客さん	御客さん	NOUN	名詞-普通名詞-一般	_	11	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;キャク;サン,御;客;さん,お;客;さん,お;客;さん,オ;キャク;サン,;;,;;,オ;キャク;サン,オキャクサン,御客さん
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6062,6 +6334,7 @@
 
 # newdoc id = test-s284
 # sent_id = test-s284
+# parallel_id = jagsdluw/test284
 # text = 石川悦男元党首は,宗教法人の総本山に異動となりました。
 1	石川悦男元党首	石川悦男元党首	PROPN	名詞-固有名詞-人名-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イシカワ;エツオ;モト;トウシュ,イシカワ;エツオ;元;党首,石川;悦男;元;党首,石川;悦男;元;党首,イシカワ;エツオ;モト;トーシュ,;;;,;;;,イシカワ;エツオ;モト;トウシュ,イシカワエツオモトトウシュ,石川悦男元党首
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6079,6 +6352,7 @@
 
 # newdoc id = test-s285
 # sent_id = test-s285
+# parallel_id = jagsdluw/test285
 # text = おいしいと聞いてただけに姉には申し訳なくてホントに最悪です
 1	おいしい	美味しい	ADJ	形容詞-一般-形容詞	_	3	ccomp	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オイシイ,美味しい,おいしい,おいしい,オイシー,,,オイシイ,オイシイ,美味しい
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -6099,6 +6373,7 @@
 
 # newdoc id = test-s286
 # sent_id = test-s286
+# parallel_id = jagsdluw/test286
 # text = セレファイスの主神。
 1	セレファイス	セレファイス	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セレファイス,セレファイス,セレファイス,セレファイス,セレファイス,,,セレファイス,セレファイス,セレファイス
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6107,6 +6382,7 @@
 
 # newdoc id = test-s287
 # sent_id = test-s287
+# parallel_id = jagsdluw/test287
 # text = 一郎の妻。
 1	一郎	一郎	PROPN	名詞-固有名詞-人名-名	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチロウ,イチロウ,一郎,一郎,イチロー,,,イチロウ,イチロウ,一郎
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6115,6 +6391,7 @@
 
 # newdoc id = test-s288
 # sent_id = test-s288
+# parallel_id = jagsdluw/test288
 # text = なお、冬期には山腹にスポットライトで雪だるまが描かれる。
 1	なお	猶	CCONJ	接続詞	_	12	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6133,6 +6410,7 @@
 
 # newdoc id = test-s289
 # sent_id = test-s289
+# parallel_id = jagsdluw/test289
 # text = この建物は、初めオフィスとして用いられたが、1909年からは市庁舎として利用された。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	建物	建物	NOUN	名詞-普通名詞-一般	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タテモノ,建物,建物,建物,タテモノ,,,タテモノ,タテモノ,建物
@@ -6158,6 +6436,7 @@
 
 # newdoc id = test-s290
 # sent_id = test-s290
+# parallel_id = jagsdluw/test290
 # text = 誕生日10月16日。
 1	誕生日	誕生日	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=タンジョウ;ヒ,誕生;日,誕生;日,誕生;日,タンジョー;ビ,;,;,タンジョウ;ヒ,タンジョウビ,誕生日
 2	10月	10月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ジュウ;ガツ,十;月,10;月,10;月,ジュー;ガツ,;,;,ジュウ;ガツ,ジュウガツ,10月
@@ -6166,6 +6445,7 @@
 
 # newdoc id = test-s291
 # sent_id = test-s291
+# parallel_id = jagsdluw/test291
 # text = また、先生方をサポートする人材の育成、教員養成のあり方を詰めていく必要がある。
 1	また	又	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6189,6 +6469,7 @@
 
 # newdoc id = test-s292
 # sent_id = test-s292
+# parallel_id = jagsdluw/test292
 # text = 事件が朝刊各版の締め切り間際に立て続けに起こったため、各新聞は配達先によって記事内容が一部異なっている。
 1	事件	事件	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジケン,事件,事件,事件,ジケン,,,ジケン,ジケン,事件
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6215,6 +6496,7 @@
 
 # newdoc id = test-s293
 # sent_id = test-s293
+# parallel_id = jagsdluw/test293
 # text = 番外編に登場。
 1	番外編	番外編	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バンガイ;ヘン,番外;編,番外;編,番外;編,バンガイ;ヘン,;,;,バンガイ;ヘン,バンガイヘン,番外編
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6223,6 +6505,7 @@
 
 # newdoc id = test-s295
 # sent_id = test-s295
+# parallel_id = jagsdluw/test295
 # text = 最高なお店で毎回感動しています。
 1	最高	最高	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイコウ,最高,最高,最高,サイコー,,,サイコウ,サイコウ,最高
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -6236,6 +6519,7 @@
 
 # newdoc id = test-s296
 # sent_id = test-s296
+# parallel_id = jagsdluw/test296
 # text = 自分でも趣味で料理をするもので一層感心することが多いのです。
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -6257,6 +6541,7 @@
 
 # newdoc id = test-s297
 # sent_id = test-s297
+# parallel_id = jagsdluw/test297
 # text = 1967年『シラノ・ド・ベルジュラック』で初舞台。
 1	1967年	1967年	NUM	名詞-数詞	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ロク;シチ;ネン,一;九;六;七;年,1;9;6;7;年,1;9;6;7;年,イチ;キュー;ロク;シチ;ネン,;;;;,;;;;,イチ;キュウ;ロク;シチ;ネン,イチキュウロクシチネン,1967年
 2	『	『	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
@@ -6268,6 +6553,7 @@
 
 # newdoc id = test-s298
 # sent_id = test-s298
+# parallel_id = jagsdluw/test298
 # text = 人間の体は何百万年前からそのことを知っていて、体の中にウイルス等の外敵が侵入してくると、彼らと戦うために脳から全身の細胞に指令を出して熱を出しているそうです。
 1	人間	人間	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニンゲン,人間,人間,人間,ニンゲン,,,ニンゲン,ニンゲン,人間
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6318,6 +6604,7 @@
 
 # newdoc id = test-s299
 # sent_id = test-s299
+# parallel_id = jagsdluw/test299
 # text = 東京にあるハイパーコンサルティング・ジャパンさんでは、パニック障害解消プログラムを組んでカウンセリングを実施しています。
 1	東京	東京	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウキョウ,トウキョウ,東京,東京,トーキョー,,,トウキョウ,トウキョウ,東京
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6339,6 +6626,7 @@
 
 # newdoc id = test-s300
 # sent_id = test-s300
+# parallel_id = jagsdluw/test300
 # text = 公称身長156cm。
 1	公称身長	公称身長	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=コウショウ;シンチョウ,公称;身長,公称;身長,公称;身長,コーショー;シンチョー,;,;,コウショウ;シンチョウ,コウショウシンチョウ,公称身長
 2	156cm	156cm	NUM	名詞-数詞	_	0	root	_	BunsetuBILabel=I|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=イチ;ゴ;ロク;センチメートル,一;五;六;センチメートル,1;5;6;cm,1;5;6;cm,イチ;ゴ;ロク;センチメートル,;;;,;;;,イチ;ゴ;ロク;センチメートル,イチゴロクセンチメートル,156cm
@@ -6346,6 +6634,7 @@
 
 # newdoc id = test-s301
 # sent_id = test-s301
+# parallel_id = jagsdluw/test301
 # text = また,木村党首が“参院選の目玉政策”として掲げたのが,“参議院の廃止”。
 1	また	又	CCONJ	接続詞	_	19	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -6371,6 +6660,7 @@
 
 # newdoc id = test-s302
 # sent_id = test-s302
+# parallel_id = jagsdluw/test302
 # text = ボルバキアという共生細菌がいないと正常な成長や繁殖が困難であることが研究で明らかにされた。
 1	ボルバキア	ボルバキア	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ボルバキア,ボルバキア,ボルバキア,ボルバキア,ボルバキア,,,ボルバキア,ボルバキア,ボルバキア
 2	という	という	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;イウ,と;言う,と;いう,と;いう,ト;イウ,;,;,ト;イウ,トイウ,という
@@ -6400,6 +6690,7 @@
 
 # newdoc id = test-s303
 # sent_id = test-s303
+# parallel_id = jagsdluw/test303
 # text = 2007年9月5日発売。
 1	2007年	2007年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;シチ;ネン,二;ゼロ;ゼロ;七;年,2;0;0;7;年,2;0;0;7;年,ニ;ゼロ;ゼロ;シチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;シチ;ネン,ニゼロゼロシチネン,2007年
 2	9月	9月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ク;ガツ,九;月,9;月,9;月,ク;ガツ,;,;,ク;ガツ,クガツ,9月
@@ -6408,6 +6699,7 @@
 
 # newdoc id = test-s304
 # sent_id = test-s304
+# parallel_id = jagsdluw/test304
 # text = 文書をどのようにファイルするか。
 1	文書	文書	NOUN	名詞-普通名詞-一般	_	6	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ブンショ,文書,文書,文書,ブンショ,,,ブンショ,ブンショ,文書
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6420,6 +6712,7 @@
 
 # newdoc id = test-s305
 # sent_id = test-s305
+# parallel_id = jagsdluw/test305
 # text = そのほかアダナ近郊のシルケリ・ホユックでは彼の名が刻まれた摩崖碑文が発見されているが、こうした屋外のヒッタイト碑文としては最古の例とされる。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ほか	他	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
@@ -6460,6 +6753,7 @@
 
 # newdoc id = test-s306
 # sent_id = test-s306
+# parallel_id = jagsdluw/test306
 # text = 次のカットまでのスタイリングも「パパッ」と出来てしまいます。
 1	次	次	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツギ,次,次,次,ツギ,,,ツギ,ツギ,次
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6479,6 +6773,7 @@
 
 # newdoc id = test-s307
 # sent_id = test-s307
+# parallel_id = jagsdluw/test307
 # text = 独立して活動する弦楽四重奏団としては日本で最も実績を重ねている団体の一つ。
 1	独立し	独立する	VERB	動詞-一般-サ行変格	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドクリツ;スル,独立;為る,独立;し,独立;する,ドクリツ;シ,;,;,ドクリツ;スル,ドクリツスル,独立する
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -6501,6 +6796,7 @@
 
 # newdoc id = test-s308
 # sent_id = test-s308
+# parallel_id = jagsdluw/test308
 # text = そののち、連隊はレンドリースにより供与されたボストンに装備を変更した。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	のち	後	NOUN	名詞-普通名詞-一般	_	15	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノチ,後,のち,のち,ノチ,,,ノチ,ノチ,後
@@ -6522,12 +6818,14 @@
 
 # newdoc id = test-s309
 # sent_id = test-s309
+# parallel_id = jagsdluw/test309
 # text = Ciao!
 1	Ciao	Ciao	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=チャオ,チャオ,Ciao,Ciao,チャオ,,,チャオ,チャオ,Ciao
 2	!	!	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,！,!,!,,,,,,！
 
 # newdoc id = test-s310
 # sent_id = test-s310
+# parallel_id = jagsdluw/test310
 # text = ジェリーとリズは恋仲になるが、アンリはリズと結婚しようとしていた。
 1	ジェリー	ジェリー	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェリー,ジェリー,ジェリー,ジェリー,ジェリー,,,ジェリー,ジェリー,ジェリー
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -6551,6 +6849,7 @@
 
 # newdoc id = test-s311
 # sent_id = test-s311
+# parallel_id = jagsdluw/test311
 # text = また、奴隷貿易の対象ではなく宗教上のライバルであった北アフリカのイスラム諸国は、19世紀には宗主国オスマン帝国の影響力が衰え、自立した群小政権もヨーロッパ勢力の経済的・軍事的な発展に対してほとんど為す術がないほど弱体化していた。
 1	また	又	CCONJ	接続詞	_	42	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6600,6 +6899,7 @@
 
 # newdoc id = test-s312
 # sent_id = test-s312
+# parallel_id = jagsdluw/test312
 # text = 実際に万全ではなかったり手を抜いている時以外の、真弥が本気で戦った戦闘では必ずその相手に圧勝している。
 1	実際	実際	NOUN	名詞-普通名詞-一般	_	26	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジッサイ,実際,実際,実際,ジッサイ,,,ジッサイ,ジッサイ,実際
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6632,6 +6932,7 @@
 
 # newdoc id = test-s313
 # sent_id = test-s313
+# parallel_id = jagsdluw/test313
 # text = ただし完全に外海から隔てられたものはほとんどなく、ごく狭い海峡により外海とつながっているものが多い。
 1	ただし	但し	CCONJ	接続詞	_	24	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	完全	完全	ADJ	形状詞-一般	_	6	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンゼン,完全,完全,完全,カンゼン,,,カンゼン,カンゼン,完全
@@ -6661,6 +6962,7 @@
 
 # newdoc id = test-s314
 # sent_id = test-s314
+# parallel_id = jagsdluw/test314
 # text = 以下は「表向き」を好むと答えた人間の割合である。
 1	以下	以下	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イカ,以下,以下,以下,イカ,,,イカ,イカ,以下
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6680,6 +6982,7 @@
 
 # newdoc id = test-s315
 # sent_id = test-s315
+# parallel_id = jagsdluw/test315
 # text = バトルに敗北するとどうなるかは作品ごとに決められている。
 1	バトル	バトル	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バトル,バトル,バトル,バトル,バトル,,,バトル,バトル,バトル
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6698,6 +7001,7 @@
 
 # newdoc id = test-s316
 # sent_id = test-s316
+# parallel_id = jagsdluw/test316
 # text = 通常この協議は1〜4年かかるとされている。
 1	通常	通常	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツウジョウ,通常,通常,通常,ツージョー,,,ツウジョウ,ツウジョウ,通常
 2	この	此の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
@@ -6713,6 +7017,7 @@
 
 # newdoc id = test-s317
 # sent_id = test-s317
+# parallel_id = jagsdluw/test317
 # text = ひびの入ったパネル。
 1	ひび	皹	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒビ,皹,ひび,ひび,ヒビ,,,ヒビ,ヒビ,皹
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6723,6 +7028,7 @@
 
 # newdoc id = test-s318
 # sent_id = test-s318
+# parallel_id = jagsdluw/test318
 # text = 昨日も仲間8人で楽しくおいしくいただきました。
 1	昨日	昨日	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キノウ,昨日,昨日,昨日,キノー,,,キノウ,キノウ,昨日
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -6738,6 +7044,7 @@
 
 # newdoc id = test-s319
 # sent_id = test-s319
+# parallel_id = jagsdluw/test319
 # text = デビュー当時からテレビにはほとんど出演しないが、CS放送には出演したことがある。
 1	デビュー当時	デビュー当時	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デビュー;トウジ,デビュー;当時,デビュー;当時,デビュー;当時,デビュー;トージ,;,;,デビュー;トウジ,デビュートウジ,デビュー当時
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -6759,6 +7066,7 @@
 
 # newdoc id = test-s320
 # sent_id = test-s320
+# parallel_id = jagsdluw/test320
 # text = 祖国を侵略者ベトナムから解放するその一点で闘う少年兵,少女兵の笑顔にまさるものはない。
 1	祖国	祖国	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソコク,祖国,祖国,祖国,ソコク,,,ソコク,ソコク,祖国
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6783,6 +7091,7 @@
 
 # newdoc id = test-s321
 # sent_id = test-s321
+# parallel_id = jagsdluw/test321
 # text = しかし取材していても,特定のイデオロギーや党派組織の影響を感じません。
 1	しかし	然し	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	取材し	取材する	VERB	動詞-一般-サ行変格	_	15	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュザイ;スル,取材;為る,取材;し,取材;する,シュザイ;シ,;,;,シュザイ;スル,シュザイスル,取材する
@@ -6805,6 +7114,7 @@
 
 # newdoc id = test-s322
 # sent_id = test-s322
+# parallel_id = jagsdluw/test322
 # text = エレクトロウェッティングは既存の液晶ディスプレイ生産ラインに変更を加えれば製造できるという。
 1	エレクトロウェッティング	エレクトロウェッティング	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エレクトロウェッティング,エレクトロウェッティング,エレクトロウェッティング,エレクトロウェッティング,エレクトローェッティング,,,エレクトロウェッティング,エレクトロウェッティング,エレクトロウェッティング
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6823,6 +7133,7 @@
 
 # newdoc id = test-s323
 # sent_id = test-s323
+# parallel_id = jagsdluw/test323
 # text = しかし、ルートによっては悠弥と結婚することになり、彼女のルートでは全ヒロイン中、ハッピーエンドを迎える。
 1	しかし	然し	CCONJ	接続詞	_	20	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6848,6 +7159,7 @@
 
 # newdoc id = test-s324
 # sent_id = test-s324
+# parallel_id = jagsdluw/test324
 # text = 今後,この様な問題の発生を防止する為,国家は厳しい規制を考える必要がある。
 1	今後	今後	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンゴ,今後,今後,今後,コンゴ,,,コンゴ,コンゴ,今後
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -6874,6 +7186,7 @@
 
 # newdoc id = test-s325
 # sent_id = test-s325
+# parallel_id = jagsdluw/test325
 # text = 会社がお世話をしてくれなかったので自分で探したのですが、価格的にも割と負担のすくないこちらのマンスリーマンションを借りることになりました。
 1	会社	会社	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイシャ,会社,会社,会社,カイシャ,,,カイシャ,カイシャ,会社
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6910,6 +7223,7 @@
 
 # newdoc id = test-s326
 # sent_id = test-s326
+# parallel_id = jagsdluw/test326
 # text = 野田佳彦首相は12月に中国を訪問する方向で最終調整に入った。
 1	野田佳彦首相	野田佳彦首相	PROPN	名詞-固有名詞-人名-一般	_	12	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノダ;ヨシヒコ;シュショウ,ノダ;ヨシヒコ;首相,野田;佳彦;首相,野田;佳彦;首相,ノダ;ヨシヒコ;シュショー,;;,;;,ノダ;ヨシヒコ;シュショウ,ノダヨシヒコシュショウ,野田佳彦首相
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6928,6 +7242,7 @@
 
 # newdoc id = test-s327
 # sent_id = test-s327
+# parallel_id = jagsdluw/test327
 # text = 第1期終了後、素顔を晒して謎のレスラー「キャプテン・モロー」として過ごし、チャンピオンにまでなっていた。
 1	第1期終了後	第1期終了後	ADV	副詞	_	11	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;イチ;キ;シュウリョウ;ゴ,第;一;期;終了;後,第;1;期;終了;後,第;1;期;終了;後,ダイ;イッ;キ;シューリョー;ゴ,;;;;,;;;;,ダイ;イチ;キ;シュウリョウ;ゴ,ダイイッキシュウリョウゴ,第1期終了後
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6951,6 +7266,7 @@
 
 # newdoc id = test-s328
 # sent_id = test-s328
+# parallel_id = jagsdluw/test328
 # text = 管轄する修道院がそもそも日本に存在しなかったのに、日本に正教会を伝えた亜使徒聖ニコライが日本伝道初期に掌院に昇叙されたことはその好例である。
 1	管轄する	管轄する	VERB	動詞-一般-サ行変格	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンカツ;スル,管轄;為る,管轄;する,管轄;する,カンカツ;スル,;,;,カンカツ;スル,カンカツスル,管轄する
 2	修道院	修道院	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウドウ;イン,修道;院,修道;院,修道;院,シュードー;イン,;,;,シュウドウ;イン,シュウドウイン,修道院
@@ -6988,6 +7304,7 @@
 
 # newdoc id = test-s329
 # sent_id = test-s329
+# parallel_id = jagsdluw/test329
 # text = ガッローネは出資をあまり大規模に行なわず、マロッタと監督の手腕にすべてをゆだねている。
 1	ガッローネ	ガッローネ	PROPN	名詞-固有名詞-人名-一般	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガッローネ,ガッローネ,ガッローネ,ガッローネ,ガッローネ,,,ガッローネ,ガッローネ,ガッローネ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7013,6 +7330,7 @@
 
 # newdoc id = test-s330
 # sent_id = test-s330
+# parallel_id = jagsdluw/test330
 # text = 上記の理由で当時はさほど売り上げにつながらなかったが、1990年代後半以降、業務用・家庭用ゲームでこれと似た体感ゲームが登場してきている。
 1	上記	上記	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョウキ,上記,上記,上記,ジョーキ,,,ジョウキ,ジョウキ,上記
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7045,6 +7363,7 @@
 
 # newdoc id = test-s331
 # sent_id = test-s331
+# parallel_id = jagsdluw/test331
 # text = その姿は見る者によって異なり、洋子には幼い頃の自分に見えた。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	姿	姿	NOUN	名詞-普通名詞-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スガタ,姿,姿,姿,スガタ,,,スガタ,スガタ,姿
@@ -7068,6 +7387,7 @@
 
 # newdoc id = test-s332
 # sent_id = test-s332
+# parallel_id = jagsdluw/test332
 # text = 事件の原因が新健康協会の教義にあったことは判決が認定しているようですし,裁判員の言葉の通り両親が子どもに対して“一生懸命愛情を持って接していた”のであれば,その愛情を間違った方向に走らせてしまった新健康協会は,なおのこと危険な団体であるということになります。
 1	事件	事件	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジケン,事件,事件,事件,ジケン,,,ジケン,ジケン,事件
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7139,6 +7459,7 @@
 
 # newdoc id = test-s333
 # sent_id = test-s333
+# parallel_id = jagsdluw/test333
 # text = クロアチアは、アドリア海のイタリアとの中間線よりクロアチア側に、排他的経済水域を設定することを計画している。
 1	クロアチア	クロアチア	PROPN	名詞-固有名詞-地名-国	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クロアチア,クロアチア,クロアチア,クロアチア,クロアチア,,,クロアチア,クロアチア,クロアチア
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7164,6 +7485,7 @@
 
 # newdoc id = test-s334
 # sent_id = test-s334
+# parallel_id = jagsdluw/test334
 # text = 復興基本計画は、昭和20年から21年にかけて、市の関係部局や学識経験者、市民代表により復興計画に関する委員会で決定され、狭い市域に多くの人口を収容するために商工業・中小企業を発展させることを基本方針にし、区画整理の実施を幹線道路の整備による経済活動の円滑化とこれまで不足していた公園緑地の確保による都市美化、従来の不規則な街区整理を目的に、着実に着工する。
 1	復興基本計画	復興基本計画	NOUN	名詞-普通名詞-一般	_	24	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フッコウ;キホン;ケイカク,復興;基本;計画,復興;基本;計画,復興;基本;計画,フッコー;キホン;ケーカク,;;,;;,フッコウ;キホン;ケイカク,フッコウキホンケイカク,復興基本計画
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7249,6 +7571,7 @@
 
 # newdoc id = test-s335
 # sent_id = test-s335
+# parallel_id = jagsdluw/test335
 # text = 土曜日の夜、仕事帰りに一人でふらりと立ち寄りました。
 1	土曜日	土曜日	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドヨウ;ヒ,土曜;日,土曜;日,土曜;日,ドヨー;ビ,;,;,ドヨウ;ヒ,ドヨウビ,土曜日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7266,6 +7589,7 @@
 
 # newdoc id = test-s336
 # sent_id = test-s336
+# parallel_id = jagsdluw/test336
 # text = 最高裁の御威光によって,文科省の判断が“違法”認定。
 1	最高裁	最高裁	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイコウ;サイ,最高;裁,最高;裁,最高;裁,サイコー;サイ,;,;,サイコウ;サイ,サイコウサイ,最高裁
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7282,6 +7606,7 @@
 
 # newdoc id = test-s337
 # sent_id = test-s337
+# parallel_id = jagsdluw/test337
 # text = 2009年地方競馬通算900勝達成。
 1	2009年地方競馬通算	2009年地方競馬通算	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;キュウ;ネン;チホウ;ケイバ;ツウサン,二;ゼロ;ゼロ;九;年;地方;競馬;通算,2;0;0;9;年;地方;競馬;通算,2;0;0;9;年;地方;競馬;通算,ニ;ゼロ;ゼロ;キュー;ネン;チホー;ケーバ;ツーサン,;;;;;;;,;;;;;;;,ニ;ゼロ;ゼロ;キュウ;ネン;チホウ;ケイバ;ツウサン,ニゼロゼロキュウネンチホウケイバツウサン,2009年地方競馬通算
 2	900勝達成	900勝達成	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=I|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=キュウヒャク;ショウ;タッセイ,九百;勝;達成,900;勝;達成,900;勝;達成,キューヒャク;ショー;タッセー,;;,;;,キュウヒャク;ショウ;タッセイ,キュウヒャクショウタッセイ,900勝達成
@@ -7289,6 +7614,7 @@
 
 # newdoc id = test-s338
 # sent_id = test-s338
+# parallel_id = jagsdluw/test338
 # text = エジプト情勢緊迫化の影響が国際商品市況へ波及し、世界景気に悪影響を及ぼす可能性が警戒された。
 1	エジプト情勢緊迫化	エジプト情勢緊迫化	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エジプト;ジョウセイ;キンパク;カ,エジプト;情勢;緊迫;化,エジプト;情勢;緊迫;化,エジプト;情勢;緊迫;化,エジプト;ジョーセー;キンパク;カ,;;;,;;;,エジプト;ジョウセイ;キンパク;カ,エジプトジョウセイキンパクカ,エジプト情勢緊迫化
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7312,6 +7638,7 @@
 
 # newdoc id = test-s339
 # sent_id = test-s339
+# parallel_id = jagsdluw/test339
 # text = 漫画『DEATH NOTE』のパロディ。
 1	漫画	漫画	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マンガ,漫画,漫画,漫画,マンガ,,,マンガ,マンガ,漫画
 2	『	『	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
@@ -7323,6 +7650,7 @@
 
 # newdoc id = test-s340
 # sent_id = test-s340
+# parallel_id = jagsdluw/test340
 # text = すごろくを基本にしたゲームで、ドックロンが揺らす邪魔で落ちないようにしながらゴールまで進んでいく。
 1	すごろく	双六	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スゴロク,双六,すごろく,すごろく,スゴロク,,,スゴロク,スゴロク,双六
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7353,6 +7681,7 @@
 
 # newdoc id = test-s341
 # sent_id = test-s341
+# parallel_id = jagsdluw/test341
 # text = 歴史上では、中国・後漢末期に発生した、党錮の禁で弾圧された集団の称として使われた。
 1	歴史上	歴史上	NOUN	名詞-普通名詞-一般	_	21	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レキシ;ジョウ,歴史;上,歴史;上,歴史;上,レキシ;ジョー,;,;,レキシ;ジョウ,レキシジョウ,歴史上
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -7381,6 +7710,7 @@
 
 # newdoc id = test-s342
 # sent_id = test-s342
+# parallel_id = jagsdluw/test342
 # text = キャラクターの心臓部とも言える、動作を制御するファイル。
 1	キャラクター	キャラクター	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キャラクター,キャラクター,キャラクター,キャラクター,キャラクター,,,キャラクター,キャラクター,キャラクター
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7397,6 +7727,7 @@
 
 # newdoc id = test-s343
 # sent_id = test-s343
+# parallel_id = jagsdluw/test343
 # text = 同じビルに調剤薬局もあるので会計後にそのまま向かうのが基本ルートです。
 1	同じ	同じ	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オナジ,同じ,同じ,同じ,オナジ,,,オナジ,オナジ,同じ
 2	ビル	蛭	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビル,ビル,ビル,ビル,ビル,,,ビル,ビル,蛭
@@ -7418,6 +7749,7 @@
 
 # newdoc id = test-s344
 # sent_id = test-s344
+# parallel_id = jagsdluw/test344
 # text = なお同馬はこのレースに於いて発走枠入りを再三嫌がり、出走を遅らせたため一定期間出走停止とゲート再試験が科せられている。
 1	なお	猶	CCONJ	接続詞	_	21	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	同馬	同馬	NOUN	名詞-普通名詞-一般	_	21	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウバ,同馬,同馬,同馬,ドーバ,,,ドウバ,ドウバ,同馬
@@ -7446,6 +7778,7 @@
 
 # newdoc id = test-s345
 # sent_id = test-s345
+# parallel_id = jagsdluw/test345
 # text = また,この養護教諭は,砂糖玉をレメディーに変換するという装置を保健室に持ち込んでいた。
 1	また	又	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -7470,6 +7803,7 @@
 
 # newdoc id = test-s346
 # sent_id = test-s346
+# parallel_id = jagsdluw/test346
 # text = 線形作用素が有界であることと、連続であることは必要十分である。
 1	線形作用素	線形作用素	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センケイ;サヨウ;ソ,線形;作用;素,線形;作用;素,線形;作用;素,センケー;サヨー;ソ,;;,;;,センケイ;サヨウ;ソ,センケイサヨウソ,線形作用素
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7488,6 +7822,7 @@
 
 # newdoc id = test-s347
 # sent_id = test-s347
+# parallel_id = jagsdluw/test347
 # text = 一方NASAのエイムズ研究センターが開発したナノセイルDは2008年8月にファルコン1ロケットによって打ち上げられるも打上げに失敗。
 1	一方	一方	CCONJ	接続詞	_	20	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	NASA	NASA	PROPN	名詞-固有名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナサ,ＮＡＳＡ,NASA,NASA,ナサ,,,ナサ,ナサ,NASA
@@ -7513,6 +7848,7 @@
 
 # newdoc id = test-s348
 # sent_id = test-s348
+# parallel_id = jagsdluw/test348
 # text = だんなさまにもこの気持ち良さを体感してもらって、スクールに通うOKをもらいます!
 1	だんなさま	旦那様	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダンナ;サマ,旦那;様,だんな;さま,だんな;さま,ダンナ;サマ,;,;,ダンナ;サマ,ダンナサマ,旦那様
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7536,6 +7872,7 @@
 
 # newdoc id = test-s349
 # sent_id = test-s349
+# parallel_id = jagsdluw/test349
 # text = 冬季に利用。
 1	冬季	冬季	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウキ,冬季,冬季,冬季,トーキ,,,トウキ,トウキ,冬季
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7544,6 +7881,7 @@
 
 # newdoc id = test-s350
 # sent_id = test-s350
+# parallel_id = jagsdluw/test350
 # text = このため先に派遣されていた2個偵察機隊に加え、新たに偵察機隊を追加派遣することとなり、事変勃発から1ヵ月後に追加編制されたのが二三空である。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	ため	為	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タメ,為,ため,ため,タメ,,,タメ,タメ,為
@@ -7579,6 +7917,7 @@
 
 # newdoc id = test-s351
 # sent_id = test-s351
+# parallel_id = jagsdluw/test351
 # text = なお、常陸国から佐竹氏の秋田転封に随行した菊池氏が数流見える。
 1	なお	猶	CCONJ	接続詞	_	14	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7598,6 +7937,7 @@
 
 # newdoc id = test-s352
 # sent_id = test-s352
+# parallel_id = jagsdluw/test352
 # text = かけがえのない家族を突然失う悲しみを知るだけに、できることをしたいと考えている。
 1	かけがえ	掛け替え	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カケガエ,掛け替え,かけがえ,かけがえ,カケガエ,,,カケガエ,カケガエ,掛け替え
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7624,6 +7964,7 @@
 
 # newdoc id = test-s353
 # sent_id = test-s353
+# parallel_id = jagsdluw/test353
 # text = そして、テレビ朝日同様縁取りは行われていない。
 1	そして	そして	CCONJ	接続詞	_	6	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7638,6 +7979,7 @@
 
 # newdoc id = test-s354
 # sent_id = test-s354
+# parallel_id = jagsdluw/test354
 # text = 上に引用した部分以外も同様です。
 1	上	上	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウエ,上,上,上,ウエ,,,ウエ,ウエ,上
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7651,6 +7993,7 @@
 
 # newdoc id = test-s355
 # sent_id = test-s355
+# parallel_id = jagsdluw/test355
 # text = 欧州不正対策局の付属機関である欧州技術・科学センターは、2002年の時点で最大で200万枚の偽造硬貨が出回っていると推測している。
 1	欧州不正対策局	欧州不正対策局	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オウシュウ;フセイ;タイサク;キョク,オウシュウ;不正;対策;局,欧州;不正;対策;局,欧州;不正;対策;局,オーシュー;フセー;タイサク;キョク,;;;,;;;,オウシュウ;フセイ;タイサク;キョク,オウシュウフセイタイサクキョク,欧州不正対策局
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7678,6 +8021,7 @@
 
 # newdoc id = test-s356
 # sent_id = test-s356
+# parallel_id = jagsdluw/test356
 # text = 新ルールを聞いて、各々に想いを語った。
 1	新ルール	新ルール	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シン;ルール,新;ルール,新;ルール,新;ルール,シン;ルール,;,;,シン;ルール,シンルール,新ルール
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7694,6 +8038,7 @@
 
 # newdoc id = test-s357
 # sent_id = test-s357
+# parallel_id = jagsdluw/test357
 # text = マイカーの輸送力は公共交通機関に比べて遥かに劣るため、比較的小規模な都市でも混雑問題が深刻化する。
 1	マイカー	マイカー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マイ;カー,マイ;カー,マイ;カー,マイ;カー,マイ;カー,;,;,マイ;カー,マイカー,マイカー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7721,6 +8066,7 @@
 
 # newdoc id = test-s358
 # sent_id = test-s358
+# parallel_id = jagsdluw/test358
 # text = 私は高校生の頃に臨床心理士になりたいと思い、心理学が学べる大学を片っ端から調べ、行けるだけオープンキャンパスに行きました。
 1	私	私	PRON	代名詞	_	27	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7755,6 +8101,7 @@
 
 # newdoc id = test-s359
 # sent_id = test-s359
+# parallel_id = jagsdluw/test359
 # text = ストーリー重視の作品を中心に掲載しているため過激な性的描写はほとんど見あたらない。
 1	ストーリー重視	ストーリー重視	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ストーリー;ジュウシ,ストーリー;重視,ストーリー;重視,ストーリー;重視,ストーリー;ジューシ,;,;,ストーリー;ジュウシ,ストーリージュウシ,ストーリー重視
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7776,6 +8123,7 @@
 
 # newdoc id = test-s360
 # sent_id = test-s360
+# parallel_id = jagsdluw/test360
 # text = 直純より一年早く務め始めている。
 1	直純	直純	PROPN	名詞-固有名詞-人名-名	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオズミ,ナオズミ,直純,直純,ナオズミ,,,ナオズミ,ナオズミ,直純
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -7787,6 +8135,7 @@
 
 # newdoc id = test-s361
 # sent_id = test-s361
+# parallel_id = jagsdluw/test361
 # text = 子供の頃は『仮面ライダーBLACK』や『機動刑事ジバン』が好きだった。
 1	子供	子供	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コドモ,子供,子供,子供,コドモ,,,コドモ,コドモ,子供
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7807,6 +8156,7 @@
 
 # newdoc id = test-s362
 # sent_id = test-s362
+# parallel_id = jagsdluw/test362
 # text = 注文をすぐにとりにこない。
 1	注文	注文	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウモン,注文,注文,注文,チューモン,,,チュウモン,チュウモン,注文
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7820,6 +8170,7 @@
 
 # newdoc id = test-s363
 # sent_id = test-s363
+# parallel_id = jagsdluw/test363
 # text = 北沢氏は防衛省と自衛隊の内部の検討だとした上で、派遣の根拠となる法令に関して防衛省設置法を念頭に「派遣が可能か検討している」と述べた。
 1	北沢氏	北沢氏	PROPN	名詞-固有名詞-人名-姓	_	36	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キタザワ;シ,キタザワ;氏,北沢;氏,北沢;氏,キタザワ;シ,;,;,キタザワ;シ,キタザワシ,北沢氏
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7862,6 +8213,7 @@
 
 # newdoc id = test-s364
 # sent_id = test-s364
+# parallel_id = jagsdluw/test364
 # text = コウスケたち三年二組の担任。
 1	コウスケたち	コウスケ達	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=コウスケ;タチ,コウスケ;達,コウスケ;たち,コウスケ;たち,コースケ;タチ,;,;,コウスケ;タチ,コウスケタチ,コウスケ達
 2	三年	三年	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=サン;ネン,三;年,三;年,三;年,サン;ネン,;,;,サン;ネン,サンネン,三年
@@ -7872,6 +8224,7 @@
 
 # newdoc id = test-s365
 # sent_id = test-s365
+# parallel_id = jagsdluw/test365
 # text = 中学卒業後は品茂先生とメル友になり、ヒナノと同じ高校に進学した。
 1	中学卒業後	中学卒業後	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウガク;ソツギョウ;ゴ,中学;卒業;後,中学;卒業;後,中学;卒業;後,チューガク;ソツギョー;ゴ,;;,;;,チュウガク;ソツギョウ;ゴ,チュウガクソツギョウゴ,中学卒業後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7892,6 +8245,7 @@
 
 # newdoc id = test-s366
 # sent_id = test-s366
+# parallel_id = jagsdluw/test366
 # text = 潜水士になる前は会社も嫌になって辞め、親も納得するという理由で海上保安庁に入庁した経緯から、あらゆる境遇に逃げてきていたと自認しているが、仙崎と行動するうちに潜水士としての成長も見せている。
 1	潜水士	潜水士	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センスイ;シ,潜水;士,潜水;士,潜水;士,センスイ;シ,;,;,センスイ;シ,センスイシ,潜水士
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7947,6 +8301,7 @@
 
 # newdoc id = test-s367
 # sent_id = test-s367
+# parallel_id = jagsdluw/test367
 # text = また雨が降ると、鉄砲水となって渓谷内を通過していった。
 1	また	又	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	雨	雨	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アメ,雨,雨,雨,アメ,,,アメ,アメ,雨
@@ -7967,6 +8322,7 @@
 
 # newdoc id = test-s368
 # sent_id = test-s368
+# parallel_id = jagsdluw/test368
 # text = 海老澤代表が統一教会の関係の人か訊くと“いえ,どなたかから聞いたのですか?”
 1	海老澤代表	海老澤代表	PROPN	名詞-固有名詞-人名-姓	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エビサワ;ダイヒョウ,エビサワ;代表,海老澤;代表,海老澤;代表,エビサワ;ダイヒョー,;,;,エビサワ;ダイヒョウ,エビサワダイヒョウ,海老澤代表
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7993,6 +8349,7 @@
 
 # newdoc id = test-s369
 # sent_id = test-s369
+# parallel_id = jagsdluw/test369
 # text = 雰囲気がすき!
 1	雰囲気	雰囲気	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フンイキ,雰囲気,雰囲気,雰囲気,フンイキ,,,フンイキ,フンイキ,雰囲気
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -8001,6 +8358,7 @@
 
 # newdoc id = test-s370
 # sent_id = test-s370
+# parallel_id = jagsdluw/test370
 # text = 私はここの病院に行き、人が怖くなり、外にでれなくなりました。
 1	私	私	PRON	代名詞	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8026,6 +8384,7 @@
 
 # newdoc id = test-s371
 # sent_id = test-s371
+# parallel_id = jagsdluw/test371
 # text = こうした技術を利用して一台のコンピュータの処理能力を飛躍的に向上させたものはスーパーコンピュータと呼ばれ、複数のコンピュータを統合して全体として処理能力を上げたものはコンピュータ・クラスターと呼ばれる。
 1	こう	こう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウ,こう,こう,こう,コー,,,コウ,コウ,こう
 2	し	する	VERB	動詞-一般-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,スル,する
@@ -8074,6 +8433,7 @@
 
 # newdoc id = test-s372
 # sent_id = test-s372
+# parallel_id = jagsdluw/test372
 # text = 趣味はソフトボール・マラソン・飲酒。
 1	趣味	趣味	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュミ,趣味,趣味,趣味,シュミ,,,シュミ,シュミ,趣味
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8082,6 +8442,7 @@
 
 # newdoc id = test-s373
 # sent_id = test-s373
+# parallel_id = jagsdluw/test373
 # text = チチュウカイリクガメ属の模式種。
 1	チチュウカイリクガメ属	地中海陸亀属	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チチュウ;カイ;リクガメ;ゾク,地中;海;陸亀;属,チチュウ;カイ;リクガメ;属,チチュウ;カイ;リクガメ;属,チチュー;カイ;リクガメ;ゾク,;;;,;;;,チチュウ;カイ;リクガメ;ゾク,チチュウカイリクガメゾク,地中海陸亀属
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8090,6 +8451,7 @@
 
 # newdoc id = test-s374
 # sent_id = test-s374
+# parallel_id = jagsdluw/test374
 # text = 自分でも説明できないものを他人に勧めるのはやめてほしいものです。
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8111,6 +8473,7 @@
 
 # newdoc id = test-s375
 # sent_id = test-s375
+# parallel_id = jagsdluw/test375
 # text = 英語が分からない私でしたが行ってみるとレベルに合わせてクラスが分かれていました。
 1	英語	英語	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エイゴ,英語,英語,英語,エーゴ,,,エイゴ,エイゴ,英語
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -8137,6 +8500,7 @@
 
 # newdoc id = test-s376
 # sent_id = test-s376
+# parallel_id = jagsdluw/test376
 # text = アドヴァンスの外壁には明日8月6日開催の荒川灯籠流しのポスターが貼ってあった。
 1	アドヴァンス	アドバンス	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アドバンス,アドバンス,アドヴァンス,アドヴァンス,アドバンス,,,アドバンス,アドバンス,アドバンス
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8158,6 +8522,7 @@
 
 # newdoc id = test-s377
 # sent_id = test-s377
+# parallel_id = jagsdluw/test377
 # text = 店舗の見た目は正直不安をあおるものではありますが、安さと使い勝手は申し分ないと思います。
 1	店舗	店舗	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンポ,店舗,店舗,店舗,テンポ,,,テンポ,テンポ,店舗
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8187,6 +8552,7 @@
 
 # newdoc id = test-s378
 # sent_id = test-s378
+# parallel_id = jagsdluw/test378
 # text = よって女子は完全内湯で開放感・景観はゼロでした。
 1	よって	因って	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨル;テ,因る;て,よっ;て,よる;て,ヨッ;テ,;,;,ヨル;テ,ヨッテ,因って
 2	女子	女子	NOUN	名詞-普通名詞-一般	_	8	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョシ,女子,女子,女子,ジョシ,,,ジョシ,ジョシ,女子
@@ -8202,6 +8568,7 @@
 
 # newdoc id = test-s379
 # sent_id = test-s379
+# parallel_id = jagsdluw/test379
 # text = 収録曲など詳細は後日発表予定。
 1	収録曲	収録曲	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウロク;キョク,収録;曲,収録;曲,収録;曲,シューロク;キョク,;,;,シュウロク;キョク,シュウロクキョク,収録曲
 2	など	など	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナド,など,など,など,ナド,,,ナド,ナド,など
@@ -8212,6 +8579,7 @@
 
 # newdoc id = test-s380
 # sent_id = test-s380
+# parallel_id = jagsdluw/test380
 # text = 見積もりは出張や電話でしますが、家具の種類と修理項目別におよその見積もりをするフォームがあります。
 1	見積もり	見積もり	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミツモリ,見積もり,見積もり,見積もり,ミツモリ,,,ミツモリ,ミツモリ,見積もり
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8241,6 +8609,7 @@
 
 # newdoc id = test-s381
 # sent_id = test-s381
+# parallel_id = jagsdluw/test381
 # text = 血の流れの末端はうなじの下向きに湾曲した線で停止しており、なにか冠のようなものに原因が有るとすれば、茨の枝が後頭部にはまった高さにその線があるように見える。
 1	血	血	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チ,血,血,血,チ,,,チ,チ,血
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8293,6 +8662,7 @@
 
 # newdoc id = test-s382
 # sent_id = test-s382
+# parallel_id = jagsdluw/test382
 # text = 戦後は1906年に装甲巡洋艦リューリク艦長に着任。
 1	戦後	戦後	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センゴ,戦後,戦後,戦後,センゴ,,,センゴ,センゴ,戦後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8305,6 +8675,7 @@
 
 # newdoc id = test-s383
 # sent_id = test-s383
+# parallel_id = jagsdluw/test383
 # text = 相手GKと1対1になったりだとか、完全にフリーでシュートを打つというのもなかった。
 1	相手GK	相手GK	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アイテ;ジーケー,相手;ＧＫ,相手;GK,相手;GK,アイテ;ジーケー,;,;,アイテ;ジーケー,アイテジーケー,相手GK
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -8332,6 +8703,7 @@
 
 # newdoc id = test-s384
 # sent_id = test-s384
+# parallel_id = jagsdluw/test384
 # text = 手配書の内容だが,記者の身長も“185cm位”から“180cm位”に修正されている。
 1	手配書	手配書	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テハイ;ショ,手配;書,手配;書,手配;書,テハイ;ショ,;,;,テハイ;ショ,テハイショ,手配書
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8360,6 +8732,7 @@
 
 # newdoc id = test-s385
 # sent_id = test-s385
+# parallel_id = jagsdluw/test385
 # text = この写真を掲載しているのは,東京都内の店舗デザイン会社です。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	写真	写真	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シャシン,写真,写真,写真,シャシン,,,シャシン,シャシン,写真
@@ -8377,6 +8750,7 @@
 
 # newdoc id = test-s386
 # sent_id = test-s386
+# parallel_id = jagsdluw/test386
 # text = ろうそくとアルコールランプを用い、炎の強さや大きさが放射能に当たり、炎からの距離に応じて感じる明るさや温かさは放射線量に当たることを関連づけて学んだ。
 1	ろうそく	蝋燭	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ロウソク,蝋燭,ろうそく,ろうそく,ローソク,,,ロウソク,ロウソク,蝋燭
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -8419,6 +8793,7 @@
 
 # newdoc id = test-s387
 # sent_id = test-s387
+# parallel_id = jagsdluw/test387
 # text = 知っているCMばかり。
 1	知っ	知る	VERB	動詞-一般-五段-ラ行	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シル,知る,知っ,知る,シッ,,,シル,シル,知る
 2	ている	ている	AUX	助動詞-上一段-ア行	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ;イル,て;居る,て;いる,て;いる,テ;イル,;,;,テ;イル,テイル,ている
@@ -8428,6 +8803,7 @@
 
 # newdoc id = test-s388
 # sent_id = test-s388
+# parallel_id = jagsdluw/test388
 # text = 古町の老舗店店主から店や町の歴史を聞く「古町老舗・名店巡りコース」や「西大畑・先人の偉業をたどるお屋敷町散歩コース」など12コースあり、一日2コースずつ開く。
 1	古町	古町	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コマチ,古町,古町,古町,コマチ,,,コマチ,コマチ,古町
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8464,6 +8840,7 @@
 
 # newdoc id = test-s389
 # sent_id = test-s389
+# parallel_id = jagsdluw/test389
 # text = この山寺のアイディアは、後に『ルパン三世風魔一族の陰謀』にて流用される。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	山寺	山寺	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤマデラ,山寺,山寺,山寺,ヤマデラ,,,ヤマデラ,ヤマデラ,山寺
@@ -8487,6 +8864,7 @@
 
 # newdoc id = test-s390
 # sent_id = test-s390
+# parallel_id = jagsdluw/test390
 # text = 当時は調騎分離される前だったこともあり、調教師の清水茂次が20戦中19戦に騎乗している。
 1	当時	当時	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウジ,当時,当時,当時,トージ,,,トウジ,トウジ,当時
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8512,6 +8890,7 @@
 
 # newdoc id = test-s392
 # sent_id = test-s392
+# parallel_id = jagsdluw/test392
 # text = 同化産物は穀粒生産に向け直されるようになり、商業的な収穫のための化学肥料の効果が特に増加する。
 1	同化産物	同化産物	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウカ;サンブツ,同化;産物,同化;産物,同化;産物,ドーカ;サンブツ,;,;,ドウカ;サンブツ,ドウカサンブツ,同化産物
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8539,6 +8918,7 @@
 
 # newdoc id = test-s393
 # sent_id = test-s393
+# parallel_id = jagsdluw/test393
 # text = 両親は転勤で北海道に在住しそれが延期となり、姉はまもなく海外へ留学のため親の意向に逆らいマンションを借りて一人暮らしをする。
 1	両親	両親	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リョウシン,両親,両親,両親,リョーシン,,,リョウシン,リョウシン,両親
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8579,6 +8959,7 @@
 
 # newdoc id = test-s394
 # sent_id = test-s394
+# parallel_id = jagsdluw/test394
 # text = 同署によると、ドラマの撮影は行われず、違約金も返却されないため、女性が2月に被害を届け出た。
 1	同署	同署	NOUN	名詞-普通名詞-一般	_	25	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウショ,同署,同署,同署,ドーショ,,,ドウショ,ドウショ,同署
 2	によると	によると	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;ト,に;因る;と,に;よる;と,に;よる;と,ニ;ヨル;ト,;;,;;,ニ;ヨル;ト,ニヨルト,によると
@@ -8610,6 +8991,7 @@
 
 # newdoc id = test-s395
 # sent_id = test-s395
+# parallel_id = jagsdluw/test395
 # text = 翌12日より五島産業汽船が同航路の運航を開始したが、2006年4月をもって廃止。
 1	翌12日	翌12日	NUM	名詞-数詞	_	9	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨク;イチ;ニ;ニチ,翌;一;二;日,翌;1;2;日,翌;1;2;日,ヨク;イチ;ニ;ニチ,;;;,;;;,ヨク;イチ;ニ;ニチ,ヨクイチニニチ,翌12日
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -8631,6 +9013,7 @@
 
 # newdoc id = test-s396
 # sent_id = test-s396
+# parallel_id = jagsdluw/test396
 # text = 翌年に試作機が完成しているが、減速装置の不調と重量過大が最後まで改善されなかった。
 1	翌年	翌年	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨクネン,翌年,翌年,翌年,ヨクネン,,,ヨクネン,ヨクネン,翌年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8656,6 +9039,7 @@
 
 # newdoc id = test-s397
 # sent_id = test-s397
+# parallel_id = jagsdluw/test397
 # text = 食後のラテと小さなデザートもお気に入り。
 1	食後	食後	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショクゴ,食後,食後,食後,ショクゴ,,,ショクゴ,ショクゴ,食後
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8669,6 +9053,7 @@
 
 # newdoc id = test-s398
 # sent_id = test-s398
+# parallel_id = jagsdluw/test398
 # text = コンピュータにおけるデータログでは、障害などが発生したとき、何が起きたのかを説明できるようにするためにプログラムが自動的にある範囲のイベントを記録する。
 1	コンピュータ	コンピュータ	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンピューター,コンピューター,コンピュータ,コンピュータ,コンピュータ,,,コンピュータ,コンピュータ,コンピュータ
 2	における	における	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;オク;リ,に;於く;り,に;おけ;る,に;おく;り,ニ;オケ;ル,;;,;;,ニ;オク;リ,ニオケル,における
@@ -8709,6 +9094,7 @@
 
 # newdoc id = test-s399
 # sent_id = test-s399
+# parallel_id = jagsdluw/test399
 # text = 受付で訊くと展示会は招待制とのことだったが,モバイルHPにその旨の記載がないことを告げると責任者を呼ぶから待つようにと言われた。
 1	受付	受け付け	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウケツケ,受け付け,受付,受付,ウケツケ,,,ウケツケ,ウケツケ,受け付け
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8751,6 +9137,7 @@
 
 # newdoc id = test-s400
 # sent_id = test-s400
+# parallel_id = jagsdluw/test400
 # text = 「MAX11836」はユーザー定義のハプティックパターンのオンチップ保存,再生ロジック,出力設定可能なDC-DC変換,および高い容量性負荷用の出力ドライバを備えている。
 1	「	「	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	MAX11836	MAX11836	NUM	名詞-数詞	_	25	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エム;エー;エックス;イチ;イチ;ハチ;サン;ロク,Ｍ;Ａ;Ｘ;一;一;八;三;六,M;A;X;1;1;8;3;6,M;A;X;1;1;8;3;6,エム;エー;エックス;イチ;イチ;ハチ;サン;ロク,;;;;;;;,;;;;;;;,エム;エー;エックス;イチ;イチ;ハチ;サン;ロク,エムエーエックスイチイチハチサンロク,MAX11836
@@ -8782,6 +9169,7 @@
 
 # newdoc id = test-s401
 # sent_id = test-s401
+# parallel_id = jagsdluw/test401
 # text = 基盤左側に某有名PC周辺機器メーカーのロゴが見えます。
 1	基盤左側	基盤左側	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キバン;ヒダリガワ,基盤;左側,基盤;左側,基盤;左側,キバン;ヒダリガワ,;,;,キバン;ヒダリガワ,キバンヒダリガワ,基盤左側
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8795,6 +9183,7 @@
 
 # newdoc id = test-s402
 # sent_id = test-s402
+# parallel_id = jagsdluw/test402
 # text = いよいよイベントもお開きの時間となり、3人は来場者に向け1人ずつコメント。
 1	いよいよ	愈	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イヨイヨ,愈,いよいよ,いよいよ,イヨイヨ,,,イヨイヨ,イヨイヨ,愈
 2	イベント	イベント	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イベント,イベント,イベント,イベント,イベント,,,イベント,イベント,イベント
@@ -8817,6 +9206,7 @@
 
 # newdoc id = test-s403
 # sent_id = test-s403
+# parallel_id = jagsdluw/test403
 # text = これのお返しとして、寝屋親が寝屋子にごちそうをふるまうことを「寝屋子振舞い」という。
 1	これ	此れ	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8841,6 +9231,7 @@
 
 # newdoc id = test-s404
 # sent_id = test-s404
+# parallel_id = jagsdluw/test404
 # text = アッシリア王名表では彼の記述の後に「食べつくされる」という注釈がついている。
 1	アッシリア王名表	アッシリア王名表	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アッシリア;オウメイ;ヒョウ,アッシリア;王名;表,アッシリア;王名;表,アッシリア;王名;表,アッシリア;オーメー;ヒョー,;;,;;,アッシリア;オウメイ;ヒョウ,アッシリアオウメイヒョウ,アッシリア王名表
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8864,6 +9255,7 @@
 
 # newdoc id = test-s405
 # sent_id = test-s405
+# parallel_id = jagsdluw/test405
 # text = 女優のランキングでは、20代から30代までの票がいろんな女優にばらけたのに対し、40代から60代までの票が、オードリー・ヘップバーンやマリリン・モンローに集中したことで、上位に往年のハリウッドスターがランキングする結果となりました。
 1	女優	女優	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョユウ,女優,女優,女優,ジョユー,,,ジョユウ,ジョユウ,女優
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8919,6 +9311,7 @@
 
 # newdoc id = test-s406
 # sent_id = test-s406
+# parallel_id = jagsdluw/test406
 # text = 菅直人首相は28日、円高で加速しかねない産業空洞化を防ぎ、地方を中心に雇用を確保するため、国内への工場立地などの推進を目指す「日本国内投資促進プログラム」の策定を直嶋正行経済産業相に指示した。
 1	菅直人首相	菅直人首相	PROPN	名詞-固有名詞-人名-一般	_	39	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カン;ナオト;シュショウ,カン;ナオト;首相,菅;直人;首相,菅;直人;首相,カン;ナオト;シュショー,;;,;;,カン;ナオト;シュショウ,カンナオトシュショウ,菅直人首相
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8964,6 +9357,7 @@
 
 # newdoc id = test-s407
 # sent_id = test-s407
+# parallel_id = jagsdluw/test407
 # text = 現在では、観光客も多く訪れるようになっている。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8981,6 +9375,7 @@
 
 # newdoc id = test-s408
 # sent_id = test-s408
+# parallel_id = jagsdluw/test408
 # text = 代わりの人がやったからって上手くできるのかなという感じもあります。
 1	代わり	代わり	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カワリ,代わり,代わり,代わり,カワリ,,,カワリ,カワリ,代わり
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9004,6 +9399,7 @@
 
 # newdoc id = test-s409
 # sent_id = test-s409
+# parallel_id = jagsdluw/test409
 # text = 創価学会員も参加している運動を“左翼&唯物論”と言われても,意味がよくわかりません。
 1	創価学会員	創価学会員	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソウカ;ガッカイ;イン,創価;学会;員,創価;学会;員,創価;学会;員,ソーカ;ガッカイ;イン,;;,;;,ソウカ;ガッカイ;イン,ソウカガッカイイン,創価学会員
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -9030,6 +9426,7 @@
 
 # newdoc id = test-s410
 # sent_id = test-s410
+# parallel_id = jagsdluw/test410
 # text = 無邪気で素直な性格であるが、少し弱虫。
 1	無邪気	無邪気	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ムジャキ,無邪気,無邪気,無邪気,ムジャキ,,,ムジャキ,ムジャキ,無邪気
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -9045,6 +9442,7 @@
 
 # newdoc id = test-s411
 # sent_id = test-s411
+# parallel_id = jagsdluw/test411
 # text = 2011年8月に行われた韓国プロ野球ドラフト会議にて、LGツインズより8位指名を受けたが、宋は日本のドラフト会議でも指名の対象になっており、日本でのプレーを希望していることからLGの指名を拒否。
 1	2011年	2011年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;イチ;ネン,二;ゼロ;一;一;年,2;0;1;1;年,2;0;1;1;年,ニ;ゼロ;イチ;イチ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;イチ;ネン,ニゼロイチイチネン,2011年
 2	8月	8月	NUM	名詞-数詞	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハチ;ガツ,八;月,8;月,8;月,ハチ;ガツ,;,;,ハチ;ガツ,ハチガツ,8月
@@ -9095,6 +9493,7 @@
 
 # newdoc id = test-s412
 # sent_id = test-s412
+# parallel_id = jagsdluw/test412
 # text = 小田急の通勤車両では初めて他事業者路線への乗り入れを前提とした車両になることから、それまでの小田急の通勤車両の標準仕様とは異なる新技術が採用された。
 1	小田急	小田急	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オダキュウ,小田急,小田急,小田急,オダキュー,,,オダキュウ,オダキュウ,小田急
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9137,6 +9536,7 @@
 
 # newdoc id = test-s413
 # sent_id = test-s413
+# parallel_id = jagsdluw/test413
 # text = 同じく11代目として登場したのが松熊由紀である。
 1	同じく	同じく	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オナジク,同じく,同じく,同じく,オナジク,,,オナジク,オナジク,同じく
 2	11代目	11代目	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;イチ;ダイ;メ,一;一;代;目,1;1;代;目,1;1;代;目,イチ;イチ;ダイ;メ,;;;,;;;,イチ;イチ;ダイ;メ,イチイチダイメ,11代目
@@ -9151,6 +9551,7 @@
 
 # newdoc id = test-s414
 # sent_id = test-s414
+# parallel_id = jagsdluw/test414
 # text = 神奈川県横浜市に所在するNPO法人。
 1	神奈川県	神奈川県	PROPN	名詞-固有名詞-地名-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カナガワ;ケン,カナガワ;県,神奈川;県,神奈川;県,カナガワ;ケン,;,;,カナガワ;ケン,カナガワケン,神奈川県
 2	横浜市	横浜市	PROPN	名詞-固有名詞-地名-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨコハマ;シ,ヨコハマ;市,横浜;市,横浜;市,ヨコハマ;シ,;,;,ヨコハマ;シ,ヨコハマシ,横浜市
@@ -9161,6 +9562,7 @@
 
 # newdoc id = test-s415
 # sent_id = test-s415
+# parallel_id = jagsdluw/test415
 # text = これはTPが南下される時,神様と約束された南北統一をなすことです。
 1	これ	此れ	PRON	代名詞	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9184,6 +9586,7 @@
 
 # newdoc id = test-s416
 # sent_id = test-s416
+# parallel_id = jagsdluw/test416
 # text = 気軽に立ち寄れるネイルサロンなので、初めての人でも是非通ってみてください。
 1	気軽	気軽	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キガル,気軽,気軽,気軽,キガル,,,キガル,キガル,気軽
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -9205,6 +9608,7 @@
 
 # newdoc id = test-s418
 # sent_id = test-s418
+# parallel_id = jagsdluw/test418
 # text = ヒットメーカーに当たりが出ない。
 1	ヒットメーカー	ヒットメーカー	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒット;メーカー,ヒット;メーカー,ヒット;メーカー,ヒット;メーカー,ヒット;メーカー,;,;,ヒット;メーカー,ヒットメーカー,ヒットメーカー
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9216,6 +9620,7 @@
 
 # newdoc id = test-s419
 # sent_id = test-s419
+# parallel_id = jagsdluw/test419
 # text = 私は“あるんだ”という以外ないので,議論になります。
 1	私	私	PRON	代名詞	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9236,6 +9641,7 @@
 
 # newdoc id = test-s420
 # sent_id = test-s420
+# parallel_id = jagsdluw/test420
 # text = デドフスクにはM9幹線道路が通るほか、モスクワからリガに向かう鉄道も通る。
 1	デドフスク	デドフスク	PROPN	名詞-固有名詞-地名-一般	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デドフスク,デドフスク,デドフスク,デドフスク,デドフスク,,,デドフスク,デドフスク,デドフスク
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9257,12 +9663,14 @@
 
 # newdoc id = test-s421
 # sent_id = test-s421
+# parallel_id = jagsdluw/test421
 # text = 日置藩領主。
 1	日置藩領主	日置藩領主	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ヒオキ;ハン;リョウシュ,ヒオキ;藩;領主,日置;藩;領主,日置;藩;領主,ヒオキ;ハン;リョーシュ,;;,;;,ヒオキ;ハン;リョウシュ,ヒオキハンリョウシュ,日置藩領主
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s422
 # sent_id = test-s422
+# parallel_id = jagsdluw/test422
 # text = 一旦はその考えを受け入れたが、CNRT率いる野党連合とフレティリンは、何週間も論争を繰り返したが合意には至らなかった。
 1	一旦	一旦	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッタン,一旦,一旦,一旦,イッタン,,,イッタン,イッタン,一旦
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9297,6 +9705,7 @@
 
 # newdoc id = test-s423
 # sent_id = test-s423
+# parallel_id = jagsdluw/test423
 # text = 1635年か36年にアントワープの画家組合に加入。
 1	1635年	1635年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ロク;サン;ゴ;ネン,一;六;三;五;年,1;6;3;5;年,1;6;3;5;年,イチ;ロク;サン;ゴ;ネン,;;;;,;;;;,イチ;ロク;サン;ゴ;ネン,イチロクサンゴネン,1635年
 2	か	か	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カ,か,か,か,カ,,,カ,カ,か
@@ -9311,6 +9720,7 @@
 
 # newdoc id = test-s424
 # sent_id = test-s424
+# parallel_id = jagsdluw/test424
 # text = 2004年の推計では100,771人に減少している。
 1	2004年	2004年	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ヨン;ネン,二;ゼロ;ゼロ;四;年,2;0;0;4;年,2;0;0;4;年,ニ;ゼロ;ゼロ;ヨ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ヨ;ネン,ニゼロゼロヨンネン,2004年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9325,6 +9735,7 @@
 
 # newdoc id = test-s425
 # sent_id = test-s425
+# parallel_id = jagsdluw/test425
 # text = 2007年3月にFIFA女子ワールドカップの出場権をかけた大陸間プレーオフで2003年と同様にメキシコとホーム・アンド・アウェーで対戦。
 1	2007年	2007年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;シチ;ネン,二;ゼロ;ゼロ;七;年,2;0;0;7;年,2;0;0;7;年,ニ;ゼロ;ゼロ;シチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;シチ;ネン,ニゼロゼロシチネン,2007年
 2	3月	3月	NUM	名詞-数詞	_	20	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ガツ,三;月,3;月,3;月,サン;ガツ,;,;,サン;ガツ,サンガツ,3月
@@ -9350,6 +9761,7 @@
 
 # newdoc id = test-s426
 # sent_id = test-s426
+# parallel_id = jagsdluw/test426
 # text = 御手洗学園高等部入学直後にミステリー執筆技術を実践的に習えるものと勘違いし、実践ミステリ倶楽部に仮入部する。
 1	御手洗学園高等部入学直後	御手洗学園高等部入学直後	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミタライ;ガクエン;コウトウ;ブ;ニュウガク;チョクゴ,ミタライ;学園;高等;部;入学;直後,御手洗;学園;高等;部;入学;直後,御手洗;学園;高等;部;入学;直後,ミタライ;ガクエン;コートー;ブ;ニューガク;チョクゴ,;;;;;,;;;;;,ミタライ;ガクエン;コウトウ;ブ;ニュウガク;チョクゴ,ミタライガクエンコウトウブニュウガクチョクゴ,御手洗学園高等部入学直後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9369,6 +9781,7 @@
 
 # newdoc id = test-s427
 # sent_id = test-s427
+# parallel_id = jagsdluw/test427
 # text = 発表会などのイベントでは、生徒さんたちの演奏だけでなく、講師陣のセッションもかなり見応えがあります♪
 1	発表会	発表会	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハッピョウ;カイ,発表;会,発表;会,発表;会,ハッピョー;カイ,;,;,ハッピョウ;カイ,ハッピョウカイ,発表会
 2	など	など	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナド,など,など,など,ナド,,,ナド,ナド,など
@@ -9395,12 +9808,14 @@
 
 # newdoc id = test-s428
 # sent_id = test-s428
+# parallel_id = jagsdluw/test428
 # text = 国民運動連合所属。
 1	国民運動連合所属	国民運動連合所属	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=コクミン;ウンドウ;レンゴウ;ショゾク,国民;運動;連合;所属,国民;運動;連合;所属,国民;運動;連合;所属,コクミン;ウンドー;レンゴー;ショゾク,;;;,;;;,コクミン;ウンドウ;レンゴウ;ショゾク,コクミンウンドウレンゴウショゾク,国民運動連合所属
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s429
 # sent_id = test-s429
+# parallel_id = jagsdluw/test429
 # text = まもなくしてミトライはラテンアメリカの芸術・文化に魅了されはじめた。
 1	ま	間	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マ,間,ま,ま,マ,,,マ,マ,間
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -9421,6 +9836,7 @@
 
 # newdoc id = test-s430
 # sent_id = test-s430
+# parallel_id = jagsdluw/test430
 # text = そこで、うなぎ屋が山伏を追っかけてその通りに言うと「わしゃ。
 1	そこ	其処	PRON	代名詞	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソコ,其処,そこ,そこ,ソコ,,,ソコ,ソコ,其処
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9442,6 +9858,7 @@
 
 # newdoc id = test-s431
 # sent_id = test-s431
+# parallel_id = jagsdluw/test431
 # text = 正午からのデモでは,紀尾井町の文芸春秋本社通用門前に30名程の信者が並び,初日からリーダーを務める井口氏の号令で一人ずつビルに向かい抗議の演説。
 1	正午	正午	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウゴ,正午,正午,正午,ショーゴ,,,ショウゴ,ショウゴ,正午
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -9482,6 +9899,7 @@
 
 # newdoc id = test-s432
 # sent_id = test-s432
+# parallel_id = jagsdluw/test432
 # text = 同大統領は、EU加盟および欧州統合を目指す意向を表明した。
 1	同大統領	同大統領	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;ダイトウリョウ,同;大統領,同;大統領,同;大統領,ドー;ダイトーリョー,;,;,ドウ;ダイトウリョウ,ドウダイトウリョウ,同大統領
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9499,6 +9917,7 @@
 
 # newdoc id = test-s433
 # sent_id = test-s433
+# parallel_id = jagsdluw/test433
 # text = したがって、横滑り側の片翼の揚力が反対側よりも大きくなり、エルロン操作を行なわなくとも傾きは回復する。
 1	したがって	従って	CCONJ	接続詞	_	22	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シタガウ;テ,従う;て,したがっ;て,したがう;て,シタガッ;テ,;,;,シタガウ;テ,シタガッテ,従って
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9526,6 +9945,7 @@
 
 # newdoc id = test-s434
 # sent_id = test-s434
+# parallel_id = jagsdluw/test434
 # text = その理由は“科学の無視”です。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	理由	理由	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リユウ,理由,理由,理由,リユー,,,リユウ,リユウ,理由
@@ -9540,6 +9960,7 @@
 
 # newdoc id = test-s435
 # sent_id = test-s435
+# parallel_id = jagsdluw/test435
 # text = 艦名はエイの一種であるスケートに因む。
 1	艦名	艦名	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンメイ,艦名,艦名,艦名,カンメー,,,カンメイ,カンメイ,艦名
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9554,6 +9975,7 @@
 
 # newdoc id = test-s436
 # sent_id = test-s436
+# parallel_id = jagsdluw/test436
 # text = 脱線の原因は不明で、地元の消防局は、煙に有害物質が含まれている可能性があると周辺の住民に注意を呼びかけている。
 1	脱線	脱線	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダッセン,脱線,脱線,脱線,ダッセン,,,ダッセン,ダッセン,脱線
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9590,6 +10012,7 @@
 
 # newdoc id = test-s437
 # sent_id = test-s437
+# parallel_id = jagsdluw/test437
 # text = こうしたことは、後の大洪水時代においても同様であり、貴族共和制の弱点を突かれたと言える。
 1	こう	こう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウ,こう,こう,こう,コー,,,コウ,コウ,こう
 2	し	する	VERB	動詞-一般-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,スル,する
@@ -9618,6 +10041,7 @@
 
 # newdoc id = test-s438
 # sent_id = test-s438
+# parallel_id = jagsdluw/test438
 # text = 安徽省安慶出身。
 1	安徽省	安徽省	PROPN	名詞-固有名詞-地名-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アンキ;ショウ,アンキ;省,安徽;省,安徽;省,アンキ;ショー,;,;,アンキ;ショウ,アンキショウ,安徽省
 2	安慶出身	安慶出身	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=アンケイ;シュッシン,アンケイ;出身,安慶;出身,安慶;出身,アンケー;シュッシン,;,;,アンケイ;シュッシン,アンケイシュッシン,安慶出身
@@ -9625,6 +10049,7 @@
 
 # newdoc id = test-s439
 # sent_id = test-s439
+# parallel_id = jagsdluw/test439
 # text = ペリューは、1804年に少将に昇進した。
 1	ペリュー	ペリュー	PROPN	名詞-固有名詞-人名-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ペリー,ペリー,ペリュー,ペリュー,ペリュー,,,ペリュー,ペリュー,ペリュー
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9639,6 +10064,7 @@
 
 # newdoc id = test-s440
 # sent_id = test-s440
+# parallel_id = jagsdluw/test440
 # text = グレズリー式連動弁装置は実質上は付加装置であって、外側二気筒の弁装置の位置を逆向きに合成して中央シリンダーの弁位置を決めている。
 1	グレズリー式連動弁装置	グレズリー式連動弁装置	NOUN	名詞-普通名詞-一般	_	24	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=グレズリー;シキ;レンドウ;ベン;ソウチ,グレズリー;式;連動;弁;装置,グレズリー;式;連動;弁;装置,グレズリー;式;連動;弁;装置,グレズリー;シキ;レンドー;ベン;ソーチ,;;;;,;;;;,グレズリー;シキ;レンドウ;ベン;ソウチ,グレズリーシキレンドウベンソウチ,グレズリー式連動弁装置
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9669,6 +10095,7 @@
 
 # newdoc id = test-s441
 # sent_id = test-s441
+# parallel_id = jagsdluw/test441
 # text = 目標が超音速飛行している場合においても、その時だけ短時間飛行できれば問題無く、長時間の超音速飛行によって追尾する必要は無いからである。
 1	目標	目標	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モクヒョウ,目標,目標,目標,モクヒョー,,,モクヒョウ,モクヒョウ,目標
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9701,6 +10128,7 @@
 
 # newdoc id = test-s442
 # sent_id = test-s442
+# parallel_id = jagsdluw/test442
 # text = 新快速の運行時間外などは快速としても運用され、稀に湘南色との混色編成などもあった。
 1	新快速	新快速	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シン;カイソク,新;快速,新;快速,新;快速,シン;カイソク,;,;,シン;カイソク,シンカイソク,新快速
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9727,6 +10155,7 @@
 
 # newdoc id = test-s443
 # sent_id = test-s443
+# parallel_id = jagsdluw/test443
 # text = 13歳の頃から数々の舞台に出演しており、アル・パチーノとの共演歴もある。
 1	13歳	13歳	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;サン;サイ,一;三;歳,1;3;歳,1;3;歳,イチ;サン;サイ,;;,;;,イチ;サン;サイ,イチサンサイ,13歳
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9749,6 +10178,7 @@
 
 # newdoc id = test-s444
 # sent_id = test-s444
+# parallel_id = jagsdluw/test444
 # text = 当初、民主党の西村智奈美が「審議に100時間は必要だ」と主張し、与党側も「重要法案」指定を見送ったことから、第171回国会での公文書管理法の成立は絶望視されていた。
 1	当初	当初	ADV	副詞	_	16	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9792,6 +10222,7 @@
 
 # newdoc id = test-s445
 # sent_id = test-s445
+# parallel_id = jagsdluw/test445
 # text = 神奈川県鎌倉市北鎌倉出身。
 1	神奈川県	神奈川県	PROPN	名詞-固有名詞-地名-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カナガワ;ケン,カナガワ;県,神奈川;県,神奈川;県,カナガワ;ケン,;,;,カナガワ;ケン,カナガワケン,神奈川県
 2	鎌倉市	鎌倉市	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カマクラ;シ,カマクラ;市,鎌倉;市,鎌倉;市,カマクラ;シ,;,;,カマクラ;シ,カマクラシ,鎌倉市
@@ -9800,6 +10231,7 @@
 
 # newdoc id = test-s446
 # sent_id = test-s446
+# parallel_id = jagsdluw/test446
 # text = 唯一、最初から冥術を使用できるクラス。
 1	唯一	唯一	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユイイツ,唯一,唯一,唯一,ユイイツ,,,ユイイツ,ユイイツ,唯一
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9813,6 +10245,7 @@
 
 # newdoc id = test-s447
 # sent_id = test-s447
+# parallel_id = jagsdluw/test447
 # text = 1883年に家族に連れられてドイツに移住。
 1	1883年	1883年	NUM	名詞-数詞	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;ハチ;サン;ネン,一;八;八;三;年,1;8;8;3;年,1;8;8;3;年,イチ;ハチ;ハチ;サン;ネン,;;;;,;;;;,イチ;ハチ;ハチ;サン;ネン,イチハチハチサンネン,1883年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9828,6 +10261,7 @@
 
 # newdoc id = test-s448
 # sent_id = test-s448
+# parallel_id = jagsdluw/test448
 # text = 味は申し分ない。
 1	味	味	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アジ,味,味,味,アジ,,,アジ,アジ,味
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9837,6 +10271,7 @@
 
 # newdoc id = test-s449
 # sent_id = test-s449
+# parallel_id = jagsdluw/test449
 # text = そして5月にリリースした「Story」は8位初登場の後、売上枚数30万枚、ダウンロード件数400万件となり、同曲で初のNHK紅白歌合戦出場を果す。
 1	そして	そして	CCONJ	接続詞	_	28	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	5月	5月	NUM	名詞-数詞	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ;ガツ,五;月,5;月,5;月,ゴ;ガツ,;,;,ゴ;ガツ,ゴガツ,5月
@@ -9870,6 +10305,7 @@
 
 # newdoc id = test-s450
 # sent_id = test-s450
+# parallel_id = jagsdluw/test450
 # text = 詳細は槍槓を参照。
 1	詳細	詳細	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウサイ,詳細,詳細,詳細,ショーサイ,,,ショウサイ,ショウサイ,詳細
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9880,6 +10316,7 @@
 
 # newdoc id = test-s451
 # sent_id = test-s451
+# parallel_id = jagsdluw/test451
 # text = プードルの女の子のキャラクター。
 1	プードル	プードル	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=プードル,プードル,プードル,プードル,プードル,,,プードル,プードル,プードル
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9890,6 +10327,7 @@
 
 # newdoc id = test-s452
 # sent_id = test-s452
+# parallel_id = jagsdluw/test452
 # text = 僕ができるのはクルマのフィードバックだけ。
 1	僕	僕	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ボク,僕,僕,僕,ボク,,,ボク,ボク,僕
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9904,6 +10342,7 @@
 
 # newdoc id = test-s453
 # sent_id = test-s453
+# parallel_id = jagsdluw/test453
 # text = バスは園児19人と運転手、幼稚園の職員の計21人が乗車し、幼稚園に向かう途中だった。
 1	バス	バス	NOUN	名詞-普通名詞-一般	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バス,バス,バス,バス,バス,,,バス,バス,バス
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9930,6 +10369,7 @@
 
 # newdoc id = test-s454
 # sent_id = test-s454
+# parallel_id = jagsdluw/test454
 # text = 一般的にハニー・ライトニング・フレアより威力が高い。
 1	一般的	一般的	ADJ	形状詞-一般	_	7	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッパン;テキ,一般;的,一般;的,一般;的,イッパン;テキ,;,;,イッパン;テキ,イッパンテキ,一般的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -9942,6 +10382,7 @@
 
 # newdoc id = test-s455
 # sent_id = test-s455
+# parallel_id = jagsdluw/test455
 # text = この地形を利用している生物がアキアカネである。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	地形	地形	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チケイ,地形,地形,地形,チケー,,,チケイ,チケイ,地形
@@ -9956,6 +10397,7 @@
 
 # newdoc id = test-s456
 # sent_id = test-s456
+# parallel_id = jagsdluw/test456
 # text = 14日未明、ジャーヴィスはスペイン艦隊が風上35マイルにあることを知った。
 1	14日未明	14日未明	ADV	副詞	_	13	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ヨン;カ;ミメイ,一;四;日;未明,1;4;日;未明,1;4;日;未明,イチ;ヨッ;カ;ミメー,;;;,;;;,イチ;ヨ;カ;ミメイ,イチヨンカミメイ,14日未明
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9975,6 +10417,7 @@
 
 # newdoc id = test-s457
 # sent_id = test-s457
+# parallel_id = jagsdluw/test457
 # text = 考え方の源流は、アルキメデスが円周率の近似値を計算する際に用いた方法にまで遡るが、現代的な形での定式化はガウスによってなされた。
 1	考え方	考え方	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンガエル;カタ,考える;方,考え;方,考える;方,カンガエ;カタ,;,;,カンガエル;カタ,カンガエカタ,考え方
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10013,6 +10456,7 @@
 
 # newdoc id = test-s458
 # sent_id = test-s458
+# parallel_id = jagsdluw/test458
 # text = 非常に楽しみです。
 1	非常	非常	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒジョウ,非常,非常,非常,ヒジョー,,,ヒジョウ,ヒジョウ,非常
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -10022,6 +10466,7 @@
 
 # newdoc id = test-s459
 # sent_id = test-s459
+# parallel_id = jagsdluw/test459
 # text = MVPは打率.450、2本塁打、6打点の成績をあげたアラン・トランメルが初選出。
 1	MVP	MVP	NOUN	名詞-普通名詞-一般	_	15	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エムブイピー,ＭＶＰ,MVP,MVP,エムブイピー,,,エムブイピー,エムブイピー,MVP
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10042,6 +10487,7 @@
 
 # newdoc id = test-s460
 # sent_id = test-s460
+# parallel_id = jagsdluw/test460
 # text = ラジカルは反応性が高く、生物学的環境ではたいていの場合あまり高濃度では存在せず、ラジカルに1電子を奪われた分子が他の分子から電子を引き抜くとその分子がさらにラジカルを形成するので反応は連鎖的に進行する。
 1	ラジカル	ラジカル	NOUN	名詞-普通名詞-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ラジカル,ラジカル,ラジカル,ラジカル,ラジカル,,,ラジカル,ラジカル,ラジカル
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10096,6 +10542,7 @@
 
 # newdoc id = test-s461
 # sent_id = test-s461
+# parallel_id = jagsdluw/test461
 # text = 会社の業務もナイフや刀剣の売買が主体となるが、いずれの名称も同好会的な誤解を生じ易いため、そうした誤解を上手く利用して業績を上げたようである。
 1	会社	会社	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイシャ,会社,会社,会社,カイシャ,,,カイシャ,カイシャ,会社
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10141,6 +10588,7 @@
 
 # newdoc id = test-s462
 # sent_id = test-s462
+# parallel_id = jagsdluw/test462
 # text = これは、学校教育や大手新聞やテレビや書籍で、「日本は韓国の優れた文化を受け入れるだけの文化劣等国」「有史以来一枚見下げるべき文化的劣等者」「韓半島に比べてみすぼらしくて短い歴史しか持たず、歴史を捏造するしかない日本」というような対日蔑視に基づいた誤った論評が日常的に行われたり、日本列島を指す「島国」という言葉が「劣等で未開」という意味で使われて、駐日韓国大使がテレビのインタビューで使うまでになっていることからも伺える。
 1	これ	此れ	PRON	代名詞	_	105	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10251,6 +10699,7 @@
 
 # newdoc id = test-s463
 # sent_id = test-s463
+# parallel_id = jagsdluw/test463
 # text = 同校は1923年に創立された、ヒューストンでは最も長い歴史を誇る法学校で、模擬裁判プログラムがつとに良く知られている。
 1	同校	同校	NOUN	名詞-普通名詞-一般	_	24	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウコウ,同校,同校,同校,ドーコー,,,ドウコウ,ドウコウ,同校
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10282,6 +10731,7 @@
 
 # newdoc id = test-s464
 # sent_id = test-s464
+# parallel_id = jagsdluw/test464
 # text = 横須賀線への転属後、主電動機を強力形に交換した7両が新形式のモハ53形を付与された。
 1	横須賀線	横須賀線	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨコスカ;セン,ヨコスカ;線,横須賀;線,横須賀;線,ヨコスカ;セン,;,;,ヨコスカ;セン,ヨコスカセン,横須賀線
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -10307,6 +10757,7 @@
 
 # newdoc id = test-s465
 # sent_id = test-s465
+# parallel_id = jagsdluw/test465
 # text = 変更点の詳細については、タイムクライシス4の項を参照のこと。
 1	変更点	変更点	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヘンコウ;テン,変更;点,変更;点,変更;点,ヘンコー;テン,;,;,ヘンコウ;テン,ヘンコウテン,変更点
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10326,6 +10777,7 @@
 
 # newdoc id = test-s466
 # sent_id = test-s466
+# parallel_id = jagsdluw/test466
 # text = 一部で9月中間期の連結営業利益が36億円前後と前年同期比35%程度増えたようだと伝えられたことが買い材料となった。
 1	一部	一部	NOUN	名詞-普通名詞-一般	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチブ,一部,一部,一部,イチブ,,,イチブ,イチブ,一部
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -10355,6 +10807,7 @@
 
 # newdoc id = test-s467
 # sent_id = test-s467
+# parallel_id = jagsdluw/test467
 # text = 便宜的に分類したがもちろん複数のケースにまたがった適応を示す動物も多い。
 1	便宜的	便宜的	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベンギ;テキ,便宜;的,便宜;的,便宜;的,ベンギ;テキ,;,;,ベンギ;テキ,ベンギテキ,便宜的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -10378,6 +10831,7 @@
 
 # newdoc id = test-s468
 # sent_id = test-s468
+# parallel_id = jagsdluw/test468
 # text = 12月2日の午後、ドイツ空軍パイロット、ヴェルナー・ハーンはMe210でバーリを上空から偵察した。
 1	12月	12月	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;ニ;ガツ,一;二;月,1;2;月,1;2;月,イチ;ニ;ガツ,;;,;;,イチ;ニ;ガツ,イチニガツ,12月
 2	2日	2日	NUM	名詞-数詞	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フタ;カ,二;日,2;日,2;日,フツ;カ,;,;,フツ;カ,フタカ,2日
@@ -10400,6 +10854,7 @@
 
 # newdoc id = test-s469
 # sent_id = test-s469
+# parallel_id = jagsdluw/test469
 # text = 暴騰する食料価格や大災害で人心は荒廃し、食料目当ての暴動や若者の退廃が進行。
 1	暴騰する	暴騰する	VERB	動詞-一般-サ行変格	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ボウトウ;スル,暴騰;為る,暴騰;する,暴騰;する,ボートー;スル,;,;,ボウトウ;スル,ボウトウスル,暴騰する
 2	食料価格	食料価格	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショクリョウ;カカク,食料;価格,食料;価格,食料;価格,ショクリョー;カカク,;,;,ショクリョウ;カカク,ショクリョウカカク,食料価格
@@ -10423,6 +10878,7 @@
 
 # newdoc id = test-s470
 # sent_id = test-s470
+# parallel_id = jagsdluw/test470
 # text = 幸福の科学学園の毎時4.20マイクロシーベルトというこの基準を上回ります。
 1	幸福の科学学園	幸福の科学学園	PROPN	名詞-固有名詞-一般	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ノ;カガク;ガクエン,幸福;の;科学;学園,幸福;の;科学;学園,幸福;の;科学;学園,コーフク;ノ;カガク;ガクエン,;;;,;;;,コウフク;ノ;カガク;ガクエン,コウフクノカガクガクエン,幸福の科学学園
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10438,6 +10894,7 @@
 
 # newdoc id = test-s471
 # sent_id = test-s471
+# parallel_id = jagsdluw/test471
 # text = 長時間拘束され半軟禁状態の女性もいた。
 1	長時間	長時間	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウ;ジカン,長;時間,長;時間,長;時間,チョー;ジカン,;,;,チョウ;ジカン,チョウジカン,長時間
 2	拘束さ	拘束する	VERB	動詞-一般-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウソク;スル,拘束;為る,拘束;さ,拘束;する,コーソク;サ,;,;,コウソク;スル,コウソクスル,拘束する
@@ -10452,6 +10909,7 @@
 
 # newdoc id = test-s472
 # sent_id = test-s472
+# parallel_id = jagsdluw/test472
 # text = 同発電所は老朽化した小規模の発電所で、警備は手薄だった。
 1	同発電所	同発電所	NOUN	名詞-普通名詞-一般	_	12	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;ハツデン;ショ,同;発電;所,同;発電;所,同;発電;所,ドー;ハツデン;ショ,;;,;;,ドウ;ハツデン;ショ,ドウハツデンショ,同発電所
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10471,6 +10929,7 @@
 
 # newdoc id = test-s473
 # sent_id = test-s473
+# parallel_id = jagsdluw/test473
 # text = 回転ジェットによる体当たり攻撃。
 1	回転ジェット	回転ジェット	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイテン;ジェット,回転;ジェット,回転;ジェット,回転;ジェット,カイテン;ジェット,;,;,カイテン;ジェット,カイテンジェット,回転ジェット
 2	による	による	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル,に;因る,に;よる,に;よる,ニ;ヨル,;,;,ニ;ヨル,ニヨル,による
@@ -10479,6 +10938,7 @@
 
 # newdoc id = test-s474
 # sent_id = test-s474
+# parallel_id = jagsdluw/test474
 # text = 屋根のアンテナにカラスが止まっていたずらをするし、屋根が汚れてこまるからと、調査の依頼がありました。
 1	屋根	屋根	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤネ,屋根,屋根,屋根,ヤネ,,,ヤネ,ヤネ,屋根
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10512,6 +10972,7 @@
 
 # newdoc id = test-s475
 # sent_id = test-s475
+# parallel_id = jagsdluw/test475
 # text = そのカステラは,表面に“祝3.16広宣流布記念の日”と印字されており,これを買うと,創価学会のシンボルである3色デザインの紙袋に入れてくれます。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	カステラ	カステラ	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カステラ,カステラ,カステラ,カステラ,カステラ,,,カステラ,カステラ,カステラ
@@ -10550,6 +11011,7 @@
 
 # newdoc id = test-s476
 # sent_id = test-s476
+# parallel_id = jagsdluw/test476
 # text = 13世紀の建築は1456年から1466年にかけて新しいサンクチュアリに合うように改築された。
 1	13世紀	13世紀	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;サン;セイキ,一;三;世紀,1;3;世紀,1;3;世紀,イチ;サン;セーキ,;;,;;,イチ;サン;セイキ,イチサンセイキ,13世紀
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10574,6 +11036,7 @@
 
 # newdoc id = test-s477
 # sent_id = test-s477
+# parallel_id = jagsdluw/test477
 # text = インクは、大きく分けてビン入りとカートリッジ入りの2種類の形態で流通している。
 1	インク	インク	NOUN	名詞-普通名詞-一般	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=インク,インク,インク,インク,インク,,,インク,インク,インク
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10595,6 +11058,7 @@
 
 # newdoc id = test-s478
 # sent_id = test-s478
+# parallel_id = jagsdluw/test478
 # text = 勧誘員と勧誘対象者。
 1	勧誘員	勧誘員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンユウ;イン,勧誘;員,勧誘;員,勧誘;員,カンユー;イン,;,;,カンユウ;イン,カンユウイン,勧誘員
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -10603,6 +11067,7 @@
 
 # newdoc id = test-s479
 # sent_id = test-s479
+# parallel_id = jagsdluw/test479
 # text = また、攻撃手法としてはJava Scriptの難読化による手口や、PDFを利用した攻撃が引き続き増加しており、フィッシング詐欺の発生件数は2009年のピーク時に比べて82%減少したが、依然として金融機関が主要ターゲットとして脅威に晒されているとしている。
 1	また	又	CCONJ	接続詞	_	51	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10660,6 +11125,7 @@
 
 # newdoc id = test-s480
 # sent_id = test-s480
+# parallel_id = jagsdluw/test480
 # text = これがまた,うまい。
 1	これ	此れ	PRON	代名詞	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -10670,6 +11136,7 @@
 
 # newdoc id = test-s481
 # sent_id = test-s481
+# parallel_id = jagsdluw/test481
 # text = 艦長は、爆薬をリモコンによる遠隔操作で爆発させて艦内の機材や機密文書等を爆破処分し、証拠を隠滅しようとしたが、効果は不十分に終わった。
 1	艦長	艦長	NOUN	名詞-普通名詞-一般	_	25	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンチョウ,艦長,艦長,艦長,カンチョー,,,カンチョウ,カンチョウ,艦長
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10709,6 +11176,7 @@
 
 # newdoc id = test-s482
 # sent_id = test-s482
+# parallel_id = jagsdluw/test482
 # text = アイドルユニットとしても売り出され、フリーランスになってからは主演Vシネマの主題歌CDもだし、歌手デビューも果たす。
 1	アイドルユニット	アイドルユニット	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アイドル;ユニット,アイドル;ユニット,アイドル;ユニット,アイドル;ユニット,アイドル;ユニット,;,;,アイドル;ユニット,アイドルユニット,アイドルユニット
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -10735,6 +11203,7 @@
 
 # newdoc id = test-s483
 # sent_id = test-s483
+# parallel_id = jagsdluw/test483
 # text = 毛布にくるまって寒さをしのぎ、おにぎり1個を家族4人で分け合った。
 1	毛布	毛布	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モウフ,毛布,毛布,毛布,モーフ,,,モウフ,モウフ,毛布
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -10756,6 +11225,7 @@
 
 # newdoc id = test-s484
 # sent_id = test-s484
+# parallel_id = jagsdluw/test484
 # text = 動きは緩慢だが常にスーパーアーマー状態であり、ほとんどの攻撃を受けてもひるまない。
 1	動き	動き	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウゴキ,動き,動き,動き,ウゴキ,,,ウゴキ,ウゴキ,動き
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10780,6 +11250,7 @@
 
 # newdoc id = test-s485
 # sent_id = test-s485
+# parallel_id = jagsdluw/test485
 # text = よく見ると、背中や腹にあるぶち模様がいずれもハートの形をしており「体全体にハートがある猫」と口コミで広がったという。
 1	よく	良く	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨク,良く,よく,よく,ヨク,,,ヨク,ヨク,良く
 2	見る	見る	VERB	動詞-一般-上一段-マ行	_	18	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=みる|SpaceAfter=No|UnidicInfo=ミル,見る,見る,見る,ミル,,,ミル,ミル,見る
@@ -10819,6 +11290,7 @@
 
 # newdoc id = test-s486
 # sent_id = test-s486
+# parallel_id = jagsdluw/test486
 # text = タダで留学生が韓国料理をふるまい,韓国語も教えるので,日本語を教えてもらったり,友達になってもらいたい。
 1	タダ	只	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダ,只,タダ,タダ,タダ,,,タダ,タダ,只
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -10848,6 +11320,7 @@
 
 # newdoc id = test-s487
 # sent_id = test-s487
+# parallel_id = jagsdluw/test487
 # text = 「VANITY DANCE」と「Labyrinth」は、オムニバスアルバム『漆黒のシンフォニー』に収録されたもののリミックスバージョンである。
 1	「	「	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	VANITY DANCE	VANITY DANCE	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バニティ;ダンス,バニティ;ダンス,VANITY;DANCE,;DANCE,バニティ;ダンス,;,;,バニティ;ダンス,バニティダンス,VANITYDANCE
@@ -10876,6 +11349,7 @@
 
 # newdoc id = test-s488
 # sent_id = test-s488
+# parallel_id = jagsdluw/test488
 # text = そのうちの幾つかはイギリス当局がケニア人を抑圧した方法をそのまま転用したものだった。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	うち	家	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウチ,内,うち,うち,ウチ,,,ウチ,ウチ,家
@@ -10902,6 +11376,7 @@
 
 # newdoc id = test-s489
 # sent_id = test-s489
+# parallel_id = jagsdluw/test489
 # text = 縦に並ぶ4門の砲台から、それぞれバウンド弾、ブーメラン弾、誘導弾、レーザーを発射する。
 1	縦	縦	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タテ,縦,縦,縦,タテ,,,タテ,タテ,縦
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -10925,6 +11400,7 @@
 
 # newdoc id = test-s490
 # sent_id = test-s490
+# parallel_id = jagsdluw/test490
 # text = 木炭デッサンにおいて消しゴムは硬くて紙を傷めるために使用できず、柔らかく油分の少ない食パンを代用している。
 1	木炭デッサン	木炭デッサン	NOUN	名詞-普通名詞-一般	_	20	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モクタン;デッサン,木炭;デッサン,木炭;デッサン,木炭;デッサン,モクタン;デッサン,;,;,モクタン;デッサン,モクタンデッサン,木炭デッサン
 2	において	において	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;オク;テ,に;於く;て,に;おい;て,に;おく;て,ニ;オイ;テ,;;,;;,ニ;オク;テ,ニオイテ,において
@@ -10951,6 +11427,7 @@
 
 # newdoc id = test-s491
 # sent_id = test-s491
+# parallel_id = jagsdluw/test491
 # text = 大変,卑怯といわざるをえない。
 1	大変	大変	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイヘン,大変,大変,大変,タイヘン,,,タイヘン,タイヘン,大変
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -10962,6 +11439,7 @@
 
 # newdoc id = test-s492
 # sent_id = test-s492
+# parallel_id = jagsdluw/test492
 # text = いろんなメニューがあり、どんどん頼みたくなっちゃいますね!
 1	いろんな	色んな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イロンナ,色んな,いろんな,いろんな,イロンナ,,,イロンナ,イロンナ,色んな
 2	メニュー	メニュー	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メニュー,メニュー,メニュー,メニュー,メニュー,,,メニュー,メニュー,メニュー
@@ -10979,6 +11457,7 @@
 
 # newdoc id = test-s493
 # sent_id = test-s493
+# parallel_id = jagsdluw/test493
 # text = この手の本が翻訳されることは少ないと思っていたのだが,昨今のソーシャル流行りが要因かはわからないが,翻訳本が原書から1年もしないでリリースされたのはよい知らせだ。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	手	手	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テ,手,手,手,テ,,,テ,テ,手
@@ -11029,6 +11508,7 @@
 
 # newdoc id = test-s494
 # sent_id = test-s494
+# parallel_id = jagsdluw/test494
 # text = 「1997〜1999」とは、FBIがデビューした年から本作が発売された年を意味する。
 1	「	「	PUNCT	補助記号-括弧開	_	4	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	1997	1997	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;キュウ;ナナ,一;九;九;七,1;9;9;7,1;9;9;7,イチ;キュー;キュー;ナナ,;;;,;;;,イチ;キュウ;キュウ;ナナ,イチキュウキュウナナ,1997
@@ -11056,6 +11536,7 @@
 
 # newdoc id = test-s495
 # sent_id = test-s495
+# parallel_id = jagsdluw/test495
 # text = 生きていくことは美しいことだといつも思う。
 1	生き	生きる	VERB	動詞-一般-上一段-カ行	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イキル,生きる,生き,生きる,イキ,,,イキル,イキル,生きる
 2	ていく	ていく	AUX	助動詞-五段-カ行	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ;イク,て;行く,て;いく,て;いく,テ;イク,;,;,テ;イク,テイク,ていく
@@ -11072,6 +11553,7 @@
 
 # newdoc id = test-s496
 # sent_id = test-s496
+# parallel_id = jagsdluw/test496
 # text = ドラゴンズは9番チェンからの打順だったが、代打に水田を送る。
 1	ドラゴンズ	ドラゴンズ	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドラゴン,ドラゴン,ドラゴンズ,ドラゴンズ,ドラゴンズ,,,ドラゴンズ,ドラゴンズ,ドラゴンズ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11093,6 +11575,7 @@
 
 # newdoc id = test-s497
 # sent_id = test-s497
+# parallel_id = jagsdluw/test497
 # text = ダウンタウンの17ブロックにわたって広がるシアター・ディストリクトには9つの著名な演技芸術団体が本部を置き、6ヶ所のホールが立地している。
 1	ダウンタウン	ダウンタウン	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダウンタウン,ダウンタウン,ダウンタウン,ダウンタウン,ダウンタウン,,,ダウンタウン,ダウンタウン,ダウンタウン
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11122,6 +11605,7 @@
 
 # newdoc id = test-s498
 # sent_id = test-s498
+# parallel_id = jagsdluw/test498
 # text = 昔ながらの「売りっぱなし」商売をしている。
 1	昔ながら	昔乍ら	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ムカシ;ナガラ,昔;乍ら,昔;ながら,昔;ながら,ムカシ;ナガラ,;,;,ムカシ;ナガラ,ムカシナガラ,昔乍ら
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11133,6 +11617,7 @@
 
 # newdoc id = test-s499
 # sent_id = test-s499
+# parallel_id = jagsdluw/test499
 # text = 中学ではシェークスピア・ギリシア哲学・演劇にも熱中した。
 1	中学	中学	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウガク,中学,中学,中学,チューガク,,,チュウガク,チュウガク,中学
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11146,6 +11631,7 @@
 
 # newdoc id = test-s500
 # sent_id = test-s500
+# parallel_id = jagsdluw/test500
 # text = 後の稲川組幹部)と知り合い、出口辰夫と兄弟分となった。
 1	後	後	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノチ,後,後,後,ノチ,,,ノチ,ノチ,後
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11164,6 +11650,7 @@
 
 # newdoc id = test-s501
 # sent_id = test-s501
+# parallel_id = jagsdluw/test501
 # text = 会議後は資料作成などに着手し、退社は夜12時前後。
 1	会議後	会議後	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイギ;ゴ,会議;後,会議;後,会議;後,カイギ;ゴ,;,;,カイギ;ゴ,カイギゴ,会議後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11180,6 +11667,7 @@
 
 # newdoc id = test-s502
 # sent_id = test-s502
+# parallel_id = jagsdluw/test502
 # text = 現在の計画停電の3時間であれば、つけっぱなしにしても大丈夫そうだ。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11201,6 +11689,7 @@
 
 # newdoc id = test-s503
 # sent_id = test-s503
+# parallel_id = jagsdluw/test503
 # text = 皮肉なことに信濃町は,共産党タウン以上に北朝鮮的な街なのである。
 1	皮肉	皮肉	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒニク,皮肉,皮肉,皮肉,ヒニク,,,ヒニク,ヒニク,皮肉
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -11220,6 +11709,7 @@
 
 # newdoc id = test-s504
 # sent_id = test-s504
+# parallel_id = jagsdluw/test504
 # text = 一般的に、貧栄養な外洋では生物過程による全エネルギー・炭素フラックスに占める微生物環の割合が沿岸や内湾よりも高い。
 1	一般的	一般的	ADJ	形状詞-一般	_	23	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッパン;テキ,一般;的,一般;的,一般;的,イッパン;テキ,;,;,イッパン;テキ,イッパンテキ,一般的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -11248,6 +11738,7 @@
 
 # newdoc id = test-s505
 # sent_id = test-s505
+# parallel_id = jagsdluw/test505
 # text = ストリンガー氏は震災発生時は米国におり、被災現場を訪れたのは初めて。
 1	ストリンガー氏	ストリンガー氏	PROPN	名詞-固有名詞-人名-一般	_	15	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ストリンガー;シ,ストリンガー;氏,ストリンガー;氏,ストリンガー;氏,ストリンガー;シ,;,;,ストリンガー;シ,ストリンガーシ,ストリンガー氏
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11268,6 +11759,7 @@
 
 # newdoc id = test-s506
 # sent_id = test-s506
+# parallel_id = jagsdluw/test506
 # text = ジョージ・ハリスンの作品。
 1	ジョージ・ハリスン	ジョージ・ハリスン	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョージ;;ハリソン,ジョージ;・;ハリソン,ジョージ;・;ハリスン,ジョージ;・;ハリスン,ジョージ;;ハリスン,;;,;;,ジョージ;;ハリスン,ジョージハリスン,ジョージ・ハリスン
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11276,6 +11768,7 @@
 
 # newdoc id = test-s507
 # sent_id = test-s507
+# parallel_id = jagsdluw/test507
 # text = 前作では10枚以上コインを取るとスーパーキノコが出てきたが、本作ではコインが5枚散らばるようになっている。
 1	前作	前作	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼンサク,前作,前作,前作,ゼンサク,,,ゼンサク,ゼンサク,前作
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11307,6 +11800,7 @@
 
 # newdoc id = test-s508
 # sent_id = test-s508
+# parallel_id = jagsdluw/test508
 # text = 籾井王子から紀州街道旧道を西に1.5kmほど進み、海営宮池という池の近くの交差点を北に向かう脇道に入ったところに墓地があり、その北側に石碑と説明板がある。
 1	籾井王子	籾井王子	PROPN	名詞-固有名詞-地名-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モロイ;オウジ,モロイ;オウジ,籾井;王子,籾井;王子,モロイ;オージ,;,;,モロイ;オウジ,モロイオウジ,籾井王子
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -11351,6 +11845,7 @@
 
 # newdoc id = test-s509
 # sent_id = test-s509
+# parallel_id = jagsdluw/test509
 # text = 2006年11月8日、関東地方から東北地方にかけてカリオペとリヌスによる恒星の掩蔽がアマチュア天文家たちによって観測され、カリオペとリヌスの正確な大きさと位置が求められた。
 1	2006年	2006年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ロク;ネン,二;ゼロ;ゼロ;六;年,2;0;0;6;年,2;0;0;6;年,ニ;ゼロ;ゼロ;ロク;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ロク;ネン,ニゼロゼロロクネン,2006年
 2	11月	11月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;イチ;ガツ,一;一;月,1;1;月,1;1;月,イチ;イチ;ガツ,;;,;;,イチ;イチ;ガツ,イチイチガツ,11月
@@ -11392,6 +11887,7 @@
 
 # newdoc id = test-s510
 # sent_id = test-s510
+# parallel_id = jagsdluw/test510
 # text = 一方、東海地方北陸地方以東の東日本は、比較的広い沖積平野に恵まれていた上に、太平洋側を中心に低開発状態の洪積台地や河岸段丘面の農地開発の余地が大きく、日本海側を中心に扇状地でも開発の余地が広く存在したため、江戸時代に至っても、急峻な山地の傾斜面を切り開いて棚田をつくるまでに至らなかったところが多く、棚田はあまりつくられないか、つくられた場合でも畔や土手は傾斜が緩やかな土盛りとなり、西日本とは対照的な棚田風景となった。
 1	一方	一方	CCONJ	接続詞	_	106	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -11504,6 +12000,7 @@
 
 # newdoc id = test-s511
 # sent_id = test-s511
+# parallel_id = jagsdluw/test511
 # text = 帰り道、あまり気持ちよかったのでフワフワしちゃいましたよ。
 1	帰り道	帰り道	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カエリミチ,帰り道,帰り道,帰り道,カエリミチ,,,カエリミチ,カエリミチ,帰り道
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -11521,6 +12018,7 @@
 
 # newdoc id = test-s512
 # sent_id = test-s512
+# parallel_id = jagsdluw/test512
 # text = 当駅の所在する地名より。
 1	当駅	当駅	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウエキ,当駅,当駅,当駅,トーエキ,,,トウエキ,トウエキ,当駅
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11531,6 +12029,7 @@
 
 # newdoc id = test-s513
 # sent_id = test-s513
+# parallel_id = jagsdluw/test513
 # text = 右腕からチャージショットを放つ「ハイパーZEROブラスター」は火力が高く、空中でのけん制にも使えるなどゼロにとって重要な技となる。
 1	右腕	右腕	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミギウデ,右腕,右腕,右腕,ミギウデ,,,ミギウデ,ミギウデ,右腕
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -11564,6 +12063,7 @@
 
 # newdoc id = test-s514
 # sent_id = test-s514
+# parallel_id = jagsdluw/test514
 # text = 本当に焼いただけでいただけるというところが気に入っています。
 1	本当	本当	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホントウ,本当,本当,本当,ホントー,,,ホントウ,ホントウ,本当
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11584,6 +12084,7 @@
 
 # newdoc id = test-s515
 # sent_id = test-s515
+# parallel_id = jagsdluw/test515
 # text = 安くて早いから、この系列店をよく使わせてもらっているが、ここはカットが下手過ぎる。
 1	安く	安い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤスイ,安い,安く,安い,ヤスク,,,ヤスイ,ヤスイ,安い
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -11609,6 +12110,7 @@
 
 # newdoc id = test-s516
 # sent_id = test-s516
+# parallel_id = jagsdluw/test516
 # text = また利用したいです。
 1	また	又	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	利用し	利用する	VERB	動詞-一般-サ行変格	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=リヨウ;スル,利用;為る,利用;し,利用;する,リヨー;シ,;,;,リヨウ;スル,リヨウスル,利用する
@@ -11618,6 +12120,7 @@
 
 # newdoc id = test-s517
 # sent_id = test-s517
+# parallel_id = jagsdluw/test517
 # text = 天理教は,新宿区高田馬場にある牛込大教会を開放。
 1	天理教	天理教	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンリ;キョウ,テンリ;教,天理;教,天理;教,テンリ;キョー,;,;,テンリ;キョウ,テンリキョウ,天理教
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11633,6 +12136,7 @@
 
 # newdoc id = test-s518
 # sent_id = test-s518
+# parallel_id = jagsdluw/test518
 # text = 馬鹿な事を続けていれば信者からの求心力がどんどん失われていくでしょうから,そのままカルト崩壊へGO!
 1	馬鹿	馬鹿	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バカ,馬鹿,馬鹿,馬鹿,バカ,,,バカ,バカ,馬鹿
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -11662,6 +12166,7 @@
 
 # newdoc id = test-s519
 # sent_id = test-s519
+# parallel_id = jagsdluw/test519
 # text = 生理的に嫌。
 1	生理的	生理的	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイリ;テキ,生理;的,生理;的,生理;的,セーリ;テキ,;,;,セイリ;テキ,セイリテキ,生理的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -11670,6 +12175,7 @@
 
 # newdoc id = test-s520
 # sent_id = test-s520
+# parallel_id = jagsdluw/test520
 # text = 言い回しや態度が妙に芝居がかっており、プレイヤーからは「キモイ」と言われていた。
 1	言い回し	言い回し	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イイマワシ,言い回し,言い回し,言い回し,イーマワシ,,,イイマワシ,イイマワシ,言い回し
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -11695,6 +12201,7 @@
 
 # newdoc id = test-s521
 # sent_id = test-s521
+# parallel_id = jagsdluw/test521
 # text = 十メートル長の巨大なライフルと、周囲の景色に同化する機能を持つマントを駆使するスナイパー。
 1	十メートル長	十メートル長	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウ;メートル;チョウ,十;メートル;長,十;メートル;長,十;メートル;長,ジュー;メートル;チョー,;;,;;,ジュウ;メートル;チョウ,ジュウメートルチョウ,十メートル長
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11719,6 +12226,7 @@
 
 # newdoc id = test-s522
 # sent_id = test-s522
+# parallel_id = jagsdluw/test522
 # text = 猫が亡くなった今でも心から感謝しています。
 1	猫	猫	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネコ,猫,猫,猫,ネコ,,,ネコ,ネコ,猫
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -11736,6 +12244,7 @@
 
 # newdoc id = test-s523
 # sent_id = test-s523
+# parallel_id = jagsdluw/test523
 # text = 2008年1月から6月に振り込め詐欺・オレオレ詐欺で使用された携帯電話約2,300台のうち約7割がソフトバンク携帯だったとの報道が12月にあった。
 1	2008年	2008年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ハチ;ネン,二;ゼロ;ゼロ;八;年,2;0;0;8;年,2;0;0;8;年,ニ;ゼロ;ゼロ;ハチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ハチ;ネン,ニゼロゼロハチネン,2008年
 2	1月	1月	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ガツ,一;月,1;月,1;月,イチ;ガツ,;,;,イチ;ガツ,イチガツ,1月
@@ -11768,6 +12277,7 @@
 
 # newdoc id = test-s524
 # sent_id = test-s524
+# parallel_id = jagsdluw/test524
 # text = これにより業務協力で会員社の経営の効率化を図った。
 1	これ	此れ	PRON	代名詞	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	により	により	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル,に;因る,に;より,に;よる,ニ;ヨリ,;,;,ニ;ヨル,ニヨリ,により
@@ -11785,6 +12295,7 @@
 
 # newdoc id = test-s525
 # sent_id = test-s525
+# parallel_id = jagsdluw/test525
 # text = 水牛のような角を持つ漆黒の巨人の姿をしており、目から放つ光線であらゆる物を砂に変えて崩壊させる。
 1	水牛	水牛	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スイギュウ,水牛,水牛,水牛,スイギュー,,,スイギュウ,スイギュウ,水牛
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11820,6 +12331,7 @@
 
 # newdoc id = test-s526
 # sent_id = test-s526
+# parallel_id = jagsdluw/test526
 # text = ただし、書いていないのか未採択なのかの区別をつけるために「研究」節内で「*私立大学学術研究高度化推進事業の採択はない。
 1	ただし	但し	CCONJ	接続詞	_	25	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -11850,6 +12362,7 @@
 
 # newdoc id = test-s527
 # sent_id = test-s527
+# parallel_id = jagsdluw/test527
 # text = 男は女の為に闘い抜いたとき女は心を寄せるのであって,何もしないで足の長さで女を釣ろうとするのはルンペンのやることである。
 1	男	男	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オトコ,男,男,男,オトコ,,,オトコ,オトコ,男
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11893,6 +12406,7 @@
 
 # newdoc id = test-s528
 # sent_id = test-s528
+# parallel_id = jagsdluw/test528
 # text = 後続の車両の方がBAの番号は若いが、BA-27の27は開発年度から来ているものと以降の車両はほぼ製作順に番号が並んでいる。
 1	後続	後続	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウゾク,後続,後続,後続,コーゾク,,,コウゾク,コウゾク,後続
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11932,6 +12446,7 @@
 
 # newdoc id = test-s529
 # sent_id = test-s529
+# parallel_id = jagsdluw/test529
 # text = ご理解とご協力,よろしくお願いいたします。
 1	ご理解	御理解	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ;リカイ,御;理解,ご;理解,ご;理解,ゴ;リカイ,;,;,ゴ;リカイ,ゴリカイ,御理解
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -11944,6 +12459,7 @@
 
 # newdoc id = test-s530
 # sent_id = test-s530
+# parallel_id = jagsdluw/test530
 # text = 亜大の東浜も6回で12三振を奪った。
 1	亜大	亜大	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アダイ,亜大,亜大,亜大,アダイ,,,アダイ,アダイ,亜大
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11959,6 +12475,7 @@
 
 # newdoc id = test-s531
 # sent_id = test-s531
+# parallel_id = jagsdluw/test531
 # text = 直人の妻。
 1	直人	直人	PROPN	名詞-固有名詞-人名-名	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオト,ナオト,直人,直人,ナオト,,,ナオト,ナオト,直人
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11967,6 +12484,7 @@
 
 # newdoc id = test-s532
 # sent_id = test-s532
+# parallel_id = jagsdluw/test532
 # text = まあAIDMA,AISASをはじめとするSIPSみたいな言葉には最近嫌悪感すらするのだけど,モデルとしては判りやすい。
 1	まあ	まあ	ADV	副詞	_	25	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マア,まあ,まあ,まあ,マー,,,マア,マア,まあ
 2	AIDMA	AIDMA	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アイドマ,ＡＩＤＭＡ,AIDMA,AIDMA,アイドマ,,,アイドマ,アイドマ,AIDMA
@@ -11997,6 +12515,7 @@
 
 # newdoc id = test-s533
 # sent_id = test-s533
+# parallel_id = jagsdluw/test533
 # text = 2006年には柏レイソルの監督に就任。
 1	2006年	2006年	NUM	名詞-数詞	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ロク;ネン,二;ゼロ;ゼロ;六;年,2;0;0;6;年,2;0;0;6;年,ニ;ゼロ;ゼロ;ロク;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ロク;ネン,ニゼロゼロロクネン,2006年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -12010,6 +12529,7 @@
 
 # newdoc id = test-s534
 # sent_id = test-s534
+# parallel_id = jagsdluw/test534
 # text = ポッドキャスト用アグリゲータの主な目的はRSSに関連付けされているポッドキャスト・ファイルのダウンロードだが、音楽再生機能を持ち、ダウンロードしたファイルを直接再生できるものも多い。
 1	ポッドキャスト用アグリゲータ	ポッドキャスト用	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ポッド;キャスト;ヨウ;アグリゲーター,ポッド;キャスト;用;アグリゲーター,ポッド;キャスト;用;アグリゲータ,ポッド;キャスト;用;アグリゲータ,ポッド;キャスト;ヨー;アグリゲータ,;;;,;;;,ポッド;キャスト;ヨウ;アグリゲータ,ポッドキャストヨウ,ポッドキャスト用
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12044,6 +12564,7 @@
 
 # newdoc id = test-s535
 # sent_id = test-s535
+# parallel_id = jagsdluw/test535
 # text = 味付けは、あっさり目で、かなり調味料に気を使っているのかもしれません。
 1	味付け	味付け	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アジツケ,味付け,味付け,味付け,アジツケ,,,アジツケ,アジツケ,味付け
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12065,6 +12586,7 @@
 
 # newdoc id = test-s536
 # sent_id = test-s536
+# parallel_id = jagsdluw/test536
 # text = ブラジルだけが、モーターやエンジンなど各国の先端技術を組み合わせることで、数千メートルの環境変化に耐えられる独自技術を開発した。
 1	ブラジル	ブラジル	PROPN	名詞-固有名詞-地名-国	_	25	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ブラジル,ブラジル,ブラジル,ブラジル,ブラジル,,,ブラジル,ブラジル,ブラジル
 2	だけ	だけ	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダケ,だけ,だけ,だけ,ダケ,,,ダケ,ダケ,だけ
@@ -12096,6 +12618,7 @@
 
 # newdoc id = test-s537
 # sent_id = test-s537
+# parallel_id = jagsdluw/test537
 # text = こうした理由で,例えプラセボとしても,医療関係者がホメオパシーを治療に使用することは認められません。
 1	こう	こう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウ,こう,こう,こう,コー,,,コウ,コウ,こう
 2	し	する	VERB	動詞-一般-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,スル,する
@@ -12125,6 +12648,7 @@
 
 # newdoc id = test-s538
 # sent_id = test-s538
+# parallel_id = jagsdluw/test538
 # text = 新聞は,助産師が所属する団体名や療法名を報じていませんが,ホメオパシーを用いる団体と思われます。
 1	新聞	新聞	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンブン,新聞,新聞,新聞,シンブン,,,シンブン,シンブン,新聞
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12154,6 +12678,7 @@
 
 # newdoc id = test-s539
 # sent_id = test-s539
+# parallel_id = jagsdluw/test539
 # text = 支持者によって20世紀最大の神学者と称される新正統主義のカール・バルトは、未完の主著「教会教義学」全4巻における第3巻、邦訳全36分冊中11冊分を創造説に割いている。
 1	支持者	支持者	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シジ;シャ,支持;者,支持;者,支持;者,シジ;シャ,;,;,シジ;シャ,シジシャ,支持者
 2	によって	によって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;テ,に;因る;て,に;よっ;て,に;よる;て,ニ;ヨッ;テ,;;,;;,ニ;ヨル;テ,ニヨッテ,によって
@@ -12189,6 +12714,7 @@
 
 # newdoc id = test-s540
 # sent_id = test-s540
+# parallel_id = jagsdluw/test540
 # text = 日産は8月6日、軽自動車「オッティ」の一部仕様を変更し、同日より発売した。
 1	日産	日産	PROPN	名詞-固有名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッサン,日産,日産,日産,ニッサン,,,ニッサン,ニッサン,日産
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12209,6 +12735,7 @@
 
 # newdoc id = test-s541
 # sent_id = test-s541
+# parallel_id = jagsdluw/test541
 # text = 翼端に付けていた増槽は機体の重心が前に寄り過ぎるために使用されず、主翼中央下面に滑らかな形状で装着できるように再設計された。
 1	翼端	翼端	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨクタン,翼端,翼端,翼端,ヨクタン,,,ヨクタン,ヨクタン,翼端
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -12245,6 +12772,7 @@
 
 # newdoc id = test-s542
 # sent_id = test-s542
+# parallel_id = jagsdluw/test542
 # text = 若い頃は土司の小作人や軍の人夫をして過ごす。
 1	若い	若い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワカイ,若い,若い,若い,ワカイ,,,ワカイ,ワカイ,若い
 2	頃	頃	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コロ,頃,頃,頃,コロ,,,コロ,コロ,頃
@@ -12264,6 +12792,7 @@
 
 # newdoc id = test-s543
 # sent_id = test-s543
+# parallel_id = jagsdluw/test543
 # text = クールな性格で、自らを「いやな子」と称する。
 1	クール	クール	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クール,クール,クール,クール,クール,,,クール,クール,クール
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -12283,6 +12812,7 @@
 
 # newdoc id = test-s544
 # sent_id = test-s544
+# parallel_id = jagsdluw/test544
 # text = ヴァランゲル半島の北東部に位置する。
 1	ヴァランゲル半島	ヴァランゲル半島	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バランゲル;ハントウ,バランゲル;半島,ヴァランゲル;半島,ヴァランゲル;半島,バランゲル;ハントー,;,;,バランゲル;ハントウ,バランゲルハントウ,ヴァランゲル半島
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12293,6 +12823,7 @@
 
 # newdoc id = test-s545
 # sent_id = test-s545
+# parallel_id = jagsdluw/test545
 # text = 統一教会足立教会の週報でも今回のイベントが信者に対して告知されていることから,集会の参加者にも統一教会信者が動員されるものと思われます。
 1	統一教会足立教会	統一教会足立教会	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウイツ;キョウカイ;アダチ;キョウカイ,統一;教会;アダチ;教会,統一;教会;足立;教会,統一;教会;足立;教会,トーイツ;キョーカイ;アダチ;キョーカイ,;;;,;;;,トウイツ;キョウカイ;アダチ;キョウカイ,トウイツキョウカイアダチキョウカイ,統一教会足立教会
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12329,6 +12860,7 @@
 
 # newdoc id = test-s546
 # sent_id = test-s546
+# parallel_id = jagsdluw/test546
 # text = 第7回以降の大会で、サッカーのビクトリーゴールのように条件を満たした時点で勝ちとなる特別な勝利条件が加えられることが度々あった。
 1	第7回以降	第7回以降	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;ナナ;カイ;イコウ,第;七;回;以降,第;7;回;以降,第;7;回;以降,ダイ;ナナ;カイ;イコー,;;;,;;;,ダイ;ナナ;カイ;イコウ,ダイナナカイイコウ,第7回以降
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12365,6 +12897,7 @@
 
 # newdoc id = test-s547
 # sent_id = test-s547
+# parallel_id = jagsdluw/test547
 # text = 反乱軍の一人。
 1	反乱軍	反乱軍	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハンラン;グン,反乱;軍,反乱;軍,反乱;軍,ハンラン;グン,;,;,ハンラン;グン,ハンラングン,反乱軍
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12373,12 +12906,14 @@
 
 # newdoc id = test-s548
 # sent_id = test-s548
+# parallel_id = jagsdluw/test548
 # text = 建築評論家。
 1	建築評論家	建築評論家	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ケンチク;ヒョウロン;カ,建築;評論;家,建築;評論;家,建築;評論;家,ケンチク;ヒョーロン;カ,;;,;;,ケンチク;ヒョウロン;カ,ケンチクヒョウロンカ,建築評論家
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s549
 # sent_id = test-s549
+# parallel_id = jagsdluw/test549
 # text = しかし中松氏については警察関係者も苦笑い。
 1	しかし	然し	CCONJ	接続詞	_	7	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	中松氏	中松氏	PROPN	名詞-固有名詞-人名-姓	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナカマツ;シ,ナカマツ;氏,中松;氏,中松;氏,ナカマツ;シ,;,;,ナカマツ;シ,ナカマツシ,中松氏
@@ -12391,6 +12926,7 @@
 
 # newdoc id = test-s550
 # sent_id = test-s550
+# parallel_id = jagsdluw/test550
 # text = 終盤のツール・ド・おきなわでは鳩村と共に最後まで走りぬき、30位に入る健闘を見せる。
 1	終盤	終盤	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウバン,終盤,終盤,終盤,シューバン,,,シュウバン,シュウバン,終盤
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12415,6 +12951,7 @@
 
 # newdoc id = test-s551
 # sent_id = test-s551
+# parallel_id = jagsdluw/test551
 # text = 護符の由来どころか,そもそも杉山先生の気功能力の出自もナゾです。
 1	護符	護符	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴフ,護符,護符,護符,ゴフ,,,ゴフ,ゴフ,護符
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12435,6 +12972,7 @@
 
 # newdoc id = test-s552
 # sent_id = test-s552
+# parallel_id = jagsdluw/test552
 # text = 見学がてらの面接後も、電話で見学してみた印象を確認してくださって後で比較検討しやすいようにとアドバイスしてくださいました。
 1	見学がてら	見学がてら	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケンガク;ガテラ,見学;がてら,見学;がてら,見学;がてら,ケンガク;ガテラ,;,;,ケンガク;ガテラ,ケンガクガテラ,見学がてら
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12465,6 +13003,7 @@
 
 # newdoc id = test-s553
 # sent_id = test-s553
+# parallel_id = jagsdluw/test553
 # text = プラスミドを改変してベクターとして利用する。
 1	プラスミド	プラスミド	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=プラスミド,プラスミド,プラスミド,プラスミド,プラスミド,,,プラスミド,プラスミド,プラスミド
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -12477,6 +13016,7 @@
 
 # newdoc id = test-s554
 # sent_id = test-s554
+# parallel_id = jagsdluw/test554
 # text = 駐車場は狭いので混みあう時間帯は注意ですが、事前に電話をして到着時間を伝えておけば良いですね。
 1	駐車場	駐車場	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウシャ;ジョウ,駐車;場,駐車;場,駐車;場,チューシャ;ジョー,;,;,チュウシャ;ジョウ,チュウシャジョウ,駐車場
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12506,6 +13046,7 @@
 
 # newdoc id = test-s555
 # sent_id = test-s555
+# parallel_id = jagsdluw/test555
 # text = 散髪のやり方次第で頭脳は発達すると考えて、どの店の散髪がよいか理髪店を絶えず替えていた。
 1	散髪	散髪	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サンパツ,散髪,散髪,散髪,サンパツ,,,サンパツ,サンパツ,散髪
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12536,6 +13077,7 @@
 
 # newdoc id = test-s556
 # sent_id = test-s556
+# parallel_id = jagsdluw/test556
 # text = 見上げる程の大きさの弧形が地表に露出しているが、これですら全体の一部でしかなく、全体は地殻を貫通して星の核にまで達している。
 1	見上げる	見上げる	VERB	動詞-一般-下一段-ガ行	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミアゲル,見上げる,見上げる,見上げる,ミアゲル,,,ミアゲル,ミアゲル,見上げる
 2	程	ほど	PART	助詞-副助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ホド,ほど,程,程,ホド,,,ホド,ホド,ほど
@@ -12576,6 +13118,7 @@
 
 # newdoc id = test-s557
 # sent_id = test-s557
+# parallel_id = jagsdluw/test557
 # text = また、顕彰当時現役の選手も存在したが、いずれも既に全女を退団していた。
 1	また	又	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、

--- a/ja_gsdluw-ud-test.conllu
+++ b/ja_gsdluw-ud-test.conllu
@@ -1,6 +1,6 @@
 # newdoc id = test-s1
 # sent_id = test-s1
-# parallel_id = jagsdluw/test1
+# parallel_id = jagsd/test1
 # text = これに不快感を示す住民はいましたが,現在,表立って反対や抗議の声を挙げている住民はいないようです。
 1	これ	此れ	PRON	代名詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -36,7 +36,7 @@
 
 # newdoc id = test-s2
 # sent_id = test-s2
-# parallel_id = jagsdluw/test2
+# parallel_id = jagsd/test2
 # text = 幸福の科学側からは,特にどうしてほしいという要望はいただいていません。
 1	幸福の科学側	幸福の科学側	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ノ;カガク;ガワ,幸福;の;科学;側,幸福;の;科学;側,幸福;の;科学;側,コーフク;ノ;カガク;ガワ,;;;,;;;,コウフク;ノ;カガク;ガワ,コウフクノカガクガワ,幸福の科学側
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -56,7 +56,7 @@
 
 # newdoc id = test-s3
 # sent_id = test-s3
-# parallel_id = jagsdluw/test3
+# parallel_id = jagsd/test3
 # text = 星取り参加は当然とされ,不参加は白眼視される。
 1	星取り参加	星取り参加	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホシトリ;サンカ,星取り;参加,星取り;参加,星取り;参加,ホシトリ;サンカ,;,;,ホシトリ;サンカ,ホシトリサンカ,星取り参加
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -73,7 +73,7 @@
 
 # newdoc id = test-s4
 # sent_id = test-s4
-# parallel_id = jagsdluw/test4
+# parallel_id = jagsd/test4
 # text = 室長の対応には終始誠実さが感じられた。
 1	室長	室長	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シツチョウ,室長,室長,室長,シツチョー,,,シツチョウ,シツチョウ,室長
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -90,7 +90,7 @@
 
 # newdoc id = test-s5
 # sent_id = test-s5
-# parallel_id = jagsdluw/test5
+# parallel_id = jagsd/test5
 # text = 多くの女性が生理のことで悩んでいます。
 1	多く	多く	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオク,多く,多く,多く,オーク,,,オオク,オオク,多く
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -107,7 +107,7 @@
 
 # newdoc id = test-s6
 # sent_id = test-s6
-# parallel_id = jagsdluw/test6
+# parallel_id = jagsd/test6
 # text = 先生の理想は限りなく高い。
 1	先生	先生	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センセイ,先生,先生,先生,センセー,,,センセイ,センセイ,先生
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -119,7 +119,7 @@
 
 # newdoc id = test-s7
 # sent_id = test-s7
-# parallel_id = jagsdluw/test7
+# parallel_id = jagsd/test7
 # text = それは兎も角,私も明日の社説を楽しみにしております。
 1	それ	其れ	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -140,7 +140,7 @@
 
 # newdoc id = test-s8
 # sent_id = test-s8
-# parallel_id = jagsdluw/test8
+# parallel_id = jagsd/test8
 # text = そうだったらいいなあとは思いますが,日本学術会議の会長談話について“当会では,標記の件について,以下のように考えます。”
 1	そう	そう	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソウ,そう,そう,そう,ソー,,,ソウ,ソウ,そう
 2	だっ	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だっ,だ,ダッ,,,ダ,ダ,だ
@@ -178,7 +178,7 @@
 
 # newdoc id = test-s9
 # sent_id = test-s9
-# parallel_id = jagsdluw/test9
+# parallel_id = jagsd/test9
 # text = 教団にとっては存続が厳しくなると思う。
 1	教団	教団	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウダン,教団,教団,教団,キョーダン,,,キョウダン,キョウダン,教団
 2	にとって	にとって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;トル;テ,に;取る;て,に;とっ;て,に;とる;て,ニ;トッ;テ,;;,;;,ニ;トル;テ,ニトッテ,にとって
@@ -193,7 +193,7 @@
 
 # newdoc id = test-s10
 # sent_id = test-s10
-# parallel_id = jagsdluw/test10
+# parallel_id = jagsd/test10
 # text = しかし強制していなくても問題です
 1	しかし	然し	CCONJ	接続詞	_	7	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	強制し	強制する	VERB	動詞-一般-サ行変格	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウセイ;スル,強制;為る,強制;し,強制;する,キョーセー;シ,;,;,キョウセイ;スル,キョウセイスル,強制する
@@ -206,7 +206,7 @@
 
 # newdoc id = test-s11
 # sent_id = test-s11
-# parallel_id = jagsdluw/test11
+# parallel_id = jagsd/test11
 # text = 民族派のみなさんにとって陛下はいちばん大切な方ですから,その霊言について“あり得ない”という前提でお話をされる。
 1	民族派	民族派	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミンゾク;ハ,民族;派,民族;派,民族;派,ミンゾク;ハ,;,;,ミンゾク;ハ,ミンゾクハ,民族派
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -239,7 +239,7 @@
 
 # newdoc id = test-s12
 # sent_id = test-s12
-# parallel_id = jagsdluw/test12
+# parallel_id = jagsd/test12
 # text = 新しい産業構造を作らなければいけない。
 1	新しい	新しい	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アタラシイ,新しい,新しい,新しい,アタラシー,,,アタラシイ,アタラシイ,新しい
 2	産業構造	産業構造	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サンギョウ;コウゾウ,産業;構造,産業;構造,産業;構造,サンギョー;コーゾー,;,;,サンギョウ;コウゾウ,サンギョウコウゾウ,産業構造
@@ -253,7 +253,7 @@
 
 # newdoc id = test-s13
 # sent_id = test-s13
-# parallel_id = jagsdluw/test13
+# parallel_id = jagsd/test13
 # text = 心がないんだ。
 1	心	心	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココロ,心,心,心,ココロ,,,ココロ,ココロ,心
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -263,7 +263,7 @@
 
 # newdoc id = test-s14
 # sent_id = test-s14
-# parallel_id = jagsdluw/test14
+# parallel_id = jagsd/test14
 # text = そのモサは今何をしているか。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	モサ	モサ	PROPN	名詞-固有名詞-人名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モサ,モサ,モサ,モサ,モサ,,,モサ,モサ,モサ
@@ -278,7 +278,7 @@
 
 # newdoc id = test-s15
 # sent_id = test-s15
-# parallel_id = jagsdluw/test15
+# parallel_id = jagsd/test15
 # text = 本音としてはこの火に油を注ぎたいけれど。
 1	本音	本音	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンネ,本音,本音,本音,ホンネ,,,ホンネ,ホンネ,本音
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -295,7 +295,7 @@
 
 # newdoc id = test-s16
 # sent_id = test-s16
-# parallel_id = jagsdluw/test16
+# parallel_id = jagsd/test16
 # text = 25日も楽しみにされてください。
 1	25日	25日	NUM	名詞-数詞	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゴ;ニチ,二;五;日,2;5;日,2;5;日,ニ;ゴ;ニチ,;;,;;,ニ;ゴ;ニチ,ニゴニチ,25日
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -308,7 +308,7 @@
 
 # newdoc id = test-s17
 # sent_id = test-s17
-# parallel_id = jagsdluw/test17
+# parallel_id = jagsd/test17
 # text = なんだよなんだよぉ~,わが署に来たのなら教えてくれよぉ~。
 1	なん	何	PRON	代名詞	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナニ,何,なん,なん,ナン,,,ナン,ナニ,何
 2	だ	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダ,だ
@@ -333,7 +333,7 @@
 
 # newdoc id = test-s18
 # sent_id = test-s18
-# parallel_id = jagsdluw/test18
+# parallel_id = jagsd/test18
 # text = どの本もツッコミどころが山ほどあり,会場内が爆笑の連続でした。
 1	どの	何の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドノ,何の,どの,どの,ドノ,,,ドノ,ドノ,何の
 2	本	本	NOUN	名詞-普通名詞-一般	_	8	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホン,本,本,本,ホン,,,ホン,ホン,本
@@ -355,7 +355,7 @@
 
 # newdoc id = test-s19
 # sent_id = test-s19
-# parallel_id = jagsdluw/test19
+# parallel_id = jagsd/test19
 # text = 社会への恨みと,破滅させたいという恐ろしいほどの煩悩。
 1	社会	社会	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シャカイ,社会,社会,社会,シャカイ,,,シャカイ,シャカイ,社会
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -375,7 +375,7 @@
 
 # newdoc id = test-s20
 # sent_id = test-s20
-# parallel_id = jagsdluw/test20
+# parallel_id = jagsd/test20
 # text = とんでもない。
 1	とんでも	とんでも	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トンデモ,とんでも,とんでも,とんでも,トンデモ,,,トンデモ,トンデモ,とんでも
 2	ない	無い	ADJ	形容詞-一般-形容詞	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|PrevUDLemma=ない|SpaceAfter=No|UnidicInfo=ナイ,無い,ない,ない,ナイ,,,ナイ,ナイ,無い
@@ -383,7 +383,7 @@
 
 # newdoc id = test-s21
 # sent_id = test-s21
-# parallel_id = jagsdluw/test21
+# parallel_id = jagsd/test21
 # text = 抗議デモの継続を宣言した統一教会,日本でも韓国東亜日報の様に襲撃事件が起こる惧れはないのか?
 1	抗議デモ	抗議デモ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウギ;デモ,抗議;デモ,抗議;デモ,抗議;デモ,コーギ;デモ,;,;,コウギ;デモ,コウギデモ,抗議デモ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -412,7 +412,7 @@
 
 # newdoc id = test-s22
 # sent_id = test-s22
-# parallel_id = jagsdluw/test22
+# parallel_id = jagsd/test22
 # text = ついつい言葉だけで机上の空論をこねがちな自分は,ここは激しく自戒ですね...
 1	ついつい	ついつい	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツイツイ,ついつい,ついつい,ついつい,ツイツイ,,,ツイツイ,ツイツイ,ついつい
 2	言葉	言葉	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コトバ,言葉,言葉,言葉,コトバ,,,コトバ,コトバ,言葉
@@ -439,7 +439,7 @@
 
 # newdoc id = test-s23
 # sent_id = test-s23
-# parallel_id = jagsdluw/test23
+# parallel_id = jagsd/test23
 # text = 当選して市長になってもなお,摂理との関係を明らかにしようとしないのは,とても残念。
 1	当選し	当選する	VERB	動詞-一般-サ行変格	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウセン;スル,当選;為る,当選;し,当選;する,トーセン;シ,;,;,トウセン;スル,トウセンスル,当選する
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -470,7 +470,7 @@
 
 # newdoc id = test-s24
 # sent_id = test-s24
-# parallel_id = jagsdluw/test24
+# parallel_id = jagsd/test24
 # text = この夏が実は最大の山場になります。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	夏	夏	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナツ,夏,夏,夏,ナツ,,,ナツ,ナツ,夏
@@ -486,7 +486,7 @@
 
 # newdoc id = test-s25
 # sent_id = test-s25
-# parallel_id = jagsdluw/test25
+# parallel_id = jagsd/test25
 # text = 政府がもっと宗教法人の定義を厳しくし,こういう団体は排除すべき。
 1	政府	政府	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイフ,政府,政府,政府,セーフ,,,セイフ,セイフ,政府
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -508,7 +508,7 @@
 
 # newdoc id = test-s26
 # sent_id = test-s26
-# parallel_id = jagsdluw/test26
+# parallel_id = jagsd/test26
 # text = まあ,それが親心だ。
 1	まあ	まあ	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マア,まあ,まあ,まあ,マー,,,マア,マア,まあ
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -520,7 +520,7 @@
 
 # newdoc id = test-s27
 # sent_id = test-s27
-# parallel_id = jagsdluw/test27
+# parallel_id = jagsd/test27
 # text = 大川隆法氏を支持する人が挙げた主な理由は,以下のとおり。
 1	大川隆法氏	大川隆法氏	PROPN	名詞-固有名詞-人名-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオカワ;リュウホウ;シ,オオカワ;リュウホウ;氏,大川;隆法;氏,大川;隆法;氏,オーカワ;リューホー;シ,;;,;;,オオカワ;リュウホウ;シ,オオカワリュウホウシ,大川隆法氏
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -540,7 +540,7 @@
 
 # newdoc id = test-s28
 # sent_id = test-s28
-# parallel_id = jagsdluw/test28
+# parallel_id = jagsd/test28
 # text = すごくそういうところを引っかかる感じですか?
 1	すごく	凄い	ADJ	形容詞-一般-形容詞	_	6	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごく,すごい,スゴク,,,スゴイ,スゴイ,凄い
 2	そう	そう	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソウ,そう,そう,そう,ソー,,,ソウ,ソウ,そう
@@ -555,7 +555,7 @@
 
 # newdoc id = test-s29
 # sent_id = test-s29
-# parallel_id = jagsdluw/test29
+# parallel_id = jagsd/test29
 # text = この記事が本当ならいくつかの問題がはっきり見えてきます。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	記事	記事	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キジ,記事,記事,記事,キジ,,,キジ,キジ,記事
@@ -575,7 +575,7 @@
 
 # newdoc id = test-s30
 # sent_id = test-s30
-# parallel_id = jagsdluw/test30
+# parallel_id = jagsd/test30
 # text = 今,何もそれは達成されていない。
 1	今	今	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イマ,今,今,今,イマ,,,イマ,イマ,今
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -591,14 +591,14 @@
 
 # newdoc id = test-s31
 # sent_id = test-s31
-# parallel_id = jagsdluw/test31
+# parallel_id = jagsd/test31
 # text = 身勝手すぎる。
 1	身勝手すぎる	身勝手過ぎる	VERB	動詞-一般-上一段-ガ行	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ミガッテ;スギル,身勝手;過ぎる,身勝手;すぎる,身勝手;すぎる,ミガッテ;スギル,;,;,ミガッテ;スギル,ミガッテスギル,身勝手過ぎる
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s32
 # sent_id = test-s32
-# parallel_id = jagsdluw/test32
+# parallel_id = jagsd/test32
 # text = 大人と子供では体質が違うので,“大人に良いものが子供にもいい”とは必ずしもいえません。
 1	大人	大人	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オトナ,大人,大人,大人,オトナ,,,オトナ,オトナ,大人
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -631,7 +631,7 @@
 
 # newdoc id = test-s33
 # sent_id = test-s33
-# parallel_id = jagsdluw/test33
+# parallel_id = jagsd/test33
 # text = 愛人がいたら怒るでしょ。
 1	愛人	愛人	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アイジン,愛人,愛人,愛人,アイジン,,,アイジン,アイジン,愛人
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -643,7 +643,7 @@
 
 # newdoc id = test-s34
 # sent_id = test-s34
-# parallel_id = jagsdluw/test34
+# parallel_id = jagsd/test34
 # text = キリスト教世界でも,たとえばアメリカでは大統領は宣誓式で聖書に手を置くし,共和党の選挙運動ではキリスト教会が力を持っている。
 1	キリスト教世界	キリスト教世界	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キリスト;キョウ;セカイ,キリスト;教;世界,キリスト;教;世界,キリスト;教;世界,キリスト;キョー;セカイ,;;,;;,キリスト;キョウ;セカイ,キリストキョウセカイ,キリスト教世界
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -679,7 +679,7 @@
 
 # newdoc id = test-s35
 # sent_id = test-s35
-# parallel_id = jagsdluw/test35
+# parallel_id = jagsd/test35
 # text = “カンボジア三百万人大量虐殺をほめたたえ,カンパ集める”
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	カンボジア三百万人大量虐殺	カンボジア三百万人大量虐殺	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンボジア;サンビャク;マン;ニン;タイリョウ;ギャクサツ,カンボジア;三百;万;人;大量;虐殺,カンボジア;三百;万;人;大量;虐殺,カンボジア;三百;万;人;大量;虐殺,カンボジア;サンビャク;マン;ニン;タイリョー;ギャクサツ,;;;;;,;;;;;,カンボジア;サンビャク;マン;ニン;タイリョウ;ギャクサツ,カンボジアサンビャクマンニンタイリョウギャクサツ,カンボジア三百万人大量虐殺
@@ -692,7 +692,7 @@
 
 # newdoc id = test-s36
 # sent_id = test-s36
-# parallel_id = jagsdluw/test36
+# parallel_id = jagsd/test36
 # text = 奇しくも,今年1月付けの最新号です。
 1	奇しくも	奇しくも	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クシクモ,奇しくも,奇しくも,奇しくも,クシクモ,,,クシクモ,クシクモ,奇しくも
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -704,7 +704,7 @@
 
 # newdoc id = test-s37
 # sent_id = test-s37
-# parallel_id = jagsdluw/test37
+# parallel_id = jagsd/test37
 # text = 一番の方法は煎じることです。
 1	一番	一番	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチバン,一番,一番,一番,イチバン,,,イチバン,イチバン,一番
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -717,7 +717,7 @@
 
 # newdoc id = test-s38
 # sent_id = test-s38
-# parallel_id = jagsdluw/test38
+# parallel_id = jagsd/test38
 # text = それでも,くり返しくり返し,人民に侵略反対を訴え続けて十年がたった。
 1	それでも	其れでも	CCONJ	接続詞	_	10	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソレ;デ;モ,其れ;で;も,それ;で;も,それ;で;も,ソレ;デ;モ,;;,;;,ソレ;デ;モ,ソレデモ,其れでも
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -738,7 +738,7 @@
 
 # newdoc id = test-s39
 # sent_id = test-s39
-# parallel_id = jagsdluw/test39
+# parallel_id = jagsd/test39
 # text = 説教というか,アジテーションが始まります。
 1	説教	説教	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セッキョウ,説教,説教,説教,セッキョー,,,セッキョウ,セッキョウ,説教
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -753,7 +753,7 @@
 
 # newdoc id = test-s40
 # sent_id = test-s40
-# parallel_id = jagsdluw/test40
+# parallel_id = jagsd/test40
 # text = 参考文献リストを見る限りでは,本を書くにあたって読んだのかはわからないが,広範囲に亘って本を読んでいて勉強していることはわかった。
 1	参考文献リスト	参考文献リスト	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サンコウ;ブンケン;リスト,参考;文献;リスト,参考;文献;リスト,参考;文献;リスト,サンコー;ブンケン;リスト,;;,;;,サンコウ;ブンケン;リスト,サンコウブンケンリスト,参考文献リスト
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -794,7 +794,7 @@
 
 # newdoc id = test-s41
 # sent_id = test-s41
-# parallel_id = jagsdluw/test41
+# parallel_id = jagsd/test41
 # text = 文殊菩薩私が幸福になっていない以上,世界伝道などはありえない!
 1	文殊菩薩	文殊菩薩	PROPN	名詞-固有名詞-人名-一般	_	14	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モンジュ;ボサツ,文殊;菩薩,文殊;菩薩,文殊;菩薩,モンジュ;ボサツ,;,;,モンジュ;ボサツ,モンジュボサツ,文殊菩薩
 2	私	私	PRON	代名詞	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
@@ -815,7 +815,7 @@
 
 # newdoc id = test-s42
 # sent_id = test-s42
-# parallel_id = jagsdluw/test42
+# parallel_id = jagsd/test42
 # text = しばらくの完全休養とリハビリが必要とのことでした。
 1	しばらく	暫く	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シバラク,暫く,しばらく,しばらく,シバラク,,,シバラク,シバラク,暫く
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -833,7 +833,7 @@
 
 # newdoc id = test-s43
 # sent_id = test-s43
-# parallel_id = jagsdluw/test43
+# parallel_id = jagsd/test43
 # text = いまのところ,訴訟沙汰になったとか,米・中・朝の軍が幸福の科学を襲撃したといった話は聞きません。
 1	いま	今	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イマ,今,いま,いま,イマ,,,イマ,イマ,今
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -864,7 +864,7 @@
 
 # newdoc id = test-s44
 # sent_id = test-s44
-# parallel_id = jagsdluw/test44
+# parallel_id = jagsd/test44
 # text = バームクーヘンでも周りにお砂糖がたっぷり付いているもの。
 1	バームクーヘン	バームクーヘン	NOUN	名詞-普通名詞-一般	_	9	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バウムクーヘン,バウムクーヘン,バームクーヘン,バームクーヘン,バームクーヘン,,,バームクーヘン,バームクーヘン,バームクーヘン
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -881,7 +881,7 @@
 
 # newdoc id = test-s45
 # sent_id = test-s45
-# parallel_id = jagsdluw/test45
+# parallel_id = jagsd/test45
 # text = しかし,心配には及ばないようです。
 1	しかし	然し	CCONJ	接続詞	_	6	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -896,7 +896,7 @@
 
 # newdoc id = test-s46
 # sent_id = test-s46
-# parallel_id = jagsdluw/test46
+# parallel_id = jagsd/test46
 # text = いったい,“次世紀ファーム研究所”とは何なのか。
 1	いったい	一体	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッタイ,一体,いったい,いったい,イッタイ,,,イッタイ,イッタイ,一体
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -913,7 +913,7 @@
 
 # newdoc id = test-s47
 # sent_id = test-s47
-# parallel_id = jagsdluw/test47
+# parallel_id = jagsd/test47
 # text = その後,一部の会員に渡すための賞状にサインしてくださいと頼まれ,サインをいたしました。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-一般	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -942,7 +942,7 @@
 
 # newdoc id = test-s48
 # sent_id = test-s48
-# parallel_id = jagsdluw/test48
+# parallel_id = jagsd/test48
 # text = 事前に海老澤代表からは“40歳くらいとお若いけれど,とても家系のことに詳しい先生”と聞かされていた。
 1	事前	事前	NOUN	名詞-普通名詞-一般	_	22	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジゼン,事前,事前,事前,ジゼン,,,ジゼン,ジゼン,事前
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -973,7 +973,7 @@
 
 # newdoc id = test-s49
 # sent_id = test-s49
-# parallel_id = jagsdluw/test49
+# parallel_id = jagsd/test49
 # text = “1000万円当たりますように”というのもありました。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	1000万円	1000万円	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッセン;マン;エン,一千;万;円,1000;万;円,1000;万;円,イッセン;マン;エン,;;,;;,イッセン;マン;エン,イッセンマンエン,1000万円
@@ -992,7 +992,7 @@
 
 # newdoc id = test-s50
 # sent_id = test-s50
-# parallel_id = jagsdluw/test50
+# parallel_id = jagsd/test50
 # text = いつもどおりなので,たぶん何も問題ありません。
 1	いつもどおり	何時も通り	NOUN	名詞-普通名詞-一般	_	9	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イツ;モ;トオリ,何時;も;通り,いつ;も;どおり,いつ;も;どおり,イツ;モ;ドーリ,;;,;;,イツ;モ;トオリ,イツモドオリ,何時も通り
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -1009,7 +1009,7 @@
 
 # newdoc id = test-s51
 # sent_id = test-s51
-# parallel_id = jagsdluw/test51
+# parallel_id = jagsd/test51
 # text = 震災に乗じて末端信者から献金を集めようとの意図が判る。
 1	震災	震災	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンサイ,震災,震災,震災,シンサイ,,,シンサイ,シンサイ,震災
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1029,7 +1029,7 @@
 
 # newdoc id = test-s52
 # sent_id = test-s52
-# parallel_id = jagsdluw/test52
+# parallel_id = jagsd/test52
 # text = Ad Plannerもサイトの月間利用者の推定データだと思うので,Twitterアカウント数でも,Twitter利用者数でもないだろう。
 1	Ad Planner	Ad Planner	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アド;プランナー,アド;プランナー,Ad;Planner,Ad;Planner,アド;プランナー,;,;,アド;プランナー,アドプランナー,AdPlanner
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -1056,7 +1056,7 @@
 
 # newdoc id = test-s53
 # sent_id = test-s53
-# parallel_id = jagsdluw/test53
+# parallel_id = jagsd/test53
 # text = “天聖稲荷大権現神社”を出て,“箱根大天狗山神社”へ向かう。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	天聖稲荷大権現神社	天聖稲荷大権現神社	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンセイ;イナリ;ダイ;ゴンゲン;ジンジャ,天聖;稲荷;大;権現;神社,天聖;稲荷;大;権現;神社,天聖;稲荷;大;権現;神社,テンセー;イナリ;ダイ;ゴンゲン;ジンジャ,;;;;,;;;;,テンセイ;イナリ;ダイ;ゴンゲン;ジンジャ,テンセイイナリダイゴンゲンジンジャ,天聖稲荷大権現神社
@@ -1074,7 +1074,7 @@
 
 # newdoc id = test-s54
 # sent_id = test-s54
-# parallel_id = jagsdluw/test54
+# parallel_id = jagsd/test54
 # text = みんな自分の立場から主張しています。
 1	みんな	皆	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミナ,皆,みんな,みんな,ミンナ,,,ミンナ,ミナ,皆
 2	自分	自分	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
@@ -1088,7 +1088,7 @@
 
 # newdoc id = test-s55
 # sent_id = test-s55
-# parallel_id = jagsdluw/test55
+# parallel_id = jagsd/test55
 # text = “鶴”は統一教会教祖・文鮮明の妻,韓鶴子が由来か。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	鶴	鶴	NOUN	名詞-普通名詞-一般	_	11	nsubj:outer	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツル,鶴,鶴,鶴,ツル,,,ツル,ツル,鶴
@@ -1106,7 +1106,7 @@
 
 # newdoc id = test-s56
 # sent_id = test-s56
-# parallel_id = jagsdluw/test56
+# parallel_id = jagsd/test56
 # text = “心筋梗塞になったが神様に命を救っていただいた”
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	心筋梗塞	心筋梗塞	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンキン;コウソク,心筋;梗塞,心筋;梗塞,心筋;梗塞,シンキン;コーソク,;,;,シンキン;コウソク,シンキンコウソク,心筋梗塞
@@ -1125,7 +1125,7 @@
 
 # newdoc id = test-s57
 # sent_id = test-s57
-# parallel_id = jagsdluw/test57
+# parallel_id = jagsd/test57
 # text = 広告審査部への取り次ぎは読者センターの判断に委ねるとのこと。
 1	広告審査部	広告審査部	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウコク;シンサ;ブ,広告;審査;部,広告;審査;部,広告;審査;部,コーコク;シンサ;ブ,;;,;;,コウコク;シンサ;ブ,コウコクシンサブ,広告審査部
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -1144,7 +1144,7 @@
 
 # newdoc id = test-s58
 # sent_id = test-s58
-# parallel_id = jagsdluw/test58
+# parallel_id = jagsd/test58
 # text = ビデオセンタースタッフも参加。
 1	ビデオセンタースタッフ	ビデオセンタースタッフ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビデオ;センター;スタッフ,ビデオ;センター;スタッフ,ビデオ;センター;スタッフ,ビデオ;センター;スタッフ,ビデオ;センター;スタッフ,;;,;;,ビデオ;センター;スタッフ,ビデオセンタースタッフ,ビデオセンタースタッフ
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -1153,7 +1153,7 @@
 
 # newdoc id = test-s59
 # sent_id = test-s59
-# parallel_id = jagsdluw/test59
+# parallel_id = jagsd/test59
 # text = 空気を読もうとする姿勢が見られ,不思議な気持ちになりました。
 1	空気	空気	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クウキ,空気,空気,空気,クーキ,,,クウキ,クウキ,空気
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -1176,7 +1176,7 @@
 
 # newdoc id = test-s60
 # sent_id = test-s60
-# parallel_id = jagsdluw/test60
+# parallel_id = jagsd/test60
 # text = だが,生真面目な彼は少し困った顔をしてこう言った。
 1	だが	だが	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;ガ,だ;が,だ;が,だ;が,ダ;ガ,;,;,ダ;ガ,ダガ,だが
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1198,7 +1198,7 @@
 
 # newdoc id = test-s61
 # sent_id = test-s61
-# parallel_id = jagsdluw/test61
+# parallel_id = jagsd/test61
 # text = どうぞ取材に来てください。
 1	どうぞ	どうぞ	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウゾ,どうぞ,どうぞ,どうぞ,ドーゾ,,,ドウゾ,ドウゾ,どうぞ
 2	取材	取材	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュザイ,取材,取材,取材,シュザイ,,,シュザイ,シュザイ,取材
@@ -1209,7 +1209,7 @@
 
 # newdoc id = test-s62
 # sent_id = test-s62
-# parallel_id = jagsdluw/test62
+# parallel_id = jagsd/test62
 # text = でも党が結成されたときは,けっこう報道されていましたよ。
 1	でも	でも	CCONJ	接続詞	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;モ,で;も,で;も,で;も,デ;モ,;,;,デ;モ,デモ,でも
 2	党	党	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウ,党,党,党,トー,,,トウ,トウ,党
@@ -1231,7 +1231,7 @@
 
 # newdoc id = test-s63
 # sent_id = test-s63
-# parallel_id = jagsdluw/test63
+# parallel_id = jagsd/test63
 # text = 陳述書に“現在も通っている”と書いてあるが?
 1	陳述書	陳述書	NOUN	名詞-普通名詞-一般	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チンジュツ;ショ,陳述;書,陳述;書,陳述;書,チンジュツ;ショ,;,;,チンジュツ;ショ,チンジュツショ,陳述書
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1249,7 +1249,7 @@
 
 # newdoc id = test-s64
 # sent_id = test-s64
-# parallel_id = jagsdluw/test64
+# parallel_id = jagsd/test64
 # text = ファンの皆様には混乱を招いてしまい,誠に申し訳ございません。
 1	ファン	ファン	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ファン,ファン,ファン,ファン,ファン,,,ファン,ファン,ファン
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1271,7 +1271,7 @@
 
 # newdoc id = test-s65
 # sent_id = test-s65
-# parallel_id = jagsdluw/test65
+# parallel_id = jagsd/test65
 # text = 教祖の浮気性,あくなき欲望。
 1	教祖	教祖	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウソ,教祖,教祖,教祖,キョーソ,,,キョウソ,キョウソ,教祖
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1284,7 +1284,7 @@
 
 # newdoc id = test-s66
 # sent_id = test-s66
-# parallel_id = jagsdluw/test66
+# parallel_id = jagsd/test66
 # text = さっぱり意味がわかりません。
 1	さっぱり	さっぱり	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サッパリ,さっぱり,さっぱり,さっぱり,サッパリ,,,サッパリ,サッパリ,さっぱり
 2	意味	意味	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イミ,意味,意味,意味,イミ,,,イミ,イミ,意味
@@ -1296,7 +1296,7 @@
 
 # newdoc id = test-s67
 # sent_id = test-s67
-# parallel_id = jagsdluw/test67
+# parallel_id = jagsd/test67
 # text = 心よりお悔やみ申し上げます。
 1	心	心	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ココロ,心,心,心,ココロ,,,ココロ,ココロ,心
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -1306,7 +1306,7 @@
 
 # newdoc id = test-s68
 # sent_id = test-s68
-# parallel_id = jagsdluw/test68
+# parallel_id = jagsd/test68
 # text = そんな俗世の快楽を楽しむ彼も,インタビューには“洗礼を受けるつもり”と答えている。
 1	そんな	そんな	PRON	連体詞	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソンナ,そんな,そんな,そんな,ソンナ,,,ソンナ,ソンナ,そんな
 2	俗世	俗世	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゾクセ,俗世,俗世,俗世,ゾクセ,,,ゾクセ,ゾクセ,俗世
@@ -1333,7 +1333,7 @@
 
 # newdoc id = test-s69
 # sent_id = test-s69
-# parallel_id = jagsdluw/test69
+# parallel_id = jagsd/test69
 # text = 記者はその勝手な言い分に対し,“暑い中,わざわざ来てくれた警官に失礼だろう!”
 1	記者	記者	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キシャ,記者,記者,記者,キシャ,,,キシャ,キシャ,記者
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1360,7 +1360,7 @@
 
 # newdoc id = test-s70
 # sent_id = test-s70
-# parallel_id = jagsdluw/test70
+# parallel_id = jagsd/test70
 # text = というか,返す刀で互いを批判し合っています。
 1	と	と	ADP	助詞-格助詞	_	2	case	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
 2	いう	言う	VERB	動詞-一般-五段-ワア行	_	10	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イウ,言う,いう,いう,イウ,,,イウ,イウ,言う
@@ -1378,7 +1378,7 @@
 
 # newdoc id = test-s71
 # sent_id = test-s71
-# parallel_id = jagsdluw/test71
+# parallel_id = jagsd/test71
 # text = みな,事実に基づいて恐怖と憎悪と嘲りを込めてぼくをカルトくんと呼んでくれています。
 1	みな	皆	ADV	副詞	_	19	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミナ,皆,みな,みな,ミナ,,,ミナ,ミナ,皆
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1406,7 +1406,7 @@
 
 # newdoc id = test-s72
 # sent_id = test-s72
-# parallel_id = jagsdluw/test72
+# parallel_id = jagsd/test72
 # text = そうだろ?
 1	そう	そう	ADV	副詞	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ソウ,そう,そう,そう,ソー,,,ソウ,ソウ,そう
 2	だろ	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だろ,だ,ダロ,,,ダ,ダ,だ
@@ -1414,7 +1414,7 @@
 
 # newdoc id = test-s73
 # sent_id = test-s73
-# parallel_id = jagsdluw/test73
+# parallel_id = jagsd/test73
 # text = すごいすごい。
 1	すごい	凄い	ADJ	形容詞-一般-形容詞	_	2	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごい,すごい,スゴイ,,,スゴイ,スゴイ,凄い
 2	すごい	凄い	ADJ	形容詞-一般-形容詞	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごい,すごい,スゴイ,,,スゴイ,スゴイ,凄い
@@ -1422,7 +1422,7 @@
 
 # newdoc id = test-s74
 # sent_id = test-s74
-# parallel_id = jagsdluw/test74
+# parallel_id = jagsd/test74
 # text = もちろん,まじめにやっている宗教法人もあるとは思いますが,やりたい放題やろうと思えばできてしまう構造は変える必要があるように思います。
 1	もちろん	勿論	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モチロン,勿論,もちろん,もちろん,モチロン,,,モチロン,モチロン,勿論
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1462,7 +1462,7 @@
 
 # newdoc id = test-s75
 # sent_id = test-s75
-# parallel_id = jagsdluw/test75
+# parallel_id = jagsd/test75
 # text = きっと,地上天国の中にいるのでしょう。
 1	きっと	急度	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キット,急度,きっと,きっと,キット,,,キット,キット,急度
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1476,7 +1476,7 @@
 
 # newdoc id = test-s76
 # sent_id = test-s76
-# parallel_id = jagsdluw/test76
+# parallel_id = jagsd/test76
 # text = 過去に自らが主催した飯田氏の講演の映像もYou Tubeから削除しました。
 1	過去	過去	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カコ,過去,過去,過去,カコ,,,カコ,カコ,過去
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1499,7 +1499,7 @@
 
 # newdoc id = test-s77
 # sent_id = test-s77
-# parallel_id = jagsdluw/test77
+# parallel_id = jagsd/test77
 # text = もう一つびっくりしたことと言えば,公立学校の中には保育所が併設されているところがあるということです。
 1	もう	もう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モウ,もう,もう,もう,モー,,,モウ,モウ,もう
 2	一つ	一つ	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒト;ツ,一;つ,一;つ,一;つ,ヒト;ツ,;,;,ヒト;ツ,ヒトツ,一つ
@@ -1530,7 +1530,7 @@
 
 # newdoc id = test-s78
 # sent_id = test-s78
-# parallel_id = jagsdluw/test78
+# parallel_id = jagsd/test78
 # text = おかしな販売をしているといっても,それはあくまでも刑事事件の話であって,公安部が出てくる筋ではありません。
 1	おかしな	可笑しな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オカシナ,可笑しな,おかしな,おかしな,オカシナ,,,オカシナ,オカシナ,可笑しな
 2	販売	販売	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハンバイ,販売,販売,販売,ハンバイ,,,ハンバイ,ハンバイ,販売
@@ -1559,7 +1559,7 @@
 
 # newdoc id = test-s79
 # sent_id = test-s79
-# parallel_id = jagsdluw/test79
+# parallel_id = jagsd/test79
 # text = 地方に住む知人の僧侶によると,こんな話もありました。
 1	地方	地方	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チホウ,地方,地方,地方,チホー,,,チホウ,チホウ,地方
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1579,7 +1579,7 @@
 
 # newdoc id = test-s80
 # sent_id = test-s80
-# parallel_id = jagsdluw/test80
+# parallel_id = jagsd/test80
 # text = だからまあ,もう,“殺ってくれ”とは言っておいたから。
 1	だから	だから	CCONJ	接続詞	_	12	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;カラ,だ;から,だ;から,だ;から,ダ;カラ,;,;,ダ;カラ,ダカラ,だから
 2	まあ	まあ	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マア,まあ,まあ,まあ,マー,,,マア,マア,まあ
@@ -1600,7 +1600,7 @@
 
 # newdoc id = test-s81
 # sent_id = test-s81
-# parallel_id = jagsdluw/test81
+# parallel_id = jagsd/test81
 # text = 右奥に見える重機が,我々に何かを物語っている気がしないでもありません。
 1	右奥	右奥	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミギオク,右奥,右奥,右奥,ミギオク,,,ミギオク,ミギオク,右奥
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1628,7 +1628,7 @@
 
 # newdoc id = test-s82
 # sent_id = test-s82
-# parallel_id = jagsdluw/test82
+# parallel_id = jagsd/test82
 # text = とても賢い生徒さんです。
 1	とても	迚も	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トテモ,迚も,とても,とても,トテモ,,,トテモ,トテモ,迚も
 2	賢い	賢い	ADJ	形容詞-一般-形容詞	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カシコイ,賢い,賢い,賢い,カシコイ,,,カシコイ,カシコイ,賢い
@@ -1638,7 +1638,7 @@
 
 # newdoc id = test-s83
 # sent_id = test-s83
-# parallel_id = jagsdluw/test83
+# parallel_id = jagsd/test83
 # text = たまたま,お互いに潜入取材の最中だった。
 1	たまたま	偶々	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タマタマ,偶々,たまたま,たまたま,タマタマ,,,タマタマ,タマタマ,偶々
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1653,7 +1653,7 @@
 
 # newdoc id = test-s84
 # sent_id = test-s84
-# parallel_id = jagsdluw/test84
+# parallel_id = jagsd/test84
 # text = ホメオパシーのレメディは毒にも薬にもならない“ただの水”と砂糖玉なので,司法解剖によってわかる類の因果関係なんてあるはずもありません。
 1	ホメオパシー	ホメオパシー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホメオパチー,ホメオパチー,ホメオパシー,ホメオパシー,ホメオパシー,,,ホメオパシー,ホメオパシー,ホメオパシー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1694,7 +1694,7 @@
 
 # newdoc id = test-s85
 # sent_id = test-s85
-# parallel_id = jagsdluw/test85
+# parallel_id = jagsd/test85
 # text = まさか松田氏は,男性が倒れる前から消防に通報していたとでもいうつもりだったのでしょうか。
 1	まさか	まさか	ADV	副詞	_	18	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マサカ,まさか,まさか,まさか,マサカ,,,マサカ,マサカ,まさか
 2	松田氏	松田氏	PROPN	名詞-固有名詞-人名-姓	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マツダ;シ,マツダ;氏,松田;氏,松田;氏,マツダ;シ,;,;,マツダ;シ,マツダシ,松田氏
@@ -1723,7 +1723,7 @@
 
 # newdoc id = test-s86
 # sent_id = test-s86
-# parallel_id = jagsdluw/test86
+# parallel_id = jagsd/test86
 # text = 是非書けるようになってみたい。
 1	是非	是非	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼヒ,是非,是非,是非,ゼヒ,,,ゼヒ,ゼヒ,是非
 2	書ける	書ける	VERB	動詞-一般-下一段-カ行	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カク,書く,書ける,書ける,カケル,,,カケル,カケル,書ける
@@ -1736,7 +1736,7 @@
 
 # newdoc id = test-s87
 # sent_id = test-s87
-# parallel_id = jagsdluw/test87
+# parallel_id = jagsd/test87
 # text = どう見ても幸福の科学出版の広告です。
 1	どう	どう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ,どう,どう,どう,ドー,,,ドウ,ドウ,どう
 2	見	見る	VERB	動詞-一般-上一段-マ行	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=みる|SpaceAfter=No|UnidicInfo=ミル,見る,見,見る,ミ,,,ミル,ミル,見る
@@ -1750,7 +1750,7 @@
 
 # newdoc id = test-s88
 # sent_id = test-s88
-# parallel_id = jagsdluw/test88
+# parallel_id = jagsd/test88
 # text = おおつた氏は数年前に勧誘され足立教会の通教組織である【びぎん】に所属,前線での違法な勧誘や霊感商法には関わっていなかったらしい。
 1	おおつた氏	おおつた氏	PROPN	名詞-固有名詞-人名-姓	_	27	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオツタ;シ,オオツタ;氏,おおつた;氏,おおつた;氏,オーツタ;シ,;,;,オオツタ;シ,オオツタシ,おおつた氏
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1787,7 +1787,7 @@
 
 # newdoc id = test-s89
 # sent_id = test-s89
-# parallel_id = jagsdluw/test89
+# parallel_id = jagsd/test89
 # text = 昔,阪神淡路大震災の時は,駅から重いリックを背負って,片道3時間歩いて仮設トイレ等の設置のボランティアに行きましたが,被災地の大変さは,想像以上でした。
 1	昔	昔	ADV	副詞	_	26	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ムカシ,昔,昔,昔,ムカシ,,,ムカシ,ムカシ,昔
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1831,7 +1831,7 @@
 
 # newdoc id = test-s90
 # sent_id = test-s90
-# parallel_id = jagsdluw/test90
+# parallel_id = jagsd/test90
 # text = かなりの長文になりますが,どうかご了解をお願いします。
 1	かなり	可成	ADJ	形状詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カナリ,可成,かなり,かなり,カナリ,,,カナリ,カナリ,可成
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1851,7 +1851,7 @@
 
 # newdoc id = test-s91
 # sent_id = test-s91
-# parallel_id = jagsdluw/test91
+# parallel_id = jagsd/test91
 # text = 政党と柴犬を同列に扱うというのも,なかなかです。
 1	政党	政党	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイトウ,政党,政党,政党,セートー,,,セイトウ,セイトウ,政党
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -1870,7 +1870,7 @@
 
 # newdoc id = test-s92
 # sent_id = test-s92
-# parallel_id = jagsdluw/test92
+# parallel_id = jagsd/test92
 # text = ですから,もろもろ客観的解説やツッコミも入ります。
 1	ですから	ですから	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デス;カラ,です;から,です;から,です;から,デス;カラ,;,;,デス;カラ,デスカラ,ですから
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1885,7 +1885,7 @@
 
 # newdoc id = test-s93
 # sent_id = test-s93
-# parallel_id = jagsdluw/test93
+# parallel_id = jagsd/test93
 # text = その後一行は,池袋駅に移動。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-一般	_	8	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -1899,7 +1899,7 @@
 
 # newdoc id = test-s94
 # sent_id = test-s94
-# parallel_id = jagsdluw/test94
+# parallel_id = jagsd/test94
 # text = 学校法人幸福の科学学園が2013年に関西校を開校するため土地を購入した滋賀県大津市内で,学園開校に反対する声が地元住民から挙がっています。
 1	学校法人幸福の科学学園	学校法人幸福の科学学園	PROPN	名詞-固有名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガッコウ;ホウジン;コウフク;ノ;カガク;ガクエン,学校;法人;幸福;の;科学;学園,学校;法人;幸福;の;科学;学園,学校;法人;幸福;の;科学;学園,ガッコー;ホージン;コーフク;ノ;カガク;ガクエン,;;;;;,;;;;;,ガッコウ;ホウジン;コウフク;ノ;カガク;ガクエン,ガッコウホウジンコウフクノカガクガクエン,学校法人幸福の科学学園
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -1931,7 +1931,7 @@
 
 # newdoc id = test-s95
 # sent_id = test-s95
-# parallel_id = jagsdluw/test95
+# parallel_id = jagsd/test95
 # text = では,同じくメディアとしての品性のかけらもない“やや日刊カルト新聞”が,品性のかけらもない宗教者たちの過去のエロ事件を調べてみました。
 1	では	では	CCONJ	接続詞	_	28	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デ;ハ,で;は,で;は,で;は,デ;ワ,;,;,デ;ハ,デハ,では
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -1968,7 +1968,7 @@
 
 # newdoc id = test-s96
 # sent_id = test-s96
-# parallel_id = jagsdluw/test96
+# parallel_id = jagsd/test96
 # text = 宗教は怖い?
 1	宗教	宗教	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウキョウ,宗教,宗教,宗教,シューキョー,,,シュウキョウ,シュウキョウ,宗教
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1977,7 +1977,7 @@
 
 # newdoc id = test-s97
 # sent_id = test-s97
-# parallel_id = jagsdluw/test97
+# parallel_id = jagsd/test97
 # text = また渡辺弁護士は,こうも指摘します。
 1	また	又	CCONJ	接続詞	_	7	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	渡辺弁護士	渡辺弁護士	PROPN	名詞-固有名詞-人名-姓	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタナベ;ベンゴ;シ,ワタナベ;弁護;士,渡辺;弁護;士,渡辺;弁護;士,ワタナベ;ベンゴ;シ,;;,;;,ワタナベ;ベンゴ;シ,ワタナベベンゴシ,渡辺弁護士
@@ -1991,7 +1991,7 @@
 
 # newdoc id = test-s98
 # sent_id = test-s98
-# parallel_id = jagsdluw/test98
+# parallel_id = jagsd/test98
 # text = その流れというのもあるので???。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	流れ	流れ	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナガレ,流れ,流れ,流れ,ナガレ,,,ナガレ,ナガレ,流れ
@@ -2007,7 +2007,7 @@
 
 # newdoc id = test-s99
 # sent_id = test-s99
-# parallel_id = jagsdluw/test99
+# parallel_id = jagsd/test99
 # text = 勝利の女神がどちらにほほ笑むか全く分からない展開。
 1	勝利	勝利	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウリ,勝利,勝利,勝利,ショーリ,,,ショウリ,ショウリ,勝利
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2025,7 +2025,7 @@
 
 # newdoc id = test-s100
 # sent_id = test-s100
-# parallel_id = jagsdluw/test100
+# parallel_id = jagsd/test100
 # text = ストイコビッチ監督は「浦和は最後まで目を覚ますことがなかった」と、ジョークを交えながら「柏さんにはおめでとうと言いたい」と新王者を称えた。
 1	ストイコビッチ監督	ストイコビッチ監督	PROPN	名詞-固有名詞-人名-一般	_	34	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ストイコビッチ;カントク,ストイコビッチ;監督,ストイコビッチ;監督,ストイコビッチ;監督,ストイコビッチ;カントク,;,;,ストイコビッチ;カントク,ストイコビッチカントク,ストイコビッチ監督
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2066,7 +2066,7 @@
 
 # newdoc id = test-s101
 # sent_id = test-s101
-# parallel_id = jagsdluw/test101
+# parallel_id = jagsd/test101
 # text = 一団の脇をレスキューボードでライフセーバーが泳ぎ、さらにカヌー、水上バイクもその外に待機する。
 1	一団	一団	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチダン,一団,一団,一団,イチダン,,,イチダン,イチダン,一団
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2091,7 +2091,7 @@
 
 # newdoc id = test-s102
 # sent_id = test-s102
-# parallel_id = jagsdluw/test102
+# parallel_id = jagsd/test102
 # text = ...あなたが涙を流した「SATC」のエピソードは?
 1	.	.	PUNCT	補助記号-句点	_	14	punct	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=,．,.,.,,,,,,．
 2	.	.	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,．,.,.,,,,,,．
@@ -2112,7 +2112,7 @@
 
 # newdoc id = test-s103
 # sent_id = test-s103
-# parallel_id = jagsdluw/test103
+# parallel_id = jagsd/test103
 # text = ジャンボ機の愛称で知られるボーイング747のうち、約20年にわたって日航で活躍してきた国内線仕様の「400D型」の引退フライトツアーが19日あり、参加した約450人が乗り込み別れを惜しんだ。
 1	ジャンボ機	ジャンボ機	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジャンボ;キ,ジャンボ;機,ジャンボ;機,ジャンボ;機,ジャンボ;キ,;,;,ジャンボ;キ,ジャンボキ,ジャンボ機
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2156,7 +2156,7 @@
 
 # newdoc id = test-s104
 # sent_id = test-s104
-# parallel_id = jagsdluw/test104
+# parallel_id = jagsd/test104
 # text = センター街の片隅で、撮影の準備を始める大島優子さんとスタッフ。
 1	センター街	センター街	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センター;ガイ,センター;街,センター;街,センター;街,センター;ガイ,;,;,センター;ガイ,センターガイ,センター街
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2175,7 +2175,7 @@
 
 # newdoc id = test-s105
 # sent_id = test-s105
-# parallel_id = jagsdluw/test105
+# parallel_id = jagsd/test105
 # text = この背景には、アメリカの金融緩和の影響で多額の資金が原油の先物市場に流れ込んでいることや、新興国の需要の拡大で国際的な原油取引の価格が上昇していることがあります。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	背景	背景	NOUN	名詞-普通名詞-一般	_	37	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハイケイ,背景,背景,背景,ハイケー,,,ハイケイ,ハイケイ,背景
@@ -2223,7 +2223,7 @@
 
 # newdoc id = test-s106
 # sent_id = test-s106
-# parallel_id = jagsdluw/test106
+# parallel_id = jagsd/test106
 # text = 本格的だし、絶対に効くと思うので、いろいろな人に覚えてもらいたいです。
 1	本格的	本格的	ADJ	形状詞-一般	_	7	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホンカク;テキ,本格;的,本格;的,本格;的,ホンカク;テキ,;,;,ホンカク;テキ,ホンカクテキ,本格的
 2	だ	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダ,だ
@@ -2248,7 +2248,7 @@
 
 # newdoc id = test-s107
 # sent_id = test-s107
-# parallel_id = jagsdluw/test107
+# parallel_id = jagsd/test107
 # text = 仮設を出た後に住みたい場所では、岩手、宮城の約6割が「以前住んでいた場所に近い高台」「同じ市町村」、福島の7割が「以前住んでいた場所」と答えた。
 1	仮設	仮設	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カセツ,仮設,仮設,仮設,カセツ,,,カセツ,カセツ,仮設
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -2301,7 +2301,7 @@
 
 # newdoc id = test-s108
 # sent_id = test-s108
-# parallel_id = jagsdluw/test108
+# parallel_id = jagsd/test108
 # text = 当初、アメリカ映画として作る発想から始まったので英語映画にしたが、舞台にニューヨークを選ばなかったのは、東京を壊すべきだと思ったから。
 1	当初	当初	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2342,7 +2342,7 @@
 
 # newdoc id = test-s109
 # sent_id = test-s109
-# parallel_id = jagsdluw/test109
+# parallel_id = jagsd/test109
 # text = このページに掲載されている記事・写真・図表などの無断転載を禁じます。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	ページ	ページ	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ページ,ページ,ページ,ページ,ページ,,,ページ,ページ,ページ
@@ -2361,7 +2361,7 @@
 
 # newdoc id = test-s110
 # sent_id = test-s110
-# parallel_id = jagsdluw/test110
+# parallel_id = jagsd/test110
 # text = 記者がアジアを飛び回っているせいか、やはりアジアの方が多いです。
 1	記者	記者	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キシャ,記者,記者,記者,キシャ,,,キシャ,キシャ,記者
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -2383,7 +2383,7 @@
 
 # newdoc id = test-s111
 # sent_id = test-s111
-# parallel_id = jagsdluw/test111
+# parallel_id = jagsd/test111
 # text = 警視庁は今後、役員らから事情を聴くなど、検査妨害の全容を解明する方針。
 1	警視庁	警視庁	PROPN	名詞-固有名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイシ;チョウ,警視;庁,警視;庁,警視;庁,ケーシ;チョー,;,;,ケイシ;チョウ,ケイシチョウ,警視庁
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2406,7 +2406,7 @@
 
 # newdoc id = test-s112
 # sent_id = test-s112
-# parallel_id = jagsdluw/test112
+# parallel_id = jagsd/test112
 # text = 70年ぶりに生息が確認されたクニマスの保護に向け、西湖で地元の漁業協同組合が、禁漁区を自主的に設定しました。
 1	70年ぶり	70年ぶり	NUM	名詞-数詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナナジュウ;ネン;ブリ,七十;年;振り,70;年;ぶり,70;年;ぶり,ナナジュー;ネン;ブリ,;;,;;,ナナジュウ;ネン;ブリ,ナナジュウネンブリ,70年ぶり
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2439,7 +2439,7 @@
 
 # newdoc id = test-s113
 # sent_id = test-s113
-# parallel_id = jagsdluw/test113
+# parallel_id = jagsd/test113
 # text = 谷川容疑者は政治団体の構成員を名乗っていて、当時、団体の車両が中国に対する批判を繰り返す街宣活動を行っていたという。
 1	谷川容疑者	谷川容疑者	PROPN	名詞-固有名詞-人名-姓	_	28	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タニガワ;ヨウギ;シャ,タニガワ;容疑;者,谷川;容疑;者,谷川;容疑;者,タニガワ;ヨーギ;シャ,;;,;;,タニガワ;ヨウギ;シャ,タニガワヨウギシャ,谷川容疑者
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2473,7 +2473,7 @@
 
 # newdoc id = test-s114
 # sent_id = test-s114
-# parallel_id = jagsdluw/test114
+# parallel_id = jagsd/test114
 # text = やがて、書きためた曲を携え、「ウクレレわらべうた」として児童館などでライブを始め、そこで出会った絵本の読み聞かせをする父親たちのグループ「パパ’S絵本プロジェクト」の活動に合流。
 1	やがて	軈て	ADV	副詞	_	18	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤガテ,軈て,やがて,やがて,ヤガテ,,,ヤガテ,ヤガテ,軈て
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2515,7 +2515,7 @@
 
 # newdoc id = test-s115
 # sent_id = test-s115
-# parallel_id = jagsdluw/test115
+# parallel_id = jagsd/test115
 # text = 昨年4月、オバマ米大統領が「核兵器のない世界を目指す」と訴えたプラハ演説以降、潮目が変わってきているのかなと、かすかな期待を抱く。
 1	昨年	昨年	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=サクネン,昨年,昨年,昨年,サクネン,,,サクネン,サクネン,昨年
 2	4月	4月	NUM	名詞-数詞	_	15	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シ;ガツ,四;月,4;月,4;月,シ;ガツ,;,;,シ;ガツ,シガツ,4月
@@ -2554,7 +2554,7 @@
 
 # newdoc id = test-s116
 # sent_id = test-s116
-# parallel_id = jagsdluw/test116
+# parallel_id = jagsd/test116
 # text = だが08年4月、あごを骨折し3つ目の王座から陥落。
 1	だが	だが	CCONJ	接続詞	_	12	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダ;ガ,だ;が,だ;が,だ;が,ダ;ガ,;,;,ダ;ガ,ダガ,だが
 2	08年	08年	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ゼロ;ハチ;ネン,ゼロ;八;年,0;8;年,0;8;年,ゼロ;ハチ;ネン,;;,;;,ゼロ;ハチ;ネン,ゼロハチネン,08年
@@ -2572,7 +2572,7 @@
 
 # newdoc id = test-s117
 # sent_id = test-s117
-# parallel_id = jagsdluw/test117
+# parallel_id = jagsd/test117
 # text = 今期の経常利益は急回復する見通しだが、中期的に見れば、震災の影響はジワジワ効いてくる。
 1	今期	今期	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンキ,今期,今期,今期,コンキ,,,コンキ,コンキ,今期
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2599,7 +2599,7 @@
 
 # newdoc id = test-s118
 # sent_id = test-s118
-# parallel_id = jagsdluw/test118
+# parallel_id = jagsd/test118
 # text = 鋭い眼光でこちらを睨み付けるニノ、ヴィジュアル系のように自分を抱きしめるニノ、壁にへばり付き何かに怯えるニノ......。
 1	鋭い	鋭い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スルドイ,鋭い,鋭い,鋭い,スルドイ,,,スルドイ,スルドイ,鋭い
 2	眼光	眼光	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガンコウ,眼光,眼光,眼光,ガンコー,,,ガンコウ,ガンコウ,眼光
@@ -2636,7 +2636,7 @@
 
 # newdoc id = test-s119
 # sent_id = test-s119
-# parallel_id = jagsdluw/test119
+# parallel_id = jagsd/test119
 # text = パク・チウォン代表は「25人の将軍級を懲戒するというが、こうした重大な問題を監査院の監査で懲戒程度で終わらせることはありえない」、「軍法会議に回付して、軍検察が徹底した調査をするように要求する」と述べた。
 1	パク・チウォン代表	パク・チウォン代表	PROPN	名詞-固有名詞-人名-一般	_	52	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=パク;;チオン;ダイヒョウ,パク;・;チオン;代表,パク;・;チウォン;代表,パク;・;チウォン;代表,パク;;チオン;ダイヒョー,;;;,;;;,パク;;チオン;ダイヒョウ,パクチオンダイヒョウ,パク・チウォン代表
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2695,7 +2695,7 @@
 
 # newdoc id = test-s120
 # sent_id = test-s120
-# parallel_id = jagsdluw/test120
+# parallel_id = jagsd/test120
 # text = SMBC日興証券は2012年秋をめどにシンガポール拠点を開設する。
 1	SMBC日興証券	SMBC日興証券	PROPN	名詞-固有名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エスエムビーシー;ニッコウ;ショウケン,ＳＭＢＣ;日興;証券,SMBC;日興;証券,SMBC;日興;証券,エスエムビーシー;ニッコー;ショーケン,;;,;;,エスエムビーシー;ニッコウ;ショウケン,エスエムビーシーニッコウショウケン,SMBC日興証券
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2710,7 +2710,7 @@
 
 # newdoc id = test-s121
 # sent_id = test-s121
-# parallel_id = jagsdluw/test121
+# parallel_id = jagsd/test121
 # text = 3年ぶりにボランチでプレーしたので自己評価は出来ない。
 1	3年ぶり	3年ぶり	NUM	名詞-数詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ネン;ブリ,三;年;振り,3;年;ぶり,3;年;ぶり,サン;ネン;ブリ,;;,;;,サン;ネン;ブリ,サンネンブリ,3年ぶり
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2727,7 +2727,7 @@
 
 # newdoc id = test-s122
 # sent_id = test-s122
-# parallel_id = jagsdluw/test122
+# parallel_id = jagsd/test122
 # text = わずか半年間に重賞を3勝し、血統馬にふさわしい活躍を見せてきた。
 1	わずか	僅か	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワズカ,僅か,わずか,わずか,ワズカ,,,ワズカ,ワズカ,僅か
 2	半年間	半年間	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハントシ;カン,半年;間,半年;間,半年;間,ハントシ;カン,;,;,ハントシ;カン,ハントシカン,半年間
@@ -2748,7 +2748,7 @@
 
 # newdoc id = test-s123
 # sent_id = test-s123
-# parallel_id = jagsdluw/test123
+# parallel_id = jagsd/test123
 # text = 伏兵の一発を含む11安打9得点で静岡県勢として春通算50勝を達成。
 1	伏兵	伏兵	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フクヘイ,伏兵,伏兵,伏兵,フクヘー,,,フクヘイ,フクヘイ,伏兵
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2769,7 +2769,7 @@
 
 # newdoc id = test-s124
 # sent_id = test-s124
-# parallel_id = jagsdluw/test124
+# parallel_id = jagsd/test124
 # text = メディアから「45年の歴史を持つメジャーリーグのドラフト史上で『最高の選手』」と言われていたストラスバーグだが、この契約金は各方面で話題になった。
 1	メディア	メディア	NOUN	名詞-普通名詞-一般	_	20	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メディア,メディア,メディア,メディア,メディア,,,メディア,メディア,メディア
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -2811,7 +2811,7 @@
 
 # newdoc id = test-s125
 # sent_id = test-s125
-# parallel_id = jagsdluw/test125
+# parallel_id = jagsd/test125
 # text = 私たち去る大戦の悲惨な教訓から戦後「命どぅ宝」、基地のない平和で安全な沖縄を希求してきました。
 1	私たち	私達	PRON	代名詞	_	23	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ;タチ,私;達,私;たち,私;たち,ワタシ;タチ,;,;,ワタシ;タチ,ワタシタチ,私達
 2	去る	然る	ADJ	連体詞	_	3	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サル,然る,去る,去る,サル,,,サル,サル,然る
@@ -2843,7 +2843,7 @@
 
 # newdoc id = test-s126
 # sent_id = test-s126
-# parallel_id = jagsdluw/test126
+# parallel_id = jagsd/test126
 # text = 5/13に放送されるフジテレビ系「僕らの音楽」にて、福原美穂とAIという豪華共演が決定した。
 1	5/13	5/13	NUM	名詞-数詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ;;イチ;サン,五;/;一;三,5;/;1;3,5;/;1;3,ゴ;;イチ;サン,;;;,;;;,ゴ;;イチ;サン,ゴイチサン,5/13
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2869,7 +2869,7 @@
 
 # newdoc id = test-s127
 # sent_id = test-s127
-# parallel_id = jagsdluw/test127
+# parallel_id = jagsd/test127
 # text = そして次巻「約束の地で」では一気に時間が20年後へと飛ぶ。
 1	そして	そして	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	次巻	次巻	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジカン,次巻,次巻,次巻,ジカン,,,ジカン,ジカン,次巻
@@ -2893,7 +2893,7 @@
 
 # newdoc id = test-s128
 # sent_id = test-s128
-# parallel_id = jagsdluw/test128
+# parallel_id = jagsd/test128
 # text = もちろん、運転可能!
 1	もちろん	勿論	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モチロン,勿論,もちろん,もちろん,モチロン,,,モチロン,モチロン,勿論
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2902,7 +2902,7 @@
 
 # newdoc id = test-s129
 # sent_id = test-s129
-# parallel_id = jagsdluw/test129
+# parallel_id = jagsd/test129
 # text = ビーチや公園、家やオフィスなど様々な場所に持ち運んで楽しむことができます。
 1	ビーチ	ビーチ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビーチ,ビーチ,ビーチ,ビーチ,ビーチ,,,ビーチ,ビーチ,ビーチ
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -2925,7 +2925,7 @@
 
 # newdoc id = test-s130
 # sent_id = test-s130
-# parallel_id = jagsdluw/test130
+# parallel_id = jagsd/test130
 # text = 2人は以前、男性に向かって石を投げた際に投げ返されたり、喫煙していてとがめられたりしたことがあり、恨みを募らせていたという。
 1	2人	2人	NOUN	名詞-普通名詞-一般	_	30	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フタリ,二人,2人,2人,フタリ,,,フタリ,フタリ,2人
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2966,7 +2966,7 @@
 
 # newdoc id = test-s131
 # sent_id = test-s131
-# parallel_id = jagsdluw/test131
+# parallel_id = jagsd/test131
 # text = 深刻度がもっとも高い「緊急」とされるのは、「Windows」に関するプログラム4件。
 1	深刻度	深刻度	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンコク;ド,深刻;度,深刻;度,深刻;度,シンコク;ド,;,;,シンコク;ド,シンコクド,深刻度
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -2991,7 +2991,7 @@
 
 # newdoc id = test-s132
 # sent_id = test-s132
-# parallel_id = jagsdluw/test132
+# parallel_id = jagsd/test132
 # text = ただ、この質問に対する回答は、誰かに回答が固まることなく、1位の木村拓哉さんでも獲得率が5%以下と幅広くいろいろな人の名前が挙がる結果となりました。
 1	ただ	唯	CCONJ	接続詞	_	37	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダ,唯,ただ,ただ,タダ,,,タダ,タダ,唯
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3036,7 +3036,7 @@
 
 # newdoc id = test-s133
 # sent_id = test-s133
-# parallel_id = jagsdluw/test133
+# parallel_id = jagsd/test133
 # text = 早ければ2010年度から行う方向となった。
 1	早けれ	早い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハヤイ,早い,早けれ,早い,ハヤケレ,,,ハヤイ,ハヤイ,早い
 2	ば	ば	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=バ,ば,ば,ば,バ,,,バ,バ,ば
@@ -3051,7 +3051,7 @@
 
 # newdoc id = test-s134
 # sent_id = test-s134
-# parallel_id = jagsdluw/test134
+# parallel_id = jagsd/test134
 # text = 車を所有する人の割合は前回平成13年度調査の71・2%から11・9ポイント減少した。
 1	車	車	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クルマ,車,車,車,クルマ,,,クルマ,クルマ,車
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -3073,7 +3073,7 @@
 
 # newdoc id = test-s135
 # sent_id = test-s135
-# parallel_id = jagsdluw/test135
+# parallel_id = jagsd/test135
 # text = 大宮は終盤、攻勢を仕掛けるも得点は奪えず。
 1	大宮	大宮	PROPN	名詞-固有名詞-地名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオミヤ,オオミヤ,大宮,大宮,オーミヤ,,,オオミヤ,オオミヤ,大宮
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3091,7 +3091,7 @@
 
 # newdoc id = test-s136
 # sent_id = test-s136
-# parallel_id = jagsdluw/test136
+# parallel_id = jagsd/test136
 # text = 本当に申し訳ない。
 1	本当	本当	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホントウ,本当,本当,本当,ホント,,,ホント,ホントウ,本当
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3100,7 +3100,7 @@
 
 # newdoc id = test-s137
 # sent_id = test-s137
-# parallel_id = jagsdluw/test137
+# parallel_id = jagsd/test137
 # text = 独立型チャペルは、本格的なヨーロピアンテイスト。
 1	独立型チャペル	独立型チャペル	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドクリツ;ガタ;チャペル,独立;型;チャペル,独立;型;チャペル,独立;型;チャペル,ドクリツ;ガタ;チャペル,;;,;;,ドクリツ;ガタ;チャペル,ドクリツガタチャペル,独立型チャペル
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3112,7 +3112,7 @@
 
 # newdoc id = test-s138
 # sent_id = test-s138
-# parallel_id = jagsdluw/test138
+# parallel_id = jagsd/test138
 # text = 教室に火の気はなく、白河署と矢吹消防署は30日、実況見分し原因を調べる。
 1	教室	教室	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キョウシツ,教室,教室,教室,キョーシツ,,,キョウシツ,キョウシツ,教室
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3134,7 +3134,7 @@
 
 # newdoc id = test-s139
 # sent_id = test-s139
-# parallel_id = jagsdluw/test139
+# parallel_id = jagsd/test139
 # text = 一方で、西側の政治家や専門家の多くは、ノーベル賞委員会の決定は非常に理にかなったものであるとの評価を与えている。
 1	一方	一方	NOUN	名詞-普通名詞-一般	_	29	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3170,7 +3170,7 @@
 
 # newdoc id = test-s140
 # sent_id = test-s140
-# parallel_id = jagsdluw/test140
+# parallel_id = jagsd/test140
 # text = 午後に入ると139円80銭付近での推移となり、結局は14銭高の139円78銭で引けた。
 1	午後	午後	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴゴ,午後,午後,午後,ゴゴ,,,ゴゴ,ゴゴ,午後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3197,7 +3197,7 @@
 
 # newdoc id = test-s141
 # sent_id = test-s141
-# parallel_id = jagsdluw/test141
+# parallel_id = jagsd/test141
 # text = ゴールドマン・サックス証券は257社、日本最大手の野村証券は608社。
 1	ゴールドマン・サックス証券	ゴールドマン・サックス証券	PROPN	名詞-固有名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴールドマン;;サックス;ショウケン,ゴールドマン;・;サックス;証券,ゴールドマン;・;サックス;証券,ゴールドマン;・;サックス;証券,ゴールドマン;;サックス;ショーケン,;;;,;;;,ゴールドマン;;サックス;ショウケン,ゴールドマンサックスショウケン,ゴールドマン・サックス証券
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3212,7 +3212,7 @@
 
 # newdoc id = test-s142
 # sent_id = test-s142
-# parallel_id = jagsdluw/test142
+# parallel_id = jagsd/test142
 # text = 知床半島も、はじめて訪れた1971年から大きく変わり、羅臼の漁師の家も番屋も立派になり、ウトロには無数のホテルが建ち、「地の果て」とは言えない様変わりをしています。
 1	知床半島	知床半島	PROPN	名詞-固有名詞-地名-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シレトコ;ハントウ,シレトコ;半島,知床;半島,知床;半島,シレトコ;ハントー,;,;,シレトコ;ハントウ,シレトコハントウ,知床半島
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -3264,7 +3264,7 @@
 
 # newdoc id = test-s143
 # sent_id = test-s143
-# parallel_id = jagsdluw/test143
+# parallel_id = jagsd/test143
 # text = 企業経営者の、そして企業人一人ひとりの意識改革ではないだろうか。
 1	企業経営者	企業経営者	NOUN	名詞-普通名詞-一般	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キギョウ;ケイエイ;シャ,企業;経営;者,企業;経営;者,企業;経営;者,キギョー;ケーエー;シャ,;;,;;,キギョウ;ケイエイ;シャ,キギョウケイエイシャ,企業経営者
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3280,7 +3280,7 @@
 
 # newdoc id = test-s144
 # sent_id = test-s144
-# parallel_id = jagsdluw/test144
+# parallel_id = jagsd/test144
 # text = ※世帯ごとに保険料の上限が決まっている。
 1	※	※	SYM	補助記号-一般	_	8	dep	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=,※,※,※,,,,,,※
 2	世帯ごと	世帯毎	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セタイ;ゴト,世帯;毎,世帯;ごと,世帯;ごと,セタイ;ゴト,;,;,セタイ;ゴト,セタイゴト,世帯毎
@@ -3295,7 +3295,7 @@
 
 # newdoc id = test-s145
 # sent_id = test-s145
-# parallel_id = jagsdluw/test145
+# parallel_id = jagsd/test145
 # text = 県では「風評被害を防ぐため」として店舗名を公表していない。
 1	県	県	NOUN	名詞-普通名詞-一般	_	13	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケン,県,県,県,ケン,,,ケン,ケン,県
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3316,7 +3316,7 @@
 
 # newdoc id = test-s146
 # sent_id = test-s146
-# parallel_id = jagsdluw/test146
+# parallel_id = jagsd/test146
 # text = 先が気になるストーリー展開や、3人の演技に引き込まれてしまうこと間違いナシだ!
 1	先	先	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サキ,先,先,先,サキ,,,サキ,サキ,先
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3339,7 +3339,7 @@
 
 # newdoc id = test-s149
 # sent_id = test-s149
-# parallel_id = jagsdluw/test149
+# parallel_id = jagsd/test149
 # text = 法案が上院を通過すれば、昨年12月に下院を通過した法案と統合する必要があり、アナリストによると、その時期は5月下旬になると見込まれている。
 1	法案	法案	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホウアン,法案,法案,法案,ホーアン,,,ホウアン,ホウアン,法案
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3379,7 +3379,7 @@
 
 # newdoc id = test-s150
 # sent_id = test-s150
-# parallel_id = jagsdluw/test150
+# parallel_id = jagsd/test150
 # text = 来場者は熱心に見入っていた。
 1	来場者	来場者	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ライジョウ;シャ,来場;者,来場;者,来場;者,ライジョー;シャ,;,;,ライジョウ;シャ,ライジョウシャ,来場者
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3392,14 +3392,14 @@
 
 # newdoc id = test-s151
 # sent_id = test-s151
-# parallel_id = jagsdluw/test151
+# parallel_id = jagsd/test151
 # text = 入場無料。
 1	入場無料	入場無料	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ニュウジョウ;ムリョウ,入場;無料,入場;無料,入場;無料,ニュージョー;ムリョー,;,;,ニュウジョウ;ムリョウ,ニュウジョウムリョウ,入場無料
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s152
 # sent_id = test-s152
-# parallel_id = jagsdluw/test152
+# parallel_id = jagsd/test152
 # text = 当面は同省職員2人を派遣。
 1	当面	当面	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウメン,当面,当面,当面,トーメン,,,トウメン,トウメン,当面
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3411,7 +3411,7 @@
 
 # newdoc id = test-s153
 # sent_id = test-s153
-# parallel_id = jagsdluw/test153
+# parallel_id = jagsd/test153
 # text = 株式会社GCIキャピタルは、信頼できる情報をもとに本資料を作成しておりますが、正確性・完全性について株式会社GCIキャピタルが責任を負うものではありません。
 1	株式会社GCIキャピタル	株式会社GCIキャピタル	PROPN	名詞-固有名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カブシキ;カイシャ;ジーシーアイ;キャピタル,株式;会社;ＧＣＩ;キャピタル,株式;会社;GCI;キャピタル,株式;会社;GCI;キャピタル,カブシキ;ガイシャ;ジーシーアイ;キャピタル,;;;,;;;,カブシキ;カイシャ;ジーシーアイ;キャピタル,カブシキガイシャジーシーアイキャピタル,株式会社GCIキャピタル
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3441,7 +3441,7 @@
 
 # newdoc id = test-s154
 # sent_id = test-s154
-# parallel_id = jagsdluw/test154
+# parallel_id = jagsd/test154
 # text = そのあだ名の通り、女性を見ると口説き、襲おうとするリョウちゃん。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	あだ名	渾名	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アダナ,渾名,あだ名,あだ名,アダナ,,,アダナ,アダナ,渾名
@@ -3462,7 +3462,7 @@
 
 # newdoc id = test-s155
 # sent_id = test-s155
-# parallel_id = jagsdluw/test155
+# parallel_id = jagsd/test155
 # text = 男女が親交を深めやすいようにと、ピザ作り体験などを企画の柱にしたところ大好評となった。
 1	男女	男女	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダンジョ,男女,男女,男女,ダンジョ,,,ダンジョ,ダンジョ,男女
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3490,7 +3490,7 @@
 
 # newdoc id = test-s156
 # sent_id = test-s156
-# parallel_id = jagsdluw/test156
+# parallel_id = jagsd/test156
 # text = 恵まれた身体能力を生かした守備はもちろん、闘争心をむき出しに前線へと駆け上がるプレーで相手を翻弄。
 1	恵まれ	恵まれる	VERB	動詞-一般-下一段-ラ行	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メグマレル,恵まれる,恵まれ,恵まれる,メグマレ,,,メグマレル,メグマレル,恵まれる
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -3519,7 +3519,7 @@
 
 # newdoc id = test-s157
 # sent_id = test-s157
-# parallel_id = jagsdluw/test157
+# parallel_id = jagsd/test157
 # text = ベストアルバム『BAD TIMES』をリリースすることが明らかになりました!
 1	ベストアルバム	ベストアルバム	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベスト;アルバム,ベスト;アルバム,ベスト;アルバム,ベスト;アルバム,ベスト;アルバム,;,;,ベスト;アルバム,ベストアルバム,ベストアルバム
 2	『	『	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
@@ -3538,7 +3538,7 @@
 
 # newdoc id = test-s158
 # sent_id = test-s158
-# parallel_id = jagsdluw/test158
+# parallel_id = jagsd/test158
 # text = 震災を考慮して街頭運動が一部異例の選挙戦がスタートした。
 1	震災	震災	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンサイ,震災,震災,震災,シンサイ,,,シンサイ,シンサイ,震災
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -3556,7 +3556,7 @@
 
 # newdoc id = test-s159
 # sent_id = test-s159
-# parallel_id = jagsdluw/test159
+# parallel_id = jagsd/test159
 # text = トッティは試合後に「この記録を誇りに思うが、ここで止まることはない」とコメント。
 1	トッティ	トッティ	PROPN	名詞-固有名詞-人名-一般	_	20	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トッティ,トッティ,トッティ,トッティ,トッティ,,,トッティ,トッティ,トッティ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3582,7 +3582,7 @@
 
 # newdoc id = test-s160
 # sent_id = test-s160
-# parallel_id = jagsdluw/test160
+# parallel_id = jagsd/test160
 # text = 尾崎淳介校長は「水筒を持たせ、帽子をかぶるように指導していた。
 1	尾崎淳介校長	尾崎淳介校長	PROPN	名詞-固有名詞-人名-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オザキ;ジュンスケ;コウチョウ,オザキ;ジュンスケ;校長,尾崎;淳介;校長,尾崎;淳介;校長,オザキ;ジュンスケ;コーチョー,;;,;;,オザキ;ジュンスケ;コウチョウ,オザキジュンスケコウチョウ,尾崎淳介校長
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3604,7 +3604,7 @@
 
 # newdoc id = test-s161
 # sent_id = test-s161
-# parallel_id = jagsdluw/test161
+# parallel_id = jagsd/test161
 # text = 自由で不思議でキュートな女の子、AKB48チームBのメンバーメンバー小林香菜。
 1	自由	自由	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジユウ,自由,自由,自由,ジユー,,,ジユウ,ジユウ,自由
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -3621,7 +3621,7 @@
 
 # newdoc id = test-s162
 # sent_id = test-s162
-# parallel_id = jagsdluw/test162
+# parallel_id = jagsd/test162
 # text = 景観・社会・文化・報道・文化遺産・近代史写真等、豊富なジャンルでご対応!
 1	景観・社会・文化・報道・文化遺産・近代史写真等	景観・社会・文化・報道・文化遺産・近代史写真等	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケイカン;;シャカイ;;ブンカ;;ホウドウ;;ブンカ;イサン;;キンダイ;シ;シャシン;トウ,景観;・;社会;・;文化;・;報道;・;文化;遺産;・;近代;史;写真;等,景観;・;社会;・;文化;・;報道;・;文化;遺産;・;近代;史;写真;等,景観;・;社会;・;文化;・;報道;・;文化;遺産;・;近代;史;写真;等,ケーカン;;シャカイ;;ブンカ;;ホードー;;ブンカ;イサン;;キンダイ;シ;シャシン;トー,;;;;;;;;;;;;;;,;;;;;;;;;;;;;;,ケイカン;;シャカイ;;ブンカ;;ホウドウ;;ブンカ;イサン;;キンダイ;シ;シャシン;トウ,ケイカンシャカイブンカホウドウブンカイサンキンダイシシャシントウ,景観・社会・文化・報道・文化遺産・近代史写真等
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3634,7 +3634,7 @@
 
 # newdoc id = test-s163
 # sent_id = test-s163
-# parallel_id = jagsdluw/test163
+# parallel_id = jagsd/test163
 # text = 過去に記者会見で歌を歌った選手などがいたが競技外のパフォーマンスがどうであったとしても競技で結果を残せなければ何の意味もない事をトリノ以降、協会が選手に伝えきれていない。
 1	過去	過去	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カコ,過去,過去,過去,カコ,,,カコ,カコ,過去
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3685,7 +3685,7 @@
 
 # newdoc id = test-s164
 # sent_id = test-s164
-# parallel_id = jagsdluw/test164
+# parallel_id = jagsd/test164
 # text = 18分以降、SAGAWAがボールをキープする時間が増え出し行くのだが、これはペースを握っているのではなく、前からのプレッシャーが厳しいため、一旦下げて後ろで回し、なんとか穴を探ろうとしたためにポゼッションする時間が増えただけのこと。
 1	18分以降	18分以降	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;フン;イコウ,一;八;分;以降,1;8;分;以降,1;8;分;以降,イチ;ハッ;プン;イコー,;;;,;;;,イチ;ハチ;フン;イコウ,イチハップンイコウ,18分以降
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3744,7 +3744,7 @@
 
 # newdoc id = test-s165
 # sent_id = test-s165
-# parallel_id = jagsdluw/test165
+# parallel_id = jagsd/test165
 # text = 通路を使って移動し、ホーム上の混雑を回避する。
 1	通路	通路	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツウロ,通路,通路,通路,ツーロ,,,ツウロ,ツウロ,通路
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -3761,7 +3761,7 @@
 
 # newdoc id = test-s166
 # sent_id = test-s166
-# parallel_id = jagsdluw/test166
+# parallel_id = jagsd/test166
 # text = 2号機の西1・1キロにある西門付近で、17日午前0時半に毎時351・4マイクロシーベルトだった放射線量が、18日午前8時には270・5マイクロシーベルトに下がった。
 1	2号機	2号機	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゴウ;キ,二;号;機,2;号;機,2;号;機,ニ;ゴー;キ,;;,;;,ニ;ゴウ;キ,ニゴウキ,2号機
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3796,7 +3796,7 @@
 
 # newdoc id = test-s167
 # sent_id = test-s167
-# parallel_id = jagsdluw/test167
+# parallel_id = jagsd/test167
 # text = 簡単でおいしい上に、栄養のバランスがいいとなれば言うことなしです。
 1	簡単	簡単	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンタン,簡単,簡単,簡単,カンタン,,,カンタン,カンタン,簡単
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -3818,7 +3818,7 @@
 
 # newdoc id = test-s168
 # sent_id = test-s168
-# parallel_id = jagsdluw/test168
+# parallel_id = jagsd/test168
 # text = また、レートにより金額が多少左右されます。
 1	また	又	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3834,7 +3834,7 @@
 
 # newdoc id = test-s169
 # sent_id = test-s169
-# parallel_id = jagsdluw/test169
+# parallel_id = jagsd/test169
 # text = 立件に消極的だったという。
 1	立件	立件	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リッケン,立件,立件,立件,リッケン,,,リッケン,リッケン,立件
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3847,7 +3847,7 @@
 
 # newdoc id = test-s170
 # sent_id = test-s170
-# parallel_id = jagsdluw/test170
+# parallel_id = jagsd/test170
 # text = わが外相が「重要な進展だ」と胸を張っているように見えたのは、きっと気のせいだ。
 1	わが	我が	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワガ,我が,わが,わが,ワガ,,,ワガ,ワガ,我が
 2	外相	外相	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガイショウ,外相,外相,外相,ガイショー,,,ガイショウ,ガイショウ,外相
@@ -3879,7 +3879,7 @@
 
 # newdoc id = test-s171
 # sent_id = test-s171
-# parallel_id = jagsdluw/test171
+# parallel_id = jagsd/test171
 # text = オバマ大統領は、雇用対策の恩恵を受ける教師や警官、建設労働者らを背に演説に臨み、「この法案が、人々を職場に戻していくことにつながる」とアピール。
 1	オバマ大統領	オバマ大統領	PROPN	名詞-固有名詞-人名-一般	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オバマ;ダイトウリョウ,オバマ;大統領,オバマ;大統領,オバマ;大統領,オバマ;ダイトーリョー,;,;,オバマ;ダイトウリョウ,オバマダイトウリョウ,オバマ大統領
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3922,7 +3922,7 @@
 
 # newdoc id = test-s172
 # sent_id = test-s172
-# parallel_id = jagsdluw/test172
+# parallel_id = jagsd/test172
 # text = オーストラリア、カナダ、メキシコでも、それぞれの国の労働者が転職先を見つけることができるとの回答が高いことがわかりました
 1	オーストラリア	オーストラリア	PROPN	名詞-固有名詞-地名-国	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オーストラリア,オーストラリア,オーストラリア,オーストラリア,オーストラリア,,,オーストラリア,オーストラリア,オーストラリア
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3955,7 +3955,7 @@
 
 # newdoc id = test-s173
 # sent_id = test-s173
-# parallel_id = jagsdluw/test173
+# parallel_id = jagsd/test173
 # text = 橋下知事は立候補を明言こそしなかったが、「大都市、大阪の市長に平松市長はふさわしくない。
 1	橋下知事	橋下知事	PROPN	名詞-固有名詞-人名-姓	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハシモト;チジ,ハシモト;知事,橋下;知事,橋下;知事,ハシモト;チジ,;,;,ハシモト;チジ,ハシモトチジ,橋下知事
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3983,7 +3983,7 @@
 
 # newdoc id = test-s174
 # sent_id = test-s174
-# parallel_id = jagsdluw/test174
+# parallel_id = jagsd/test174
 # text = 米中戦略・経済対話初日の米側は中国の反体制派への弾圧を厳しく批判したが、世界の経済成長については協調的な姿勢を示した。
 1	米中戦略・経済対話初日	米中戦略・経済対話初日	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベイチュウ;センリャク;;ケイザイ;タイワ;ショニチ,米中;戦略;・;経済;対話;初日,米中;戦略;・;経済;対話;初日,米中;戦略;・;経済;対話;初日,ベーチュー;センリャク;;ケーザイ;タイワ;ショニチ,;;;;;,;;;;;,ベイチュウ;センリャク;;ケイザイ;タイワ;ショニチ,ベイチュウセンリャクケイザイタイワショニチ,米中戦略・経済対話初日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4016,7 +4016,7 @@
 
 # newdoc id = test-s175
 # sent_id = test-s175
-# parallel_id = jagsdluw/test175
+# parallel_id = jagsd/test175
 # text = ジャカルタの街中で自転車を利用する人が増えたように思う。
 1	ジャカルタ	ジャカルタ	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジャカルタ,ジャカルタ,ジャカルタ,ジャカルタ,ジャカルタ,,,ジャカルタ,ジャカルタ,ジャカルタ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4036,7 +4036,7 @@
 
 # newdoc id = test-s176
 # sent_id = test-s176
-# parallel_id = jagsdluw/test176
+# parallel_id = jagsd/test176
 # text = サイトの新しい楽しみ方「屋上会議室」好評公開中!
 1	サイト	サイト	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイト,サイト,サイト,サイト,サイト,,,サイト,サイト,サイト
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4050,7 +4050,7 @@
 
 # newdoc id = test-s177
 # sent_id = test-s177
-# parallel_id = jagsdluw/test177
+# parallel_id = jagsd/test177
 # text = その名の通り、スライド全面にグラフィックを配置。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	名	名	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナ,名,名,名,ナ,,,ナ,ナ,名
@@ -4066,7 +4066,7 @@
 
 # newdoc id = test-s178
 # sent_id = test-s178
-# parallel_id = jagsdluw/test178
+# parallel_id = jagsd/test178
 # text = 高校時代の同級生とあって合宿中も、不安を打ち明け合っているという。
 1	高校時代	高校時代	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウコウ;ジダイ,高校;時代,高校;時代,高校;時代,コーコー;ジダイ,;,;,コウコウ;ジダイ,コウコウジダイ,高校時代
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4087,7 +4087,7 @@
 
 # newdoc id = test-s179
 # sent_id = test-s179
-# parallel_id = jagsdluw/test179
+# parallel_id = jagsd/test179
 # text = あるいは、試練に挑もうとしない逃避癖だ。
 1	あるいは	或いは	CCONJ	接続詞	_	9	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アルイハ,或いは,あるいは,あるいは,アルイワ,,,アルイハ,アルイハ,或いは
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4103,7 +4103,7 @@
 
 # newdoc id = test-s180
 # sent_id = test-s180
-# parallel_id = jagsdluw/test180
+# parallel_id = jagsd/test180
 # text = イランが、IEF国際エネルギー・フォーラム実行委員会の常任メンバー国に選出されました。
 1	イラン	イラン	PROPN	名詞-固有名詞-地名-国	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イラン,イラン,イラン,イラン,イラン,,,イラン,イラン,イラン
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4120,7 +4120,7 @@
 
 # newdoc id = test-s181
 # sent_id = test-s181
-# parallel_id = jagsdluw/test181
+# parallel_id = jagsd/test181
 # text = 信号変換効率を向上するとともに、超低域の歪みを改善し、低域から高域まで、すぐれた周波数特性を実現している。
 1	信号変換効率	信号変換効率	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンゴウ;ヘンカン;コウリツ,信号;変換;効率,信号;変換;効率,信号;変換;効率,シンゴー;ヘンカン;コーリツ,;;,;;,シンゴウ;ヘンカン;コウリツ,シンゴウヘンカンコウリツ,信号変換効率
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4148,7 +4148,7 @@
 
 # newdoc id = test-s182
 # sent_id = test-s182
-# parallel_id = jagsdluw/test182
+# parallel_id = jagsd/test182
 # text = 初期投資のいくらか全ての損失を被る可能性が存在します、
 1	初期投資	初期投資	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショキ;トウシ,初期;投資,初期;投資,初期;投資,ショキ;トーシ,;,;,ショキ;トウシ,ショキトウシ,初期投資
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4167,7 +4167,7 @@
 
 # newdoc id = test-s183
 # sent_id = test-s183
-# parallel_id = jagsdluw/test183
+# parallel_id = jagsd/test183
 # text = 最初の仕切りで芳東に待ったをかけられた宝智山は、仕切り直しの立ち合いで得意の右四つとなり左上手を取ると、相手に構うことなく前に出てそのまま寄り倒した。
 1	最初	最初	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイショ,最初,最初,最初,サイショ,,,サイショ,サイショ,最初
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4216,7 +4216,7 @@
 
 # newdoc id = test-s184
 # sent_id = test-s184
-# parallel_id = jagsdluw/test184
+# parallel_id = jagsd/test184
 # text = 父から「おまえが決意して、そこまでやるなら応援する」と思いもよらない言葉で激励された。
 1	父	父	NOUN	名詞-普通名詞-一般	_	22	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チチ,父,父,父,チチ,,,チチ,チチ,父
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -4246,7 +4246,7 @@
 
 # newdoc id = test-s185
 # sent_id = test-s185
-# parallel_id = jagsdluw/test185
+# parallel_id = jagsd/test185
 # text = 西宮市は活動を大規模災害に限っているため、日常的に活動する機能別消防団員は県内初。
 1	西宮市	西宮市	PROPN	名詞-固有名詞-地名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニシノミヤ;シ,ニシノミヤ;市,西宮;市,西宮;市,ニシノミヤ;シ,;,;,ニシノミヤ;シ,ニシノミヤシ,西宮市
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4268,7 +4268,7 @@
 
 # newdoc id = test-s186
 # sent_id = test-s186
-# parallel_id = jagsdluw/test186
+# parallel_id = jagsd/test186
 # text = 東中本運動場まで徒歩5分一日600円/5台
 1	東中本運動場	東中本運動場	NOUN	名詞-普通名詞-一般	_	8	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒガシ;ナカモト;ウンドウ;ジョウ,東;ナカモト;運動;場,東;中本;運動;場,東;中本;運動;場,ヒガシ;ナカモト;ウンドー;ジョー,;;;,;;;,ヒガシ;ナカモト;ウンドウ;ジョウ,ヒガシナカモトウンドウジョウ,東中本運動場
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -4281,7 +4281,7 @@
 
 # newdoc id = test-s187
 # sent_id = test-s187
-# parallel_id = jagsdluw/test187
+# parallel_id = jagsd/test187
 # text = って言ってる年齢不詳?
 1	って	つう	PART	助詞-副助詞	_	2	mark	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ッテ,って,って,って,ッテ,,,ッテ,ツウ,つう
 2	言っ	言う	VERB	動詞-一般-五段-ワア行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イウ,言う,言っ,言う,イッ,,,イウ,イウ,言う
@@ -4291,7 +4291,7 @@
 
 # newdoc id = test-s188
 # sent_id = test-s188
-# parallel_id = jagsdluw/test188
+# parallel_id = jagsd/test188
 # text = キレイでオシャレな店内はずっといてもいいぐらいですね。
 1	キレイ	奇麗	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キレイ,奇麗,キレイ,キレイ,キレー,,,キレイ,キレイ,奇麗
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -4309,7 +4309,7 @@
 
 # newdoc id = test-s189
 # sent_id = test-s189
-# parallel_id = jagsdluw/test189
+# parallel_id = jagsd/test189
 # text = 自分は希望スタイルをいつも複数抱えて来店しますが、センスの良いスタッフの意見が役に立っていつも満足のいく仕上がりを施してくださいます。
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4349,7 +4349,7 @@
 
 # newdoc id = test-s190
 # sent_id = test-s190
-# parallel_id = jagsdluw/test190
+# parallel_id = jagsd/test190
 # text = あれじゃ客は来ないね、
 1	あれ	彼れ	PRON	代名詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アレ,彼れ,あれ,あれ,アレ,,,アレ,アレ,彼れ
 2	じゃ	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,じゃ,じゃ,ジャ,,,ジャ,デ,で
@@ -4362,7 +4362,7 @@
 
 # newdoc id = test-s191
 # sent_id = test-s191
-# parallel_id = jagsdluw/test191
+# parallel_id = jagsd/test191
 # text = 診察は予約制なのに1時間まちはざらです。
 1	診察	診察	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンサツ,診察,診察,診察,シンサツ,,,シンサツ,シンサツ,診察
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4378,7 +4378,7 @@
 
 # newdoc id = test-s192
 # sent_id = test-s192
-# parallel_id = jagsdluw/test192
+# parallel_id = jagsd/test192
 # text = “シールド工法”が良くわかります。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	シールド工法	シールド工法	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シールド;コウホウ,シールド;工法,シールド;工法,シールド;工法,シールド;コーホー,;,;,シールド;コウホウ,シールドコウホウ,シールド工法
@@ -4391,7 +4391,7 @@
 
 # newdoc id = test-s193
 # sent_id = test-s193
-# parallel_id = jagsdluw/test193
+# parallel_id = jagsd/test193
 # text = エステは受けたことが無いので相場はわかりませんでしたが、まぁ、これなら妥当かな、という感じでした。
 1	エステ	エステ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エステ,エステ,エステ,エステ,エステ,,,エステ,エステ,エステ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4426,7 +4426,7 @@
 
 # newdoc id = test-s194
 # sent_id = test-s194
-# parallel_id = jagsdluw/test194
+# parallel_id = jagsd/test194
 # text = 父には90分コースをセレクトしましたが、新規価格ということで少しお得になっていました。
 1	父	父	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チチ,父,父,父,チチ,,,チチ,チチ,父
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4453,7 +4453,7 @@
 
 # newdoc id = test-s195
 # sent_id = test-s195
-# parallel_id = jagsdluw/test195
+# parallel_id = jagsd/test195
 # text = 友人の紹介で東京の出張マッサージを利用。
 1	友人	友人	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユウジン,友人,友人,友人,ユージン,,,ユウジン,ユウジン,友人
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4468,7 +4468,7 @@
 
 # newdoc id = test-s196
 # sent_id = test-s196
-# parallel_id = jagsdluw/test196
+# parallel_id = jagsd/test196
 # text = スタッフがフレンドリー。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフ,スタッフ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4477,7 +4477,7 @@
 
 # newdoc id = test-s197
 # sent_id = test-s197
-# parallel_id = jagsdluw/test197
+# parallel_id = jagsd/test197
 # text = お皿は全て重ねてたのですが、しばらくすると女性の従業員が来て、こちらのトロ刺身のお皿はお取りになられましたか?
 1	お皿	御皿	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;サラ,御;皿,お;皿,お;皿,オ;サラ,;,;,オ;サラ,オサラ,御皿
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4513,7 +4513,7 @@
 
 # newdoc id = test-s198
 # sent_id = test-s198
-# parallel_id = jagsdluw/test198
+# parallel_id = jagsd/test198
 # text = 営業時間は朝9時~夜7時までみたいですが、人気のあるパンはすぐなくなってしまいます。
 1	営業時間	営業時間	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エイギョウ;ジカン,営業;時間,営業;時間,営業;時間,エーギョー;ジカン,;,;,エイギョウ;ジカン,エイギョウジカン,営業時間
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4540,7 +4540,7 @@
 
 # newdoc id = test-s199
 # sent_id = test-s199
-# parallel_id = jagsdluw/test199
+# parallel_id = jagsd/test199
 # text = 大門側から高野山に入って最初の信号にある出光興産系のガソリンスタンド。
 1	大門側	大門側	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイモン;ガワ,大門;側,大門;側,大門;側,ダイモン;ガワ,;,;,ダイモン;ガワ,ダイモンガワ,大門側
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -4560,7 +4560,7 @@
 
 # newdoc id = test-s200
 # sent_id = test-s200
-# parallel_id = jagsdluw/test200
+# parallel_id = jagsd/test200
 # text = テレビにて、こちらの店を知りましたが、こだわりの店と認識していたので正直がっかりさせられました。
 1	テレビ	テレビ	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テレビ,テレビ,テレビ,テレビ,テレビ,,,テレビ,テレビ,テレビ
 2	にて	にて	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニテ,にて,にて,にて,ニテ,,,ニテ,ニテ,にて
@@ -4592,7 +4592,7 @@
 
 # newdoc id = test-s201
 # sent_id = test-s201
-# parallel_id = jagsdluw/test201
+# parallel_id = jagsd/test201
 # text = アアルトさんのコーヒー豆を使ったコーヒーは文句のつけようなし!
 1	アアルトさん	アアルトさん	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アールト;サン,アールト;さん,アアルト;さん,アアルト;さん,アールト;サン,;,;,アールト;サン,アールトサン,アアルトさん
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4610,7 +4610,7 @@
 
 # newdoc id = test-s202
 # sent_id = test-s202
-# parallel_id = jagsdluw/test202
+# parallel_id = jagsd/test202
 # text = 値段も普通くらいかな。
 1	値段	値段	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネダン,値段,値段,値段,ネダン,,,ネダン,ネダン,値段
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4622,7 +4622,7 @@
 
 # newdoc id = test-s203
 # sent_id = test-s203
-# parallel_id = jagsdluw/test203
+# parallel_id = jagsd/test203
 # text = いつも割りと混んでる。
 1	いつ	何時	PRON	代名詞	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イツ,何時,いつ,いつ,イツ,,,イツ,イツ,何時
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4633,7 +4633,7 @@
 
 # newdoc id = test-s204
 # sent_id = test-s204
-# parallel_id = jagsdluw/test204
+# parallel_id = jagsd/test204
 # text = 宴会が入って忙しかったのかも知れないが、接客は最悪、味も最低、刺身の盛り合わせは水っぽく、町のスーパーで売っている最低ランクの刺身と同じ味。
 1	宴会	宴会	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エンカイ,宴会,宴会,宴会,エンカイ,,,エンカイ,エンカイ,宴会
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4675,7 +4675,7 @@
 
 # newdoc id = test-s205
 # sent_id = test-s205
-# parallel_id = jagsdluw/test205
+# parallel_id = jagsd/test205
 # text = 夜は5時に行くのが1番です。
 1	夜	夜	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨル,夜,夜,夜,ヨル,,,ヨル,ヨル,夜
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4690,7 +4690,7 @@
 
 # newdoc id = test-s206
 # sent_id = test-s206
-# parallel_id = jagsdluw/test206
+# parallel_id = jagsd/test206
 # text = 治療やケアの方も素晴らしく、待合室もここが歯医者だと忘れてしまうくらい立派です。
 1	治療	治療	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チリョウ,治療,治療,治療,チリョー,,,チリョウ,チリョウ,治療
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -4716,7 +4716,7 @@
 
 # newdoc id = test-s207
 # sent_id = test-s207
-# parallel_id = jagsdluw/test207
+# parallel_id = jagsd/test207
 # text = 料理も美味しいし、女将・スタッフの皆さんよい感じでしたよ!
 1	料理	料理	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リョウリ,料理,料理,料理,リョーリ,,,リョウリ,リョウリ,料理
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4735,7 +4735,7 @@
 
 # newdoc id = test-s211
 # sent_id = test-s211
-# parallel_id = jagsdluw/test211
+# parallel_id = jagsd/test211
 # text = この様な担当者の姿勢、とても良いと思います。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	様	様	NOUN	形状詞-助動詞語幹	_	6	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=ヨウ,様,様,様,ヨー,,,ヨウ,ヨウ,様
@@ -4753,7 +4753,7 @@
 
 # newdoc id = test-s212
 # sent_id = test-s212
-# parallel_id = jagsdluw/test212
+# parallel_id = jagsd/test212
 # text = 他社と比べても初めての見積もりの内容が非常に具体的でイメージがわきやすく好印象でした。
 1	他社	他社	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タシャ,他社,他社,他社,タシャ,,,タシャ,タシャ,他社
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -4780,7 +4780,7 @@
 
 # newdoc id = test-s213
 # sent_id = test-s213
-# parallel_id = jagsdluw/test213
+# parallel_id = jagsd/test213
 # text = 持ってきてくれるのはいいのですが、他のメニューは食べ終わってしまって「おあずけ」状態です。
 1	持っ	持つ	VERB	動詞-一般-五段-タ行	_	6	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モツ,持つ,持っ,持つ,モッ,,,モツ,モツ,持つ
 2	てき	てく	AUX	助動詞-五段-カ行	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ;クル,て;来る,て;き,て;くる,テ;キ,;,;,テ;クル,テク,てく
@@ -4807,7 +4807,7 @@
 
 # newdoc id = test-s214
 # sent_id = test-s214
-# parallel_id = jagsdluw/test214
+# parallel_id = jagsd/test214
 # text = また、この店は、土日になるとドライブスルー渋滞ができます。
 1	また	又	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4827,7 +4827,7 @@
 
 # newdoc id = test-s215
 # sent_id = test-s215
-# parallel_id = jagsdluw/test215
+# parallel_id = jagsd/test215
 # text = 料理は美味しい、雰囲気も良い、なによりお酒が美味しい。
 1	料理	料理	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リョウリ,料理,料理,料理,リョーリ,,,リョウリ,リョウリ,料理
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4845,7 +4845,7 @@
 
 # newdoc id = test-s216
 # sent_id = test-s216
-# parallel_id = jagsdluw/test216
+# parallel_id = jagsd/test216
 # text = 最近かなり混んで来ましたが先生は相変わらずマイペースでしっかり診療してくれるので予約が遅くなっても不満はありません。
 1	最近	最近	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイキン,最近,最近,最近,サイキン,,,サイキン,サイキン,最近
 2	かなり	可成	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カナリ,可成,かなり,かなり,カナリ,,,カナリ,カナリ,可成
@@ -4879,7 +4879,7 @@
 
 # newdoc id = test-s217
 # sent_id = test-s217
-# parallel_id = jagsdluw/test217
+# parallel_id = jagsd/test217
 # text = 参ったなぁ、と途方にくれた時ふと最初に「あれではないよな」と思っていた不動明王の像があるお墓。
 1	参っ	参る	VERB	動詞-一般-五段-ラ行	_	8	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マイル,参る,参っ,参る,マイッ,,,マイル,マイル,参る
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -4914,7 +4914,7 @@
 
 # newdoc id = test-s218
 # sent_id = test-s218
-# parallel_id = jagsdluw/test218
+# parallel_id = jagsd/test218
 # text = バッティングセンターとビリヤード台もあって、仕出しをとれる会議室もあり、小さいながらも施設機能は充実してます。
 1	バッティングセンター	バッティングセンター	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バッティング;センター,バッティング;センター,バッティング;センター,バッティング;センター,バッティング;センター,;,;,バッティング;センター,バッティングセンター,バッティングセンター
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -4942,7 +4942,7 @@
 
 # newdoc id = test-s219
 # sent_id = test-s219
-# parallel_id = jagsdluw/test219
+# parallel_id = jagsd/test219
 # text = 子供お祝い返しに買ったロールケーキがカビていたので、本当に怒りしんとうでした
 1	子供お祝い返し	子供御祝い返し	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コドモ;オ;イワイガエシ,子供;御;祝い返し,子供;お;祝い返し,子供;お;祝い返し,コドモ;オ;イワイガエシ,;;,;;,コドモ;オ;イワイガエシ,コドモオイワイガエシ,子供御祝い返し
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4963,7 +4963,7 @@
 
 # newdoc id = test-s220
 # sent_id = test-s220
-# parallel_id = jagsdluw/test220
+# parallel_id = jagsd/test220
 # text = すごく親身にお世話してくれました。
 1	すごく	凄い	ADJ	形容詞-一般-形容詞	_	2	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごく,すごい,スゴク,,,スゴイ,スゴイ,凄い
 2	親身	親身	ADJ	形状詞-一般	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンミ,親身,親身,親身,シンミ,,,シンミ,シンミ,親身
@@ -4976,7 +4976,7 @@
 
 # newdoc id = test-s221
 # sent_id = test-s221
-# parallel_id = jagsdluw/test221
+# parallel_id = jagsd/test221
 # text = 最近出来た新しい産婦人科と悩みましたが、こちらの病院を選び正解だったと感じてます。
 1	最近	最近	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイキン,最近,最近,最近,サイキン,,,サイキン,サイキン,最近
 2	出来	出来る	VERB	動詞-一般-上一段-カ行	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=できる|SpaceAfter=No|UnidicInfo=デキル,出来る,出来,出来る,デキ,,,デキル,デキル,出来る
@@ -5005,7 +5005,7 @@
 
 # newdoc id = test-s222
 # sent_id = test-s222
-# parallel_id = jagsdluw/test222
+# parallel_id = jagsd/test222
 # text = その時からのだから?
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	時	時	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=トキ,時,時,時,トキ,,,トキ,トキ,時
@@ -5016,7 +5016,7 @@
 
 # newdoc id = test-s223
 # sent_id = test-s223
-# parallel_id = jagsdluw/test223
+# parallel_id = jagsd/test223
 # text = 美味しいおせんべいの他、ワッフルやゼリーなどもオススメです。
 1	美味しい	美味しい	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オイシイ,美味しい,美味しい,美味しい,オイシー,,,オイシイ,オイシイ,美味しい
 2	おせんべい	御煎餅	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;センベイ,御;煎餅,お;せんべい,お;せんべい,オ;センベー,;,;,オ;センベイ,オセンベイ,御煎餅
@@ -5034,7 +5034,7 @@
 
 # newdoc id = test-s224
 # sent_id = test-s224
-# parallel_id = jagsdluw/test224
+# parallel_id = jagsd/test224
 # text = ずっとコンプレックスだったので、キレイにしていただけて本当に良かったです。
 1	ずっと	ずっと	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ズット,ずっと,ずっと,ずっと,ズット,,,ズット,ズット,ずっと
 2	コンプレックス	コンプレックス	NOUN	名詞-普通名詞-一般	_	14	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンプレックス,コンプレックス,コンプレックス,コンプレックス,コンプレックス,,,コンプレックス,コンプレックス,コンプレックス
@@ -5056,7 +5056,7 @@
 
 # newdoc id = test-s226
 # sent_id = test-s226
-# parallel_id = jagsdluw/test226
+# parallel_id = jagsd/test226
 # text = とりあえず生ビールから始め、華のれんさんのサイトで気になってた「ばくだん」という名物料理でまずは一杯。
 1	とりあえず	取り敢えず	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トリアエズ,取り敢えず,とりあえず,とりあえず,トリアエズ,,,トリアエズ,トリアエズ,取り敢えず
 2	生ビール	生ビール	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナマ;ビール,生;ビール,生;ビール,生;ビール,ナマ;ビール,;,;,ナマ;ビール,ナマビール,生ビール
@@ -5085,7 +5085,7 @@
 
 # newdoc id = test-s227
 # sent_id = test-s227
-# parallel_id = jagsdluw/test227
+# parallel_id = jagsd/test227
 # text = Tacoは1つ3ドルぐらい。
 1	Taco	Taco	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タコ,Taco,Taco,Taco,タコ,,,タコ,タコ,Taco
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5096,7 +5096,7 @@
 
 # newdoc id = test-s228
 # sent_id = test-s228
-# parallel_id = jagsdluw/test228
+# parallel_id = jagsd/test228
 # text = ゼクシィを見て、いろいろなお店に体験に行きましたが、このお店が圧倒的によかったので、通うことにしました。
 1	ゼクシィ	ゼクシィ	PROPN	名詞-固有名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼクシー,ゼクシー,ゼクシィ,ゼクシィ,ゼクシー,,,ゼクシー,ゼクシー,ゼクシー
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -5131,7 +5131,7 @@
 
 # newdoc id = test-s229
 # sent_id = test-s229
-# parallel_id = jagsdluw/test229
+# parallel_id = jagsd/test229
 # text = 私はあまりエステにお金をかけれないと思い色々なエステサロンに相談にすごく親身になって下さり他のエステさんより安心できました。
 1	私	私	PRON	代名詞	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5166,7 +5166,7 @@
 
 # newdoc id = test-s230
 # sent_id = test-s230
-# parallel_id = jagsdluw/test230
+# parallel_id = jagsd/test230
 # text = 着付けや和装ヘアスタイルが得意。
 1	着付け	着付け	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キツケ,着付け,着付け,着付け,キツケ,,,キツケ,キツケ,着付け
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -5177,7 +5177,7 @@
 
 # newdoc id = test-s231
 # sent_id = test-s231
-# parallel_id = jagsdluw/test231
+# parallel_id = jagsd/test231
 # text = スタッフの皆さんが笑顔で接してくれて、全然緊張することなく過ごせました。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフ,スタッフ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5200,7 +5200,7 @@
 
 # newdoc id = test-s232
 # sent_id = test-s232
-# parallel_id = jagsdluw/test232
+# parallel_id = jagsd/test232
 # text = デスクワークで固まった肩や背中を、アロママッサージで気持ちよくほぐしていただいて助かります。
 1	デスクワーク	デスクワーク	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デスク;ワーク,デスク;ワーク,デスク;ワーク,デスク;ワーク,デスク;ワーク,;,;,デスク;ワーク,デスクワーク,デスクワーク
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -5224,7 +5224,7 @@
 
 # newdoc id = test-s233
 # sent_id = test-s233
-# parallel_id = jagsdluw/test233
+# parallel_id = jagsd/test233
 # text = 最後まで熱々で食べれる温度管理白馬近辺でラーメンと言ったらここですかね。
 1	最後	最後	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイゴ,最後,最後,最後,サイゴ,,,サイゴ,サイゴ,最後
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -5246,7 +5246,7 @@
 
 # newdoc id = test-s234
 # sent_id = test-s234
-# parallel_id = jagsdluw/test234
+# parallel_id = jagsd/test234
 # text = 声もほとんど筒抜け状態であった。
 1	声	声	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コエ,声,声,声,コエ,,,コエ,コエ,声
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -5258,7 +5258,7 @@
 
 # newdoc id = test-s235
 # sent_id = test-s235
-# parallel_id = jagsdluw/test235
+# parallel_id = jagsd/test235
 # text = 隠れ家居酒屋という名前にぴったり。
 1	隠れ家居酒屋	隠れ家居酒屋	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カクレガ;イザカヤ,隠れ家;居酒屋,隠れ家;居酒屋,隠れ家;居酒屋,カクレガ;イザカヤ,;,;,カクレガ;イザカヤ,カクレガイザカヤ,隠れ家居酒屋
 2	という	という	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;イウ,と;言う,と;いう,と;いう,ト;イウ,;,;,ト;イウ,トイウ,という
@@ -5269,7 +5269,7 @@
 
 # newdoc id = test-s236
 # sent_id = test-s236
-# parallel_id = jagsdluw/test236
+# parallel_id = jagsd/test236
 # text = 私たちの場合、金銭に絡んだ多重債務の処理等たくさん手がけているとのことで安心して相談できました。
 1	私たち	私達	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ;タチ,私;達,私;たち,私;たち,ワタシ;タチ,;,;,ワタシ;タチ,ワタシタチ,私達
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5298,7 +5298,7 @@
 
 # newdoc id = test-s237
 # sent_id = test-s237
-# parallel_id = jagsdluw/test237
+# parallel_id = jagsd/test237
 # text = 在庫の様子がよくわからないけど、デパートの中なのでたぶん小さい。
 1	在庫	在庫	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ザイコ,在庫,在庫,在庫,ザイコ,,,ザイコ,ザイコ,在庫
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5320,7 +5320,7 @@
 
 # newdoc id = test-s238
 # sent_id = test-s238
-# parallel_id = jagsdluw/test238
+# parallel_id = jagsd/test238
 # text = 若いお客さんよりそれ相応の年代のお客が多く、落ち着いて飲めるBarです。
 1	若い	若い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワカイ,若い,若い,若い,ワカイ,,,ワカイ,ワカイ,若い
 2	お客さん	御客さん	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;キャク;サン,御;客;さん,お;客;さん,お;客;さん,オ;キャク;サン,;;,;;,オ;キャク;サン,オキャクサン,御客さん
@@ -5343,7 +5343,7 @@
 
 # newdoc id = test-s239
 # sent_id = test-s239
-# parallel_id = jagsdluw/test239
+# parallel_id = jagsd/test239
 # text = 出入り口の交差点はもともと歩行者や自転車が多いので、かなり混雑しています。
 1	出入り口	出入り口	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デイリ;クチ,出入り;口,出入り;口,出入り;口,デイリ;グチ,;,;,デイリ;クチ,デイリグチ,出入り口
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5365,7 +5365,7 @@
 
 # newdoc id = test-s240
 # sent_id = test-s240
-# parallel_id = jagsdluw/test240
+# parallel_id = jagsd/test240
 # text = 食べきれないくらい出てきました。
 1	食べきれ	食べ切れる	VERB	動詞-一般-下一段-ラ行	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タベル;キル,食べる;切る,食べ;きれ,食べる;きれる,タベ;キレ,;,;,タベル;キレル,タベキレル,食べ切れる
 2	ない	ない	AUX	助動詞-助動詞-ナイ	Polarity=Neg	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナイ,ない,ない,ない,ナイ,,,ナイ,ナイ,ない
@@ -5378,7 +5378,7 @@
 
 # newdoc id = test-s241
 # sent_id = test-s241
-# parallel_id = jagsdluw/test241
+# parallel_id = jagsd/test241
 # text = 小さいお子さんがいるお母さんには最高のお店です。
 1	小さい	小さい	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チイサイ,小さい,小さい,小さい,チーサイ,,,チイサイ,チイサイ,小さい
 2	お子さん	御子さん	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;コ;サン,御;子;さん,お;子;さん,お;子;さん,オ;コ;サン,;;,;;,オ;コ;サン,オコサン,御子さん
@@ -5395,7 +5395,7 @@
 
 # newdoc id = test-s243
 # sent_id = test-s243
-# parallel_id = jagsdluw/test243
+# parallel_id = jagsd/test243
 # text = 値段は間違えてぼられるし刺身は最悪でした
 1	値段	値段	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネダン,値段,値段,値段,ネダン,,,ネダン,ネダン,値段
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5412,7 +5412,7 @@
 
 # newdoc id = test-s244
 # sent_id = test-s244
-# parallel_id = jagsdluw/test244
+# parallel_id = jagsd/test244
 # text = ソフトバンク直営店より高く売っています
 1	ソフトバンク直営店	ソフトバンク直営店	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソフト;バンク;チョクエイ;テン,ソフト;バンク;直営;店,ソフト;バンク;直営;店,ソフト;バンク;直営;店,ソフト;バンク;チョクエー;テン,;;;,;;;,ソフト;バンク;チョクエイ;テン,ソフトバンクチョクエイテン,ソフトバンク直営店
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -5423,7 +5423,7 @@
 
 # newdoc id = test-s245
 # sent_id = test-s245
-# parallel_id = jagsdluw/test245
+# parallel_id = jagsd/test245
 # text = しかしこのフロントの女性は、結局エレベーターに乗れずに階段を下りてきた私たちに向かって、「タクシーがずーーーっと待ってますので、急いでください」と言ってきました。
 1	しかし	然し	CCONJ	接続詞	_	37	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	この	此の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
@@ -5469,7 +5469,7 @@
 
 # newdoc id = test-s246
 # sent_id = test-s246
-# parallel_id = jagsdluw/test246
+# parallel_id = jagsd/test246
 # text = ビンや缶に入っているのは糀が死んでいるのですね。
 1	ビン	瓶	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビン,瓶,ビン,ビン,ビン,,,ビン,ビン,瓶
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -5489,7 +5489,7 @@
 
 # newdoc id = test-s247
 # sent_id = test-s247
-# parallel_id = jagsdluw/test247
+# parallel_id = jagsd/test247
 # text = 大きなお店は苦手なので私にとってはアットホームな感じで楽しい時間を過ごすことができ大満足です。
 1	大きな	大きな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オオキナ,大きな,大きな,大きな,オーキナ,,,オオキナ,オオキナ,大きな
 2	お店	御店	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセ,御;店,お;店,お;店,オ;ミセ,;,;,オ;ミセ,オミセ,御店
@@ -5515,7 +5515,7 @@
 
 # newdoc id = test-s249
 # sent_id = test-s249
-# parallel_id = jagsdluw/test249
+# parallel_id = jagsd/test249
 # text = まだまだ聞きとれない単語もいっぱいですが、最近は英語を聞いてもビクッと構えることなくどんどん質問しちゃってます、
 1	まだまだ	未だ未だ	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マダマダ,未だ未だ,まだまだ,まだまだ,マダマダ,,,マダマダ,マダマダ,未だ未だ
 2	聞きとれ	聞き取れる	VERB	動詞-一般-下一段-ラ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キキトル,聞き取る,聞きとれ,聞きとれる,キキトレ,,,キキトレル,キキトレル,聞き取れる
@@ -5546,7 +5546,7 @@
 
 # newdoc id = test-s250
 # sent_id = test-s250
-# parallel_id = jagsdluw/test250
+# parallel_id = jagsd/test250
 # text = レッスンが楽しみで、何をしても長続きしない私でも、週1回きっちり通えています。
 1	レッスン	レッスン	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レッスン,レッスン,レッスン,レッスン,レッスン,,,レッスン,レッスン,レッスン
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5574,7 +5574,7 @@
 
 # newdoc id = test-s251
 # sent_id = test-s251
-# parallel_id = jagsdluw/test251
+# parallel_id = jagsd/test251
 # text = また問診についてですが、他所受診にて原因不明のままの痛みについてしばらくの間レントゲンではなくMRI検査を検討していた為、やはり検査手段について医師と相談したかったです。
 1	また	又	CCONJ	接続詞	_	32	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	問診	問診	NOUN	名詞-普通名詞-一般	_	32	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モンシン,問診,問診,問診,モンシン,,,モンシン,モンシン,問診
@@ -5615,7 +5615,7 @@
 
 # newdoc id = test-s252
 # sent_id = test-s252
-# parallel_id = jagsdluw/test252
+# parallel_id = jagsd/test252
 # text = なかなか、女性一人で、ゆっくり、休める宿は少ない、
 1	なかなか	中々	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナカナカ,中々,なかなか,なかなか,ナカナカ,,,ナカナカ,ナカナカ,中々
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5633,7 +5633,7 @@
 
 # newdoc id = test-s253
 # sent_id = test-s253
-# parallel_id = jagsdluw/test253
+# parallel_id = jagsd/test253
 # text = 高松以外のホテルエリアワンを利用したことがあり、その際にサービス、ホテルの施設などが気に入って、今回も利用させていただくことにしました。
 1	高松以外	高松以外	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タカマツ;イガイ,タカマツ;以外,高松;以外,高松;以外,タカマツ;イガイ,;,;,タカマツ;イガイ,タカマツイガイ,高松以外
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5670,7 +5670,7 @@
 
 # newdoc id = test-s254
 # sent_id = test-s254
-# parallel_id = jagsdluw/test254
+# parallel_id = jagsd/test254
 # text = 色々な飲食店が乱立する中、老舗の安定感と手軽さを兼ね揃えています。
 1	色々	色々	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イロイロ,色々,色々,色々,イロイロ,,,イロイロ,イロイロ,色々
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -5692,7 +5692,7 @@
 
 # newdoc id = test-s256
 # sent_id = test-s256
-# parallel_id = jagsdluw/test256
+# parallel_id = jagsd/test256
 # text = ただ、自分で同じような柔軟やマッサージをしてみてもうまくできないようだ。
 1	ただ	唯	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダ,唯,ただ,ただ,タダ,,,タダ,タダ,唯
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5718,7 +5718,7 @@
 
 # newdoc id = test-s257
 # sent_id = test-s257
-# parallel_id = jagsdluw/test257
+# parallel_id = jagsd/test257
 # text = 席数はあまり多くないお店だが、食事の内容には満足出来る。
 1	席数	席数	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セキスウ,席数,席数,席数,セキスー,,,セキスウ,セキスウ,席数
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5739,7 +5739,7 @@
 
 # newdoc id = test-s258
 # sent_id = test-s258
-# parallel_id = jagsdluw/test258
+# parallel_id = jagsd/test258
 # text = 整体やマッサージで良くならなかった人にもオススメします。
 1	整体	整体	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイタイ,整体,整体,整体,セータイ,,,セイタイ,セイタイ,整体
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -5758,7 +5758,7 @@
 
 # newdoc id = test-s259
 # sent_id = test-s259
-# parallel_id = jagsdluw/test259
+# parallel_id = jagsd/test259
 # text = こちらのホテルは多少の設備の古さは感じなくも無いものの、スタッフさんのサービスが普通のホテルのように行き届いています。
 1	こちら	此方	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コチラ,此方,こちら,こちら,コチラ,,,コチラ,コチラ,此方
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5793,7 +5793,7 @@
 
 # newdoc id = test-s260
 # sent_id = test-s260
-# parallel_id = jagsdluw/test260
+# parallel_id = jagsd/test260
 # text = この低料金でこの設備を提供してくれるのはありがたいですね。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	低料金	低料金	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テイ;リョウキン,低;料金,低;料金,低;料金,テー;リョーキン,;,;,テイ;リョウキン,テイリョウキン,低料金
@@ -5812,7 +5812,7 @@
 
 # newdoc id = test-s261
 # sent_id = test-s261
-# parallel_id = jagsdluw/test261
+# parallel_id = jagsd/test261
 # text = 仕事に疲れてフラフラでチェックインしても、フロントの方をはじめホテルのスタッフの方々が気持ちのいい対応をしてくれるので、泊まりに行きたくなります。
 1	仕事	仕事	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シゴト,仕事,仕事,仕事,シゴト,,,シゴト,シゴト,仕事
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -5853,7 +5853,7 @@
 
 # newdoc id = test-s262
 # sent_id = test-s262
-# parallel_id = jagsdluw/test262
+# parallel_id = jagsd/test262
 # text = 値段相応といえばそれまでですが、風呂が狭いことだけが残念。
 1	値段相応	値段相応	ADJ	形状詞-一般	_	3	ccomp	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネダン;ソウオウ,値段;相応,値段;相応,値段;相応,ネダン;ソーオー,;,;,ネダン;ソウオウ,ネダンソウオウ,値段相応
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -5875,7 +5875,7 @@
 
 # newdoc id = test-s263
 # sent_id = test-s263
-# parallel_id = jagsdluw/test263
+# parallel_id = jagsd/test263
 # text = 従業員の方々もいつも暖かく送り出してくれるので、私が千葉で宿泊するホテルはここできまりです。
 1	従業員	従業員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウギョウ;イン,従業;員,従業;員,従業;員,ジューギョー;イン,;,;,ジュウギョウ;イン,ジュウギョウイン,従業員
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5903,7 +5903,7 @@
 
 # newdoc id = test-s264
 # sent_id = test-s264
-# parallel_id = jagsdluw/test264
+# parallel_id = jagsd/test264
 # text = ビジネスマンに対しての細かいところにまで気を配ったサービスがありがたく、ネットにキッチンにランドリーまで使えてこのお値段というのは安いと思います。
 1	ビジネスマン	ビジネスマン	NOUN	名詞-普通名詞-一般	_	12	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビジネスマン,ビジネスマン,ビジネスマン,ビジネスマン,ビジネスマン,,,ビジネスマン,ビジネスマン,ビジネスマン
 2	に対して	に対して	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;タイスル;テ,に;対する;て,に;対し;て,に;対する;て,ニ;タイシ;テ,;;,;;,ニ;タイスル;テ,ニタイシテ,に対して
@@ -5941,7 +5941,7 @@
 
 # newdoc id = test-s265
 # sent_id = test-s265
-# parallel_id = jagsdluw/test265
+# parallel_id = jagsd/test265
 # text = 初めて宿泊したのですが、はじめてに感じない、そんなアットホームな雰囲気もあるホテルでした。
 1	初めて	初めて	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハジメテ,初めて,初めて,初めて,ハジメテ,,,ハジメテ,ハジメテ,初めて
 2	宿泊し	宿泊する	VERB	動詞-一般-サ行変格	_	18	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュクハク;スル,宿泊;為る,宿泊;し,宿泊;する,シュクハク;シ,;,;,シュクハク;スル,シュクハクスル,宿泊する
@@ -5967,7 +5967,7 @@
 
 # newdoc id = test-s266
 # sent_id = test-s266
-# parallel_id = jagsdluw/test266
+# parallel_id = jagsd/test266
 # text = ですがほかのブックオフの中型店では多くの店員を雇うと教育がされておらず、私語がうるさいと店員はそちらを向くと、なんと店員がおしゃべりしていた。
 1	ですが	ですが	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デス;ガ,です;が,です;が,です;が,デス;ガ,;,;,デス;ガ,デスガ,ですが
 2	ほか	他	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
@@ -6011,7 +6011,7 @@
 
 # newdoc id = test-s267
 # sent_id = test-s267
-# parallel_id = jagsdluw/test267
+# parallel_id = jagsd/test267
 # text = もう少し早い時間に営業していると嬉しいですが、お店のスタンスはgoodです。
 1	もう	もう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モウ,もう,もう,もう,モー,,,モウ,モウ,もう
 2	少し	少し	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スコシ,少し,少し,少し,スコシ,,,スコシ,スコシ,少し
@@ -6035,7 +6035,7 @@
 
 # newdoc id = test-s269
 # sent_id = test-s269
-# parallel_id = jagsdluw/test269
+# parallel_id = jagsd/test269
 # text = あまり期待していなかったのに結構な額になったのでとてもうれしかったです。
 1	あまり	余り	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アマリ,余り,あまり,あまり,アマリ,,,アマリ,アマリ,余り
 2	期待し	期待する	VERB	動詞-一般-サ行変格	_	12	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キタイ;スル,期待;為る,期待;し,期待;する,キタイ;シ,;,;,キタイ;スル,キタイスル,期待する
@@ -6059,7 +6059,7 @@
 
 # newdoc id = test-s270
 # sent_id = test-s270
-# parallel_id = jagsdluw/test270
+# parallel_id = jagsd/test270
 # text = 西友の中にあり、入りやすい雰囲気なので、初めての方にもオススメできます。
 1	西友	西友	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイユウ,西友,西友,西友,セーユー,,,セイユウ,セイユウ,西友
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6083,7 +6083,7 @@
 
 # newdoc id = test-s271
 # sent_id = test-s271
-# parallel_id = jagsdluw/test271
+# parallel_id = jagsd/test271
 # text = リーズナブルな価格、味は勿論のこと、若いマスター夫婦の温かい雰囲気についつい長居してしまいます。
 1	リーズナブル	リーズナブル	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リーズナブル,リーズナブル,リーズナブル,リーズナブル,リーズナブル,,,リーズナブル,リーズナブル,リーズナブル
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -6109,7 +6109,7 @@
 
 # newdoc id = test-s272
 # sent_id = test-s272
-# parallel_id = jagsdluw/test272
+# parallel_id = jagsd/test272
 # text = 姫路の良く行く美容室でしたっ
 1	姫路	姫路	PROPN	名詞-固有名詞-地名-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒメジ,ヒメジ,姫路,姫路,ヒメジ,,,ヒメジ,ヒメジ,姫路
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6122,7 +6122,7 @@
 
 # newdoc id = test-s273
 # sent_id = test-s273
-# parallel_id = jagsdluw/test273
+# parallel_id = jagsd/test273
 # text = 感じのいいスタッフさんなので安心して通えます。
 1	感じ	感じ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンジ,感じ,感じ,感じ,カンジ,,,カンジ,カンジ,感じ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6138,7 +6138,7 @@
 
 # newdoc id = test-s274
 # sent_id = test-s274
-# parallel_id = jagsdluw/test274
+# parallel_id = jagsd/test274
 # text = 駐車場はあるものの立体駐車場で出入りに時間がかかり、6号と14号の交差点前で交通量が多くかつ駅前直結なため常に混雑しており、事実上地元の人以外のアクセスは辛いです。
 1	駐車場	駐車場	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウシャ;ジョウ,駐車;場,駐車;場,駐車;場,チューシャ;ジョー,;,;,チュウシャ;ジョウ,チュウシャジョウ,駐車場
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6183,7 +6183,7 @@
 
 # newdoc id = test-s275
 # sent_id = test-s275
-# parallel_id = jagsdluw/test275
+# parallel_id = jagsd/test275
 # text = テキストもとても分かりやすいですし、旅行やホームステイに使える英語を勉強、練習できるので大変気に入っております。
 1	テキスト	テキスト	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テキスト,テキスト,テキスト,テキスト,テキスト,,,テキスト,テキスト,テキスト
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -6213,7 +6213,7 @@
 
 # newdoc id = test-s276
 # sent_id = test-s276
-# parallel_id = jagsdluw/test276
+# parallel_id = jagsd/test276
 # text = 小さいお店なので常連さん優先なのは仕方がないですね。
 1	小さい	小さい	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チイサイ,小さい,小さい,小さい,チーサイ,,,チイサイ,チイサイ,小さい
 2	お店	御店	NOUN	名詞-普通名詞-一般	_	9	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;ミセ,御;店,お;店,お;店,オ;ミセ,;,;,オ;ミセ,オミセ,御店
@@ -6232,7 +6232,7 @@
 
 # newdoc id = test-s277
 # sent_id = test-s277
-# parallel_id = jagsdluw/test277
+# parallel_id = jagsd/test277
 # text = 振袖はかなり豊富で流行りのトレンド着物からベーシックなものまで色々とありました。
 1	振袖	振り袖	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フリソデ,振り袖,振袖,振袖,フリソデ,,,フリソデ,フリソデ,振り袖
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6256,7 +6256,7 @@
 
 # newdoc id = test-s278
 # sent_id = test-s278
-# parallel_id = jagsdluw/test278
+# parallel_id = jagsd/test278
 # text = つけ麺の王様は間違いなくここ。
 1	つけ麺	付け麺	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツケメン,付け麺,つけ麺,つけ麺,ツケメン,,,ツケメン,ツケメン,付け麺
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6268,7 +6268,7 @@
 
 # newdoc id = test-s279
 # sent_id = test-s279
-# parallel_id = jagsdluw/test279
+# parallel_id = jagsd/test279
 # text = 袋や箱が、簡素で格好いいと思います。
 1	袋	袋	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フクロ,袋,袋,袋,フクロ,,,フクロ,フクロ,袋
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -6285,7 +6285,7 @@
 
 # newdoc id = test-s280
 # sent_id = test-s280
-# parallel_id = jagsdluw/test280
+# parallel_id = jagsd/test280
 # text = 味が少し濃いかなぁ。
 1	味	味	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アジ,味,味,味,アジ,,,アジ,アジ,味
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6297,7 +6297,7 @@
 
 # newdoc id = test-s281
 # sent_id = test-s281
-# parallel_id = jagsdluw/test281
+# parallel_id = jagsd/test281
 # text = 院長と話をしたところ、腰痛治療も得意なようです。
 1	院長	院長	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=インチョウ,院長,院長,院長,インチョー,,,インチョウ,インチョウ,院長
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -6316,7 +6316,7 @@
 
 # newdoc id = test-s282
 # sent_id = test-s282
-# parallel_id = jagsdluw/test282
+# parallel_id = jagsd/test282
 # text = お客さんはガヤガヤしたところがイヤな方はいいかもしれません。
 1	お客さん	御客さん	NOUN	名詞-普通名詞-一般	_	11	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オ;キャク;サン,御;客;さん,お;客;さん,お;客;さん,オ;キャク;サン,;;,;;,オ;キャク;サン,オキャクサン,御客さん
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6334,7 +6334,7 @@
 
 # newdoc id = test-s284
 # sent_id = test-s284
-# parallel_id = jagsdluw/test284
+# parallel_id = jagsd/test284
 # text = 石川悦男元党首は,宗教法人の総本山に異動となりました。
 1	石川悦男元党首	石川悦男元党首	PROPN	名詞-固有名詞-人名-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イシカワ;エツオ;モト;トウシュ,イシカワ;エツオ;元;党首,石川;悦男;元;党首,石川;悦男;元;党首,イシカワ;エツオ;モト;トーシュ,;;;,;;;,イシカワ;エツオ;モト;トウシュ,イシカワエツオモトトウシュ,石川悦男元党首
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6352,7 +6352,7 @@
 
 # newdoc id = test-s285
 # sent_id = test-s285
-# parallel_id = jagsdluw/test285
+# parallel_id = jagsd/test285
 # text = おいしいと聞いてただけに姉には申し訳なくてホントに最悪です
 1	おいしい	美味しい	ADJ	形容詞-一般-形容詞	_	3	ccomp	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オイシイ,美味しい,おいしい,おいしい,オイシー,,,オイシイ,オイシイ,美味しい
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -6373,7 +6373,7 @@
 
 # newdoc id = test-s286
 # sent_id = test-s286
-# parallel_id = jagsdluw/test286
+# parallel_id = jagsd/test286
 # text = セレファイスの主神。
 1	セレファイス	セレファイス	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セレファイス,セレファイス,セレファイス,セレファイス,セレファイス,,,セレファイス,セレファイス,セレファイス
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6382,7 +6382,7 @@
 
 # newdoc id = test-s287
 # sent_id = test-s287
-# parallel_id = jagsdluw/test287
+# parallel_id = jagsd/test287
 # text = 一郎の妻。
 1	一郎	一郎	PROPN	名詞-固有名詞-人名-名	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチロウ,イチロウ,一郎,一郎,イチロー,,,イチロウ,イチロウ,一郎
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6391,7 +6391,7 @@
 
 # newdoc id = test-s288
 # sent_id = test-s288
-# parallel_id = jagsdluw/test288
+# parallel_id = jagsd/test288
 # text = なお、冬期には山腹にスポットライトで雪だるまが描かれる。
 1	なお	猶	CCONJ	接続詞	_	12	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6410,7 +6410,7 @@
 
 # newdoc id = test-s289
 # sent_id = test-s289
-# parallel_id = jagsdluw/test289
+# parallel_id = jagsd/test289
 # text = この建物は、初めオフィスとして用いられたが、1909年からは市庁舎として利用された。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	建物	建物	NOUN	名詞-普通名詞-一般	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タテモノ,建物,建物,建物,タテモノ,,,タテモノ,タテモノ,建物
@@ -6436,7 +6436,7 @@
 
 # newdoc id = test-s290
 # sent_id = test-s290
-# parallel_id = jagsdluw/test290
+# parallel_id = jagsd/test290
 # text = 誕生日10月16日。
 1	誕生日	誕生日	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=タンジョウ;ヒ,誕生;日,誕生;日,誕生;日,タンジョー;ビ,;,;,タンジョウ;ヒ,タンジョウビ,誕生日
 2	10月	10月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ジュウ;ガツ,十;月,10;月,10;月,ジュー;ガツ,;,;,ジュウ;ガツ,ジュウガツ,10月
@@ -6445,7 +6445,7 @@
 
 # newdoc id = test-s291
 # sent_id = test-s291
-# parallel_id = jagsdluw/test291
+# parallel_id = jagsd/test291
 # text = また、先生方をサポートする人材の育成、教員養成のあり方を詰めていく必要がある。
 1	また	又	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6469,7 +6469,7 @@
 
 # newdoc id = test-s292
 # sent_id = test-s292
-# parallel_id = jagsdluw/test292
+# parallel_id = jagsd/test292
 # text = 事件が朝刊各版の締め切り間際に立て続けに起こったため、各新聞は配達先によって記事内容が一部異なっている。
 1	事件	事件	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジケン,事件,事件,事件,ジケン,,,ジケン,ジケン,事件
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6496,7 +6496,7 @@
 
 # newdoc id = test-s293
 # sent_id = test-s293
-# parallel_id = jagsdluw/test293
+# parallel_id = jagsd/test293
 # text = 番外編に登場。
 1	番外編	番外編	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バンガイ;ヘン,番外;編,番外;編,番外;編,バンガイ;ヘン,;,;,バンガイ;ヘン,バンガイヘン,番外編
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6505,7 +6505,7 @@
 
 # newdoc id = test-s295
 # sent_id = test-s295
-# parallel_id = jagsdluw/test295
+# parallel_id = jagsd/test295
 # text = 最高なお店で毎回感動しています。
 1	最高	最高	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイコウ,最高,最高,最高,サイコー,,,サイコウ,サイコウ,最高
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -6519,7 +6519,7 @@
 
 # newdoc id = test-s296
 # sent_id = test-s296
-# parallel_id = jagsdluw/test296
+# parallel_id = jagsd/test296
 # text = 自分でも趣味で料理をするもので一層感心することが多いのです。
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -6541,7 +6541,7 @@
 
 # newdoc id = test-s297
 # sent_id = test-s297
-# parallel_id = jagsdluw/test297
+# parallel_id = jagsd/test297
 # text = 1967年『シラノ・ド・ベルジュラック』で初舞台。
 1	1967年	1967年	NUM	名詞-数詞	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;キュウ;ロク;シチ;ネン,一;九;六;七;年,1;9;6;7;年,1;9;6;7;年,イチ;キュー;ロク;シチ;ネン,;;;;,;;;;,イチ;キュウ;ロク;シチ;ネン,イチキュウロクシチネン,1967年
 2	『	『	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
@@ -6553,7 +6553,7 @@
 
 # newdoc id = test-s298
 # sent_id = test-s298
-# parallel_id = jagsdluw/test298
+# parallel_id = jagsd/test298
 # text = 人間の体は何百万年前からそのことを知っていて、体の中にウイルス等の外敵が侵入してくると、彼らと戦うために脳から全身の細胞に指令を出して熱を出しているそうです。
 1	人間	人間	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニンゲン,人間,人間,人間,ニンゲン,,,ニンゲン,ニンゲン,人間
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6604,7 +6604,7 @@
 
 # newdoc id = test-s299
 # sent_id = test-s299
-# parallel_id = jagsdluw/test299
+# parallel_id = jagsd/test299
 # text = 東京にあるハイパーコンサルティング・ジャパンさんでは、パニック障害解消プログラムを組んでカウンセリングを実施しています。
 1	東京	東京	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウキョウ,トウキョウ,東京,東京,トーキョー,,,トウキョウ,トウキョウ,東京
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6626,7 +6626,7 @@
 
 # newdoc id = test-s300
 # sent_id = test-s300
-# parallel_id = jagsdluw/test300
+# parallel_id = jagsd/test300
 # text = 公称身長156cm。
 1	公称身長	公称身長	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=コウショウ;シンチョウ,公称;身長,公称;身長,公称;身長,コーショー;シンチョー,;,;,コウショウ;シンチョウ,コウショウシンチョウ,公称身長
 2	156cm	156cm	NUM	名詞-数詞	_	0	root	_	BunsetuBILabel=I|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=イチ;ゴ;ロク;センチメートル,一;五;六;センチメートル,1;5;6;cm,1;5;6;cm,イチ;ゴ;ロク;センチメートル,;;;,;;;,イチ;ゴ;ロク;センチメートル,イチゴロクセンチメートル,156cm
@@ -6634,7 +6634,7 @@
 
 # newdoc id = test-s301
 # sent_id = test-s301
-# parallel_id = jagsdluw/test301
+# parallel_id = jagsd/test301
 # text = また,木村党首が“参院選の目玉政策”として掲げたのが,“参議院の廃止”。
 1	また	又	CCONJ	接続詞	_	19	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -6660,7 +6660,7 @@
 
 # newdoc id = test-s302
 # sent_id = test-s302
-# parallel_id = jagsdluw/test302
+# parallel_id = jagsd/test302
 # text = ボルバキアという共生細菌がいないと正常な成長や繁殖が困難であることが研究で明らかにされた。
 1	ボルバキア	ボルバキア	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ボルバキア,ボルバキア,ボルバキア,ボルバキア,ボルバキア,,,ボルバキア,ボルバキア,ボルバキア
 2	という	という	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;イウ,と;言う,と;いう,と;いう,ト;イウ,;,;,ト;イウ,トイウ,という
@@ -6690,7 +6690,7 @@
 
 # newdoc id = test-s303
 # sent_id = test-s303
-# parallel_id = jagsdluw/test303
+# parallel_id = jagsd/test303
 # text = 2007年9月5日発売。
 1	2007年	2007年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;シチ;ネン,二;ゼロ;ゼロ;七;年,2;0;0;7;年,2;0;0;7;年,ニ;ゼロ;ゼロ;シチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;シチ;ネン,ニゼロゼロシチネン,2007年
 2	9月	9月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ク;ガツ,九;月,9;月,9;月,ク;ガツ,;,;,ク;ガツ,クガツ,9月
@@ -6699,7 +6699,7 @@
 
 # newdoc id = test-s304
 # sent_id = test-s304
-# parallel_id = jagsdluw/test304
+# parallel_id = jagsd/test304
 # text = 文書をどのようにファイルするか。
 1	文書	文書	NOUN	名詞-普通名詞-一般	_	6	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ブンショ,文書,文書,文書,ブンショ,,,ブンショ,ブンショ,文書
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6712,7 +6712,7 @@
 
 # newdoc id = test-s305
 # sent_id = test-s305
-# parallel_id = jagsdluw/test305
+# parallel_id = jagsd/test305
 # text = そのほかアダナ近郊のシルケリ・ホユックでは彼の名が刻まれた摩崖碑文が発見されているが、こうした屋外のヒッタイト碑文としては最古の例とされる。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ほか	他	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
@@ -6753,7 +6753,7 @@
 
 # newdoc id = test-s306
 # sent_id = test-s306
-# parallel_id = jagsdluw/test306
+# parallel_id = jagsd/test306
 # text = 次のカットまでのスタイリングも「パパッ」と出来てしまいます。
 1	次	次	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツギ,次,次,次,ツギ,,,ツギ,ツギ,次
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6773,7 +6773,7 @@
 
 # newdoc id = test-s307
 # sent_id = test-s307
-# parallel_id = jagsdluw/test307
+# parallel_id = jagsd/test307
 # text = 独立して活動する弦楽四重奏団としては日本で最も実績を重ねている団体の一つ。
 1	独立し	独立する	VERB	動詞-一般-サ行変格	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドクリツ;スル,独立;為る,独立;し,独立;する,ドクリツ;シ,;,;,ドクリツ;スル,ドクリツスル,独立する
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -6796,7 +6796,7 @@
 
 # newdoc id = test-s308
 # sent_id = test-s308
-# parallel_id = jagsdluw/test308
+# parallel_id = jagsd/test308
 # text = そののち、連隊はレンドリースにより供与されたボストンに装備を変更した。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	のち	後	NOUN	名詞-普通名詞-一般	_	15	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノチ,後,のち,のち,ノチ,,,ノチ,ノチ,後
@@ -6818,14 +6818,14 @@
 
 # newdoc id = test-s309
 # sent_id = test-s309
-# parallel_id = jagsdluw/test309
+# parallel_id = jagsd/test309
 # text = Ciao!
 1	Ciao	Ciao	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=チャオ,チャオ,Ciao,Ciao,チャオ,,,チャオ,チャオ,Ciao
 2	!	!	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,！,!,!,,,,,,！
 
 # newdoc id = test-s310
 # sent_id = test-s310
-# parallel_id = jagsdluw/test310
+# parallel_id = jagsd/test310
 # text = ジェリーとリズは恋仲になるが、アンリはリズと結婚しようとしていた。
 1	ジェリー	ジェリー	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジェリー,ジェリー,ジェリー,ジェリー,ジェリー,,,ジェリー,ジェリー,ジェリー
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -6849,7 +6849,7 @@
 
 # newdoc id = test-s311
 # sent_id = test-s311
-# parallel_id = jagsdluw/test311
+# parallel_id = jagsd/test311
 # text = また、奴隷貿易の対象ではなく宗教上のライバルであった北アフリカのイスラム諸国は、19世紀には宗主国オスマン帝国の影響力が衰え、自立した群小政権もヨーロッパ勢力の経済的・軍事的な発展に対してほとんど為す術がないほど弱体化していた。
 1	また	又	CCONJ	接続詞	_	42	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6899,7 +6899,7 @@
 
 # newdoc id = test-s312
 # sent_id = test-s312
-# parallel_id = jagsdluw/test312
+# parallel_id = jagsd/test312
 # text = 実際に万全ではなかったり手を抜いている時以外の、真弥が本気で戦った戦闘では必ずその相手に圧勝している。
 1	実際	実際	NOUN	名詞-普通名詞-一般	_	26	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジッサイ,実際,実際,実際,ジッサイ,,,ジッサイ,ジッサイ,実際
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6932,7 +6932,7 @@
 
 # newdoc id = test-s313
 # sent_id = test-s313
-# parallel_id = jagsdluw/test313
+# parallel_id = jagsd/test313
 # text = ただし完全に外海から隔てられたものはほとんどなく、ごく狭い海峡により外海とつながっているものが多い。
 1	ただし	但し	CCONJ	接続詞	_	24	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	完全	完全	ADJ	形状詞-一般	_	6	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンゼン,完全,完全,完全,カンゼン,,,カンゼン,カンゼン,完全
@@ -6962,7 +6962,7 @@
 
 # newdoc id = test-s314
 # sent_id = test-s314
-# parallel_id = jagsdluw/test314
+# parallel_id = jagsd/test314
 # text = 以下は「表向き」を好むと答えた人間の割合である。
 1	以下	以下	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イカ,以下,以下,以下,イカ,,,イカ,イカ,以下
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6982,7 +6982,7 @@
 
 # newdoc id = test-s315
 # sent_id = test-s315
-# parallel_id = jagsdluw/test315
+# parallel_id = jagsd/test315
 # text = バトルに敗北するとどうなるかは作品ごとに決められている。
 1	バトル	バトル	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バトル,バトル,バトル,バトル,バトル,,,バトル,バトル,バトル
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7001,7 +7001,7 @@
 
 # newdoc id = test-s316
 # sent_id = test-s316
-# parallel_id = jagsdluw/test316
+# parallel_id = jagsd/test316
 # text = 通常この協議は1〜4年かかるとされている。
 1	通常	通常	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ツウジョウ,通常,通常,通常,ツージョー,,,ツウジョウ,ツウジョウ,通常
 2	この	此の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
@@ -7017,7 +7017,7 @@
 
 # newdoc id = test-s317
 # sent_id = test-s317
-# parallel_id = jagsdluw/test317
+# parallel_id = jagsd/test317
 # text = ひびの入ったパネル。
 1	ひび	皹	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒビ,皹,ひび,ひび,ヒビ,,,ヒビ,ヒビ,皹
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7028,7 +7028,7 @@
 
 # newdoc id = test-s318
 # sent_id = test-s318
-# parallel_id = jagsdluw/test318
+# parallel_id = jagsd/test318
 # text = 昨日も仲間8人で楽しくおいしくいただきました。
 1	昨日	昨日	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キノウ,昨日,昨日,昨日,キノー,,,キノウ,キノウ,昨日
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -7044,7 +7044,7 @@
 
 # newdoc id = test-s319
 # sent_id = test-s319
-# parallel_id = jagsdluw/test319
+# parallel_id = jagsd/test319
 # text = デビュー当時からテレビにはほとんど出演しないが、CS放送には出演したことがある。
 1	デビュー当時	デビュー当時	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デビュー;トウジ,デビュー;当時,デビュー;当時,デビュー;当時,デビュー;トージ,;,;,デビュー;トウジ,デビュートウジ,デビュー当時
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -7066,7 +7066,7 @@
 
 # newdoc id = test-s320
 # sent_id = test-s320
-# parallel_id = jagsdluw/test320
+# parallel_id = jagsd/test320
 # text = 祖国を侵略者ベトナムから解放するその一点で闘う少年兵,少女兵の笑顔にまさるものはない。
 1	祖国	祖国	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソコク,祖国,祖国,祖国,ソコク,,,ソコク,ソコク,祖国
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7091,7 +7091,7 @@
 
 # newdoc id = test-s321
 # sent_id = test-s321
-# parallel_id = jagsdluw/test321
+# parallel_id = jagsd/test321
 # text = しかし取材していても,特定のイデオロギーや党派組織の影響を感じません。
 1	しかし	然し	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	取材し	取材する	VERB	動詞-一般-サ行変格	_	15	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュザイ;スル,取材;為る,取材;し,取材;する,シュザイ;シ,;,;,シュザイ;スル,シュザイスル,取材する
@@ -7114,7 +7114,7 @@
 
 # newdoc id = test-s322
 # sent_id = test-s322
-# parallel_id = jagsdluw/test322
+# parallel_id = jagsd/test322
 # text = エレクトロウェッティングは既存の液晶ディスプレイ生産ラインに変更を加えれば製造できるという。
 1	エレクトロウェッティング	エレクトロウェッティング	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エレクトロウェッティング,エレクトロウェッティング,エレクトロウェッティング,エレクトロウェッティング,エレクトローェッティング,,,エレクトロウェッティング,エレクトロウェッティング,エレクトロウェッティング
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7133,7 +7133,7 @@
 
 # newdoc id = test-s323
 # sent_id = test-s323
-# parallel_id = jagsdluw/test323
+# parallel_id = jagsd/test323
 # text = しかし、ルートによっては悠弥と結婚することになり、彼女のルートでは全ヒロイン中、ハッピーエンドを迎える。
 1	しかし	然し	CCONJ	接続詞	_	20	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7159,7 +7159,7 @@
 
 # newdoc id = test-s324
 # sent_id = test-s324
-# parallel_id = jagsdluw/test324
+# parallel_id = jagsd/test324
 # text = 今後,この様な問題の発生を防止する為,国家は厳しい規制を考える必要がある。
 1	今後	今後	ADV	副詞	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンゴ,今後,今後,今後,コンゴ,,,コンゴ,コンゴ,今後
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -7186,7 +7186,7 @@
 
 # newdoc id = test-s325
 # sent_id = test-s325
-# parallel_id = jagsdluw/test325
+# parallel_id = jagsd/test325
 # text = 会社がお世話をしてくれなかったので自分で探したのですが、価格的にも割と負担のすくないこちらのマンスリーマンションを借りることになりました。
 1	会社	会社	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイシャ,会社,会社,会社,カイシャ,,,カイシャ,カイシャ,会社
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7223,7 +7223,7 @@
 
 # newdoc id = test-s326
 # sent_id = test-s326
-# parallel_id = jagsdluw/test326
+# parallel_id = jagsd/test326
 # text = 野田佳彦首相は12月に中国を訪問する方向で最終調整に入った。
 1	野田佳彦首相	野田佳彦首相	PROPN	名詞-固有名詞-人名-一般	_	12	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノダ;ヨシヒコ;シュショウ,ノダ;ヨシヒコ;首相,野田;佳彦;首相,野田;佳彦;首相,ノダ;ヨシヒコ;シュショー,;;,;;,ノダ;ヨシヒコ;シュショウ,ノダヨシヒコシュショウ,野田佳彦首相
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7242,7 +7242,7 @@
 
 # newdoc id = test-s327
 # sent_id = test-s327
-# parallel_id = jagsdluw/test327
+# parallel_id = jagsd/test327
 # text = 第1期終了後、素顔を晒して謎のレスラー「キャプテン・モロー」として過ごし、チャンピオンにまでなっていた。
 1	第1期終了後	第1期終了後	ADV	副詞	_	11	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;イチ;キ;シュウリョウ;ゴ,第;一;期;終了;後,第;1;期;終了;後,第;1;期;終了;後,ダイ;イッ;キ;シューリョー;ゴ,;;;;,;;;;,ダイ;イチ;キ;シュウリョウ;ゴ,ダイイッキシュウリョウゴ,第1期終了後
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7266,7 +7266,7 @@
 
 # newdoc id = test-s328
 # sent_id = test-s328
-# parallel_id = jagsdluw/test328
+# parallel_id = jagsd/test328
 # text = 管轄する修道院がそもそも日本に存在しなかったのに、日本に正教会を伝えた亜使徒聖ニコライが日本伝道初期に掌院に昇叙されたことはその好例である。
 1	管轄する	管轄する	VERB	動詞-一般-サ行変格	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンカツ;スル,管轄;為る,管轄;する,管轄;する,カンカツ;スル,;,;,カンカツ;スル,カンカツスル,管轄する
 2	修道院	修道院	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウドウ;イン,修道;院,修道;院,修道;院,シュードー;イン,;,;,シュウドウ;イン,シュウドウイン,修道院
@@ -7304,7 +7304,7 @@
 
 # newdoc id = test-s329
 # sent_id = test-s329
-# parallel_id = jagsdluw/test329
+# parallel_id = jagsd/test329
 # text = ガッローネは出資をあまり大規模に行なわず、マロッタと監督の手腕にすべてをゆだねている。
 1	ガッローネ	ガッローネ	PROPN	名詞-固有名詞-人名-一般	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ガッローネ,ガッローネ,ガッローネ,ガッローネ,ガッローネ,,,ガッローネ,ガッローネ,ガッローネ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7330,7 +7330,7 @@
 
 # newdoc id = test-s330
 # sent_id = test-s330
-# parallel_id = jagsdluw/test330
+# parallel_id = jagsd/test330
 # text = 上記の理由で当時はさほど売り上げにつながらなかったが、1990年代後半以降、業務用・家庭用ゲームでこれと似た体感ゲームが登場してきている。
 1	上記	上記	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョウキ,上記,上記,上記,ジョーキ,,,ジョウキ,ジョウキ,上記
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7363,7 +7363,7 @@
 
 # newdoc id = test-s331
 # sent_id = test-s331
-# parallel_id = jagsdluw/test331
+# parallel_id = jagsd/test331
 # text = その姿は見る者によって異なり、洋子には幼い頃の自分に見えた。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	姿	姿	NOUN	名詞-普通名詞-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スガタ,姿,姿,姿,スガタ,,,スガタ,スガタ,姿
@@ -7387,7 +7387,7 @@
 
 # newdoc id = test-s332
 # sent_id = test-s332
-# parallel_id = jagsdluw/test332
+# parallel_id = jagsd/test332
 # text = 事件の原因が新健康協会の教義にあったことは判決が認定しているようですし,裁判員の言葉の通り両親が子どもに対して“一生懸命愛情を持って接していた”のであれば,その愛情を間違った方向に走らせてしまった新健康協会は,なおのこと危険な団体であるということになります。
 1	事件	事件	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジケン,事件,事件,事件,ジケン,,,ジケン,ジケン,事件
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7459,7 +7459,7 @@
 
 # newdoc id = test-s333
 # sent_id = test-s333
-# parallel_id = jagsdluw/test333
+# parallel_id = jagsd/test333
 # text = クロアチアは、アドリア海のイタリアとの中間線よりクロアチア側に、排他的経済水域を設定することを計画している。
 1	クロアチア	クロアチア	PROPN	名詞-固有名詞-地名-国	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クロアチア,クロアチア,クロアチア,クロアチア,クロアチア,,,クロアチア,クロアチア,クロアチア
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7485,7 +7485,7 @@
 
 # newdoc id = test-s334
 # sent_id = test-s334
-# parallel_id = jagsdluw/test334
+# parallel_id = jagsd/test334
 # text = 復興基本計画は、昭和20年から21年にかけて、市の関係部局や学識経験者、市民代表により復興計画に関する委員会で決定され、狭い市域に多くの人口を収容するために商工業・中小企業を発展させることを基本方針にし、区画整理の実施を幹線道路の整備による経済活動の円滑化とこれまで不足していた公園緑地の確保による都市美化、従来の不規則な街区整理を目的に、着実に着工する。
 1	復興基本計画	復興基本計画	NOUN	名詞-普通名詞-一般	_	24	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フッコウ;キホン;ケイカク,復興;基本;計画,復興;基本;計画,復興;基本;計画,フッコー;キホン;ケーカク,;;,;;,フッコウ;キホン;ケイカク,フッコウキホンケイカク,復興基本計画
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7571,7 +7571,7 @@
 
 # newdoc id = test-s335
 # sent_id = test-s335
-# parallel_id = jagsdluw/test335
+# parallel_id = jagsd/test335
 # text = 土曜日の夜、仕事帰りに一人でふらりと立ち寄りました。
 1	土曜日	土曜日	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドヨウ;ヒ,土曜;日,土曜;日,土曜;日,ドヨー;ビ,;,;,ドヨウ;ヒ,ドヨウビ,土曜日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7589,7 +7589,7 @@
 
 # newdoc id = test-s336
 # sent_id = test-s336
-# parallel_id = jagsdluw/test336
+# parallel_id = jagsd/test336
 # text = 最高裁の御威光によって,文科省の判断が“違法”認定。
 1	最高裁	最高裁	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サイコウ;サイ,最高;裁,最高;裁,最高;裁,サイコー;サイ,;,;,サイコウ;サイ,サイコウサイ,最高裁
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7606,7 +7606,7 @@
 
 # newdoc id = test-s337
 # sent_id = test-s337
-# parallel_id = jagsdluw/test337
+# parallel_id = jagsd/test337
 # text = 2009年地方競馬通算900勝達成。
 1	2009年地方競馬通算	2009年地方競馬通算	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;キュウ;ネン;チホウ;ケイバ;ツウサン,二;ゼロ;ゼロ;九;年;地方;競馬;通算,2;0;0;9;年;地方;競馬;通算,2;0;0;9;年;地方;競馬;通算,ニ;ゼロ;ゼロ;キュー;ネン;チホー;ケーバ;ツーサン,;;;;;;;,;;;;;;;,ニ;ゼロ;ゼロ;キュウ;ネン;チホウ;ケイバ;ツウサン,ニゼロゼロキュウネンチホウケイバツウサン,2009年地方競馬通算
 2	900勝達成	900勝達成	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=I|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=キュウヒャク;ショウ;タッセイ,九百;勝;達成,900;勝;達成,900;勝;達成,キューヒャク;ショー;タッセー,;;,;;,キュウヒャク;ショウ;タッセイ,キュウヒャクショウタッセイ,900勝達成
@@ -7614,7 +7614,7 @@
 
 # newdoc id = test-s338
 # sent_id = test-s338
-# parallel_id = jagsdluw/test338
+# parallel_id = jagsd/test338
 # text = エジプト情勢緊迫化の影響が国際商品市況へ波及し、世界景気に悪影響を及ぼす可能性が警戒された。
 1	エジプト情勢緊迫化	エジプト情勢緊迫化	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エジプト;ジョウセイ;キンパク;カ,エジプト;情勢;緊迫;化,エジプト;情勢;緊迫;化,エジプト;情勢;緊迫;化,エジプト;ジョーセー;キンパク;カ,;;;,;;;,エジプト;ジョウセイ;キンパク;カ,エジプトジョウセイキンパクカ,エジプト情勢緊迫化
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7638,7 +7638,7 @@
 
 # newdoc id = test-s339
 # sent_id = test-s339
-# parallel_id = jagsdluw/test339
+# parallel_id = jagsd/test339
 # text = 漫画『DEATH NOTE』のパロディ。
 1	漫画	漫画	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マンガ,漫画,漫画,漫画,マンガ,,,マンガ,マンガ,漫画
 2	『	『	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
@@ -7650,7 +7650,7 @@
 
 # newdoc id = test-s340
 # sent_id = test-s340
-# parallel_id = jagsdluw/test340
+# parallel_id = jagsd/test340
 # text = すごろくを基本にしたゲームで、ドックロンが揺らす邪魔で落ちないようにしながらゴールまで進んでいく。
 1	すごろく	双六	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スゴロク,双六,すごろく,すごろく,スゴロク,,,スゴロク,スゴロク,双六
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7681,7 +7681,7 @@
 
 # newdoc id = test-s341
 # sent_id = test-s341
-# parallel_id = jagsdluw/test341
+# parallel_id = jagsd/test341
 # text = 歴史上では、中国・後漢末期に発生した、党錮の禁で弾圧された集団の称として使われた。
 1	歴史上	歴史上	NOUN	名詞-普通名詞-一般	_	21	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=レキシ;ジョウ,歴史;上,歴史;上,歴史;上,レキシ;ジョー,;,;,レキシ;ジョウ,レキシジョウ,歴史上
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -7710,7 +7710,7 @@
 
 # newdoc id = test-s342
 # sent_id = test-s342
-# parallel_id = jagsdluw/test342
+# parallel_id = jagsd/test342
 # text = キャラクターの心臓部とも言える、動作を制御するファイル。
 1	キャラクター	キャラクター	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キャラクター,キャラクター,キャラクター,キャラクター,キャラクター,,,キャラクター,キャラクター,キャラクター
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7727,7 +7727,7 @@
 
 # newdoc id = test-s343
 # sent_id = test-s343
-# parallel_id = jagsdluw/test343
+# parallel_id = jagsd/test343
 # text = 同じビルに調剤薬局もあるので会計後にそのまま向かうのが基本ルートです。
 1	同じ	同じ	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オナジ,同じ,同じ,同じ,オナジ,,,オナジ,オナジ,同じ
 2	ビル	蛭	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ビル,ビル,ビル,ビル,ビル,,,ビル,ビル,蛭
@@ -7749,7 +7749,7 @@
 
 # newdoc id = test-s344
 # sent_id = test-s344
-# parallel_id = jagsdluw/test344
+# parallel_id = jagsd/test344
 # text = なお同馬はこのレースに於いて発走枠入りを再三嫌がり、出走を遅らせたため一定期間出走停止とゲート再試験が科せられている。
 1	なお	猶	CCONJ	接続詞	_	21	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	同馬	同馬	NOUN	名詞-普通名詞-一般	_	21	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウバ,同馬,同馬,同馬,ドーバ,,,ドウバ,ドウバ,同馬
@@ -7778,7 +7778,7 @@
 
 # newdoc id = test-s345
 # sent_id = test-s345
-# parallel_id = jagsdluw/test345
+# parallel_id = jagsd/test345
 # text = また,この養護教諭は,砂糖玉をレメディーに変換するという装置を保健室に持ち込んでいた。
 1	また	又	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -7803,7 +7803,7 @@
 
 # newdoc id = test-s346
 # sent_id = test-s346
-# parallel_id = jagsdluw/test346
+# parallel_id = jagsd/test346
 # text = 線形作用素が有界であることと、連続であることは必要十分である。
 1	線形作用素	線形作用素	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センケイ;サヨウ;ソ,線形;作用;素,線形;作用;素,線形;作用;素,センケー;サヨー;ソ,;;,;;,センケイ;サヨウ;ソ,センケイサヨウソ,線形作用素
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7822,7 +7822,7 @@
 
 # newdoc id = test-s347
 # sent_id = test-s347
-# parallel_id = jagsdluw/test347
+# parallel_id = jagsd/test347
 # text = 一方NASAのエイムズ研究センターが開発したナノセイルDは2008年8月にファルコン1ロケットによって打ち上げられるも打上げに失敗。
 1	一方	一方	CCONJ	接続詞	_	20	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	NASA	NASA	PROPN	名詞-固有名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナサ,ＮＡＳＡ,NASA,NASA,ナサ,,,ナサ,ナサ,NASA
@@ -7848,7 +7848,7 @@
 
 # newdoc id = test-s348
 # sent_id = test-s348
-# parallel_id = jagsdluw/test348
+# parallel_id = jagsd/test348
 # text = だんなさまにもこの気持ち良さを体感してもらって、スクールに通うOKをもらいます!
 1	だんなさま	旦那様	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダンナ;サマ,旦那;様,だんな;さま,だんな;さま,ダンナ;サマ,;,;,ダンナ;サマ,ダンナサマ,旦那様
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7872,7 +7872,7 @@
 
 # newdoc id = test-s349
 # sent_id = test-s349
-# parallel_id = jagsdluw/test349
+# parallel_id = jagsd/test349
 # text = 冬季に利用。
 1	冬季	冬季	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウキ,冬季,冬季,冬季,トーキ,,,トウキ,トウキ,冬季
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7881,7 +7881,7 @@
 
 # newdoc id = test-s350
 # sent_id = test-s350
-# parallel_id = jagsdluw/test350
+# parallel_id = jagsd/test350
 # text = このため先に派遣されていた2個偵察機隊に加え、新たに偵察機隊を追加派遣することとなり、事変勃発から1ヵ月後に追加編制されたのが二三空である。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	ため	為	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タメ,為,ため,ため,タメ,,,タメ,タメ,為
@@ -7917,7 +7917,7 @@
 
 # newdoc id = test-s351
 # sent_id = test-s351
-# parallel_id = jagsdluw/test351
+# parallel_id = jagsd/test351
 # text = なお、常陸国から佐竹氏の秋田転封に随行した菊池氏が数流見える。
 1	なお	猶	CCONJ	接続詞	_	14	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7937,7 +7937,7 @@
 
 # newdoc id = test-s352
 # sent_id = test-s352
-# parallel_id = jagsdluw/test352
+# parallel_id = jagsd/test352
 # text = かけがえのない家族を突然失う悲しみを知るだけに、できることをしたいと考えている。
 1	かけがえ	掛け替え	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カケガエ,掛け替え,かけがえ,かけがえ,カケガエ,,,カケガエ,カケガエ,掛け替え
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7964,7 +7964,7 @@
 
 # newdoc id = test-s353
 # sent_id = test-s353
-# parallel_id = jagsdluw/test353
+# parallel_id = jagsd/test353
 # text = そして、テレビ朝日同様縁取りは行われていない。
 1	そして	そして	CCONJ	接続詞	_	6	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7979,7 +7979,7 @@
 
 # newdoc id = test-s354
 # sent_id = test-s354
-# parallel_id = jagsdluw/test354
+# parallel_id = jagsd/test354
 # text = 上に引用した部分以外も同様です。
 1	上	上	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウエ,上,上,上,ウエ,,,ウエ,ウエ,上
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7993,7 +7993,7 @@
 
 # newdoc id = test-s355
 # sent_id = test-s355
-# parallel_id = jagsdluw/test355
+# parallel_id = jagsd/test355
 # text = 欧州不正対策局の付属機関である欧州技術・科学センターは、2002年の時点で最大で200万枚の偽造硬貨が出回っていると推測している。
 1	欧州不正対策局	欧州不正対策局	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オウシュウ;フセイ;タイサク;キョク,オウシュウ;不正;対策;局,欧州;不正;対策;局,欧州;不正;対策;局,オーシュー;フセー;タイサク;キョク,;;;,;;;,オウシュウ;フセイ;タイサク;キョク,オウシュウフセイタイサクキョク,欧州不正対策局
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8021,7 +8021,7 @@
 
 # newdoc id = test-s356
 # sent_id = test-s356
-# parallel_id = jagsdluw/test356
+# parallel_id = jagsd/test356
 # text = 新ルールを聞いて、各々に想いを語った。
 1	新ルール	新ルール	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シン;ルール,新;ルール,新;ルール,新;ルール,シン;ルール,;,;,シン;ルール,シンルール,新ルール
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8038,7 +8038,7 @@
 
 # newdoc id = test-s357
 # sent_id = test-s357
-# parallel_id = jagsdluw/test357
+# parallel_id = jagsd/test357
 # text = マイカーの輸送力は公共交通機関に比べて遥かに劣るため、比較的小規模な都市でも混雑問題が深刻化する。
 1	マイカー	マイカー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マイ;カー,マイ;カー,マイ;カー,マイ;カー,マイ;カー,;,;,マイ;カー,マイカー,マイカー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8066,7 +8066,7 @@
 
 # newdoc id = test-s358
 # sent_id = test-s358
-# parallel_id = jagsdluw/test358
+# parallel_id = jagsd/test358
 # text = 私は高校生の頃に臨床心理士になりたいと思い、心理学が学べる大学を片っ端から調べ、行けるだけオープンキャンパスに行きました。
 1	私	私	PRON	代名詞	_	27	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8101,7 +8101,7 @@
 
 # newdoc id = test-s359
 # sent_id = test-s359
-# parallel_id = jagsdluw/test359
+# parallel_id = jagsd/test359
 # text = ストーリー重視の作品を中心に掲載しているため過激な性的描写はほとんど見あたらない。
 1	ストーリー重視	ストーリー重視	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ストーリー;ジュウシ,ストーリー;重視,ストーリー;重視,ストーリー;重視,ストーリー;ジューシ,;,;,ストーリー;ジュウシ,ストーリージュウシ,ストーリー重視
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8123,7 +8123,7 @@
 
 # newdoc id = test-s360
 # sent_id = test-s360
-# parallel_id = jagsdluw/test360
+# parallel_id = jagsd/test360
 # text = 直純より一年早く務め始めている。
 1	直純	直純	PROPN	名詞-固有名詞-人名-名	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオズミ,ナオズミ,直純,直純,ナオズミ,,,ナオズミ,ナオズミ,直純
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -8135,7 +8135,7 @@
 
 # newdoc id = test-s361
 # sent_id = test-s361
-# parallel_id = jagsdluw/test361
+# parallel_id = jagsd/test361
 # text = 子供の頃は『仮面ライダーBLACK』や『機動刑事ジバン』が好きだった。
 1	子供	子供	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コドモ,子供,子供,子供,コドモ,,,コドモ,コドモ,子供
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8156,7 +8156,7 @@
 
 # newdoc id = test-s362
 # sent_id = test-s362
-# parallel_id = jagsdluw/test362
+# parallel_id = jagsd/test362
 # text = 注文をすぐにとりにこない。
 1	注文	注文	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウモン,注文,注文,注文,チューモン,,,チュウモン,チュウモン,注文
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8170,7 +8170,7 @@
 
 # newdoc id = test-s363
 # sent_id = test-s363
-# parallel_id = jagsdluw/test363
+# parallel_id = jagsd/test363
 # text = 北沢氏は防衛省と自衛隊の内部の検討だとした上で、派遣の根拠となる法令に関して防衛省設置法を念頭に「派遣が可能か検討している」と述べた。
 1	北沢氏	北沢氏	PROPN	名詞-固有名詞-人名-姓	_	36	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キタザワ;シ,キタザワ;氏,北沢;氏,北沢;氏,キタザワ;シ,;,;,キタザワ;シ,キタザワシ,北沢氏
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8213,7 +8213,7 @@
 
 # newdoc id = test-s364
 # sent_id = test-s364
-# parallel_id = jagsdluw/test364
+# parallel_id = jagsd/test364
 # text = コウスケたち三年二組の担任。
 1	コウスケたち	コウスケ達	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=コウスケ;タチ,コウスケ;達,コウスケ;たち,コウスケ;たち,コースケ;タチ,;,;,コウスケ;タチ,コウスケタチ,コウスケ達
 2	三年	三年	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=サン;ネン,三;年,三;年,三;年,サン;ネン,;,;,サン;ネン,サンネン,三年
@@ -8224,7 +8224,7 @@
 
 # newdoc id = test-s365
 # sent_id = test-s365
-# parallel_id = jagsdluw/test365
+# parallel_id = jagsd/test365
 # text = 中学卒業後は品茂先生とメル友になり、ヒナノと同じ高校に進学した。
 1	中学卒業後	中学卒業後	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウガク;ソツギョウ;ゴ,中学;卒業;後,中学;卒業;後,中学;卒業;後,チューガク;ソツギョー;ゴ,;;,;;,チュウガク;ソツギョウ;ゴ,チュウガクソツギョウゴ,中学卒業後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8245,7 +8245,7 @@
 
 # newdoc id = test-s366
 # sent_id = test-s366
-# parallel_id = jagsdluw/test366
+# parallel_id = jagsd/test366
 # text = 潜水士になる前は会社も嫌になって辞め、親も納得するという理由で海上保安庁に入庁した経緯から、あらゆる境遇に逃げてきていたと自認しているが、仙崎と行動するうちに潜水士としての成長も見せている。
 1	潜水士	潜水士	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センスイ;シ,潜水;士,潜水;士,潜水;士,センスイ;シ,;,;,センスイ;シ,センスイシ,潜水士
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8301,7 +8301,7 @@
 
 # newdoc id = test-s367
 # sent_id = test-s367
-# parallel_id = jagsdluw/test367
+# parallel_id = jagsd/test367
 # text = また雨が降ると、鉄砲水となって渓谷内を通過していった。
 1	また	又	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	雨	雨	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アメ,雨,雨,雨,アメ,,,アメ,アメ,雨
@@ -8322,7 +8322,7 @@
 
 # newdoc id = test-s368
 # sent_id = test-s368
-# parallel_id = jagsdluw/test368
+# parallel_id = jagsd/test368
 # text = 海老澤代表が統一教会の関係の人か訊くと“いえ,どなたかから聞いたのですか?”
 1	海老澤代表	海老澤代表	PROPN	名詞-固有名詞-人名-姓	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エビサワ;ダイヒョウ,エビサワ;代表,海老澤;代表,海老澤;代表,エビサワ;ダイヒョー,;,;,エビサワ;ダイヒョウ,エビサワダイヒョウ,海老澤代表
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -8349,7 +8349,7 @@
 
 # newdoc id = test-s369
 # sent_id = test-s369
-# parallel_id = jagsdluw/test369
+# parallel_id = jagsd/test369
 # text = 雰囲気がすき!
 1	雰囲気	雰囲気	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フンイキ,雰囲気,雰囲気,雰囲気,フンイキ,,,フンイキ,フンイキ,雰囲気
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -8358,7 +8358,7 @@
 
 # newdoc id = test-s370
 # sent_id = test-s370
-# parallel_id = jagsdluw/test370
+# parallel_id = jagsd/test370
 # text = 私はここの病院に行き、人が怖くなり、外にでれなくなりました。
 1	私	私	PRON	代名詞	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8384,7 +8384,7 @@
 
 # newdoc id = test-s371
 # sent_id = test-s371
-# parallel_id = jagsdluw/test371
+# parallel_id = jagsd/test371
 # text = こうした技術を利用して一台のコンピュータの処理能力を飛躍的に向上させたものはスーパーコンピュータと呼ばれ、複数のコンピュータを統合して全体として処理能力を上げたものはコンピュータ・クラスターと呼ばれる。
 1	こう	こう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウ,こう,こう,こう,コー,,,コウ,コウ,こう
 2	し	する	VERB	動詞-一般-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,スル,する
@@ -8433,7 +8433,7 @@
 
 # newdoc id = test-s372
 # sent_id = test-s372
-# parallel_id = jagsdluw/test372
+# parallel_id = jagsd/test372
 # text = 趣味はソフトボール・マラソン・飲酒。
 1	趣味	趣味	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュミ,趣味,趣味,趣味,シュミ,,,シュミ,シュミ,趣味
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8442,7 +8442,7 @@
 
 # newdoc id = test-s373
 # sent_id = test-s373
-# parallel_id = jagsdluw/test373
+# parallel_id = jagsd/test373
 # text = チチュウカイリクガメ属の模式種。
 1	チチュウカイリクガメ属	地中海陸亀属	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チチュウ;カイ;リクガメ;ゾク,地中;海;陸亀;属,チチュウ;カイ;リクガメ;属,チチュウ;カイ;リクガメ;属,チチュー;カイ;リクガメ;ゾク,;;;,;;;,チチュウ;カイ;リクガメ;ゾク,チチュウカイリクガメゾク,地中海陸亀属
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8451,7 +8451,7 @@
 
 # newdoc id = test-s374
 # sent_id = test-s374
-# parallel_id = jagsdluw/test374
+# parallel_id = jagsd/test374
 # text = 自分でも説明できないものを他人に勧めるのはやめてほしいものです。
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -8473,7 +8473,7 @@
 
 # newdoc id = test-s375
 # sent_id = test-s375
-# parallel_id = jagsdluw/test375
+# parallel_id = jagsd/test375
 # text = 英語が分からない私でしたが行ってみるとレベルに合わせてクラスが分かれていました。
 1	英語	英語	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エイゴ,英語,英語,英語,エーゴ,,,エイゴ,エイゴ,英語
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -8500,7 +8500,7 @@
 
 # newdoc id = test-s376
 # sent_id = test-s376
-# parallel_id = jagsdluw/test376
+# parallel_id = jagsd/test376
 # text = アドヴァンスの外壁には明日8月6日開催の荒川灯籠流しのポスターが貼ってあった。
 1	アドヴァンス	アドバンス	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アドバンス,アドバンス,アドヴァンス,アドヴァンス,アドバンス,,,アドバンス,アドバンス,アドバンス
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8522,7 +8522,7 @@
 
 # newdoc id = test-s377
 # sent_id = test-s377
-# parallel_id = jagsdluw/test377
+# parallel_id = jagsd/test377
 # text = 店舗の見た目は正直不安をあおるものではありますが、安さと使い勝手は申し分ないと思います。
 1	店舗	店舗	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンポ,店舗,店舗,店舗,テンポ,,,テンポ,テンポ,店舗
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8552,7 +8552,7 @@
 
 # newdoc id = test-s378
 # sent_id = test-s378
-# parallel_id = jagsdluw/test378
+# parallel_id = jagsd/test378
 # text = よって女子は完全内湯で開放感・景観はゼロでした。
 1	よって	因って	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨル;テ,因る;て,よっ;て,よる;て,ヨッ;テ,;,;,ヨル;テ,ヨッテ,因って
 2	女子	女子	NOUN	名詞-普通名詞-一般	_	8	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョシ,女子,女子,女子,ジョシ,,,ジョシ,ジョシ,女子
@@ -8568,7 +8568,7 @@
 
 # newdoc id = test-s379
 # sent_id = test-s379
-# parallel_id = jagsdluw/test379
+# parallel_id = jagsd/test379
 # text = 収録曲など詳細は後日発表予定。
 1	収録曲	収録曲	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウロク;キョク,収録;曲,収録;曲,収録;曲,シューロク;キョク,;,;,シュウロク;キョク,シュウロクキョク,収録曲
 2	など	など	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナド,など,など,など,ナド,,,ナド,ナド,など
@@ -8579,7 +8579,7 @@
 
 # newdoc id = test-s380
 # sent_id = test-s380
-# parallel_id = jagsdluw/test380
+# parallel_id = jagsd/test380
 # text = 見積もりは出張や電話でしますが、家具の種類と修理項目別におよその見積もりをするフォームがあります。
 1	見積もり	見積もり	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミツモリ,見積もり,見積もり,見積もり,ミツモリ,,,ミツモリ,ミツモリ,見積もり
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8609,7 +8609,7 @@
 
 # newdoc id = test-s381
 # sent_id = test-s381
-# parallel_id = jagsdluw/test381
+# parallel_id = jagsd/test381
 # text = 血の流れの末端はうなじの下向きに湾曲した線で停止しており、なにか冠のようなものに原因が有るとすれば、茨の枝が後頭部にはまった高さにその線があるように見える。
 1	血	血	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チ,血,血,血,チ,,,チ,チ,血
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8662,7 +8662,7 @@
 
 # newdoc id = test-s382
 # sent_id = test-s382
-# parallel_id = jagsdluw/test382
+# parallel_id = jagsd/test382
 # text = 戦後は1906年に装甲巡洋艦リューリク艦長に着任。
 1	戦後	戦後	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=センゴ,戦後,戦後,戦後,センゴ,,,センゴ,センゴ,戦後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8675,7 +8675,7 @@
 
 # newdoc id = test-s383
 # sent_id = test-s383
-# parallel_id = jagsdluw/test383
+# parallel_id = jagsd/test383
 # text = 相手GKと1対1になったりだとか、完全にフリーでシュートを打つというのもなかった。
 1	相手GK	相手GK	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アイテ;ジーケー,相手;ＧＫ,相手;GK,相手;GK,アイテ;ジーケー,;,;,アイテ;ジーケー,アイテジーケー,相手GK
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -8703,7 +8703,7 @@
 
 # newdoc id = test-s384
 # sent_id = test-s384
-# parallel_id = jagsdluw/test384
+# parallel_id = jagsd/test384
 # text = 手配書の内容だが,記者の身長も“185cm位”から“180cm位”に修正されている。
 1	手配書	手配書	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テハイ;ショ,手配;書,手配;書,手配;書,テハイ;ショ,;,;,テハイ;ショ,テハイショ,手配書
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8732,7 +8732,7 @@
 
 # newdoc id = test-s385
 # sent_id = test-s385
-# parallel_id = jagsdluw/test385
+# parallel_id = jagsd/test385
 # text = この写真を掲載しているのは,東京都内の店舗デザイン会社です。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	写真	写真	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シャシン,写真,写真,写真,シャシン,,,シャシン,シャシン,写真
@@ -8750,7 +8750,7 @@
 
 # newdoc id = test-s386
 # sent_id = test-s386
-# parallel_id = jagsdluw/test386
+# parallel_id = jagsd/test386
 # text = ろうそくとアルコールランプを用い、炎の強さや大きさが放射能に当たり、炎からの距離に応じて感じる明るさや温かさは放射線量に当たることを関連づけて学んだ。
 1	ろうそく	蝋燭	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ロウソク,蝋燭,ろうそく,ろうそく,ローソク,,,ロウソク,ロウソク,蝋燭
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -8793,7 +8793,7 @@
 
 # newdoc id = test-s387
 # sent_id = test-s387
-# parallel_id = jagsdluw/test387
+# parallel_id = jagsd/test387
 # text = 知っているCMばかり。
 1	知っ	知る	VERB	動詞-一般-五段-ラ行	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シル,知る,知っ,知る,シッ,,,シル,シル,知る
 2	ている	ている	AUX	助動詞-上一段-ア行	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ;イル,て;居る,て;いる,て;いる,テ;イル,;,;,テ;イル,テイル,ている
@@ -8803,7 +8803,7 @@
 
 # newdoc id = test-s388
 # sent_id = test-s388
-# parallel_id = jagsdluw/test388
+# parallel_id = jagsd/test388
 # text = 古町の老舗店店主から店や町の歴史を聞く「古町老舗・名店巡りコース」や「西大畑・先人の偉業をたどるお屋敷町散歩コース」など12コースあり、一日2コースずつ開く。
 1	古町	古町	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コマチ,古町,古町,古町,コマチ,,,コマチ,コマチ,古町
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8840,7 +8840,7 @@
 
 # newdoc id = test-s389
 # sent_id = test-s389
-# parallel_id = jagsdluw/test389
+# parallel_id = jagsd/test389
 # text = この山寺のアイディアは、後に『ルパン三世風魔一族の陰謀』にて流用される。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	山寺	山寺	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤマデラ,山寺,山寺,山寺,ヤマデラ,,,ヤマデラ,ヤマデラ,山寺
@@ -8864,7 +8864,7 @@
 
 # newdoc id = test-s390
 # sent_id = test-s390
-# parallel_id = jagsdluw/test390
+# parallel_id = jagsd/test390
 # text = 当時は調騎分離される前だったこともあり、調教師の清水茂次が20戦中19戦に騎乗している。
 1	当時	当時	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウジ,当時,当時,当時,トージ,,,トウジ,トウジ,当時
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8890,7 +8890,7 @@
 
 # newdoc id = test-s392
 # sent_id = test-s392
-# parallel_id = jagsdluw/test392
+# parallel_id = jagsd/test392
 # text = 同化産物は穀粒生産に向け直されるようになり、商業的な収穫のための化学肥料の効果が特に増加する。
 1	同化産物	同化産物	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウカ;サンブツ,同化;産物,同化;産物,同化;産物,ドーカ;サンブツ,;,;,ドウカ;サンブツ,ドウカサンブツ,同化産物
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8918,7 +8918,7 @@
 
 # newdoc id = test-s393
 # sent_id = test-s393
-# parallel_id = jagsdluw/test393
+# parallel_id = jagsd/test393
 # text = 両親は転勤で北海道に在住しそれが延期となり、姉はまもなく海外へ留学のため親の意向に逆らいマンションを借りて一人暮らしをする。
 1	両親	両親	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リョウシン,両親,両親,両親,リョーシン,,,リョウシン,リョウシン,両親
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8959,7 +8959,7 @@
 
 # newdoc id = test-s394
 # sent_id = test-s394
-# parallel_id = jagsdluw/test394
+# parallel_id = jagsd/test394
 # text = 同署によると、ドラマの撮影は行われず、違約金も返却されないため、女性が2月に被害を届け出た。
 1	同署	同署	NOUN	名詞-普通名詞-一般	_	25	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウショ,同署,同署,同署,ドーショ,,,ドウショ,ドウショ,同署
 2	によると	によると	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;ト,に;因る;と,に;よる;と,に;よる;と,ニ;ヨル;ト,;;,;;,ニ;ヨル;ト,ニヨルト,によると
@@ -8991,7 +8991,7 @@
 
 # newdoc id = test-s395
 # sent_id = test-s395
-# parallel_id = jagsdluw/test395
+# parallel_id = jagsd/test395
 # text = 翌12日より五島産業汽船が同航路の運航を開始したが、2006年4月をもって廃止。
 1	翌12日	翌12日	NUM	名詞-数詞	_	9	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨク;イチ;ニ;ニチ,翌;一;二;日,翌;1;2;日,翌;1;2;日,ヨク;イチ;ニ;ニチ,;;;,;;;,ヨク;イチ;ニ;ニチ,ヨクイチニニチ,翌12日
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -9013,7 +9013,7 @@
 
 # newdoc id = test-s396
 # sent_id = test-s396
-# parallel_id = jagsdluw/test396
+# parallel_id = jagsd/test396
 # text = 翌年に試作機が完成しているが、減速装置の不調と重量過大が最後まで改善されなかった。
 1	翌年	翌年	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨクネン,翌年,翌年,翌年,ヨクネン,,,ヨクネン,ヨクネン,翌年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9039,7 +9039,7 @@
 
 # newdoc id = test-s397
 # sent_id = test-s397
-# parallel_id = jagsdluw/test397
+# parallel_id = jagsd/test397
 # text = 食後のラテと小さなデザートもお気に入り。
 1	食後	食後	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショクゴ,食後,食後,食後,ショクゴ,,,ショクゴ,ショクゴ,食後
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9053,7 +9053,7 @@
 
 # newdoc id = test-s398
 # sent_id = test-s398
-# parallel_id = jagsdluw/test398
+# parallel_id = jagsd/test398
 # text = コンピュータにおけるデータログでは、障害などが発生したとき、何が起きたのかを説明できるようにするためにプログラムが自動的にある範囲のイベントを記録する。
 1	コンピュータ	コンピュータ	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コンピューター,コンピューター,コンピュータ,コンピュータ,コンピュータ,,,コンピュータ,コンピュータ,コンピュータ
 2	における	における	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;オク;リ,に;於く;り,に;おけ;る,に;おく;り,ニ;オケ;ル,;;,;;,ニ;オク;リ,ニオケル,における
@@ -9094,7 +9094,7 @@
 
 # newdoc id = test-s399
 # sent_id = test-s399
-# parallel_id = jagsdluw/test399
+# parallel_id = jagsd/test399
 # text = 受付で訊くと展示会は招待制とのことだったが,モバイルHPにその旨の記載がないことを告げると責任者を呼ぶから待つようにと言われた。
 1	受付	受け付け	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウケツケ,受け付け,受付,受付,ウケツケ,,,ウケツケ,ウケツケ,受け付け
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9137,7 +9137,7 @@
 
 # newdoc id = test-s400
 # sent_id = test-s400
-# parallel_id = jagsdluw/test400
+# parallel_id = jagsd/test400
 # text = 「MAX11836」はユーザー定義のハプティックパターンのオンチップ保存,再生ロジック,出力設定可能なDC-DC変換,および高い容量性負荷用の出力ドライバを備えている。
 1	「	「	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	MAX11836	MAX11836	NUM	名詞-数詞	_	25	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エム;エー;エックス;イチ;イチ;ハチ;サン;ロク,Ｍ;Ａ;Ｘ;一;一;八;三;六,M;A;X;1;1;8;3;6,M;A;X;1;1;8;3;6,エム;エー;エックス;イチ;イチ;ハチ;サン;ロク,;;;;;;;,;;;;;;;,エム;エー;エックス;イチ;イチ;ハチ;サン;ロク,エムエーエックスイチイチハチサンロク,MAX11836
@@ -9169,7 +9169,7 @@
 
 # newdoc id = test-s401
 # sent_id = test-s401
-# parallel_id = jagsdluw/test401
+# parallel_id = jagsd/test401
 # text = 基盤左側に某有名PC周辺機器メーカーのロゴが見えます。
 1	基盤左側	基盤左側	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キバン;ヒダリガワ,基盤;左側,基盤;左側,基盤;左側,キバン;ヒダリガワ,;,;,キバン;ヒダリガワ,キバンヒダリガワ,基盤左側
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9183,7 +9183,7 @@
 
 # newdoc id = test-s402
 # sent_id = test-s402
-# parallel_id = jagsdluw/test402
+# parallel_id = jagsd/test402
 # text = いよいよイベントもお開きの時間となり、3人は来場者に向け1人ずつコメント。
 1	いよいよ	愈	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イヨイヨ,愈,いよいよ,いよいよ,イヨイヨ,,,イヨイヨ,イヨイヨ,愈
 2	イベント	イベント	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イベント,イベント,イベント,イベント,イベント,,,イベント,イベント,イベント
@@ -9206,7 +9206,7 @@
 
 # newdoc id = test-s403
 # sent_id = test-s403
-# parallel_id = jagsdluw/test403
+# parallel_id = jagsd/test403
 # text = これのお返しとして、寝屋親が寝屋子にごちそうをふるまうことを「寝屋子振舞い」という。
 1	これ	此れ	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9231,7 +9231,7 @@
 
 # newdoc id = test-s404
 # sent_id = test-s404
-# parallel_id = jagsdluw/test404
+# parallel_id = jagsd/test404
 # text = アッシリア王名表では彼の記述の後に「食べつくされる」という注釈がついている。
 1	アッシリア王名表	アッシリア王名表	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アッシリア;オウメイ;ヒョウ,アッシリア;王名;表,アッシリア;王名;表,アッシリア;王名;表,アッシリア;オーメー;ヒョー,;;,;;,アッシリア;オウメイ;ヒョウ,アッシリアオウメイヒョウ,アッシリア王名表
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9255,7 +9255,7 @@
 
 # newdoc id = test-s405
 # sent_id = test-s405
-# parallel_id = jagsdluw/test405
+# parallel_id = jagsd/test405
 # text = 女優のランキングでは、20代から30代までの票がいろんな女優にばらけたのに対し、40代から60代までの票が、オードリー・ヘップバーンやマリリン・モンローに集中したことで、上位に往年のハリウッドスターがランキングする結果となりました。
 1	女優	女優	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョユウ,女優,女優,女優,ジョユー,,,ジョユウ,ジョユウ,女優
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9311,7 +9311,7 @@
 
 # newdoc id = test-s406
 # sent_id = test-s406
-# parallel_id = jagsdluw/test406
+# parallel_id = jagsd/test406
 # text = 菅直人首相は28日、円高で加速しかねない産業空洞化を防ぎ、地方を中心に雇用を確保するため、国内への工場立地などの推進を目指す「日本国内投資促進プログラム」の策定を直嶋正行経済産業相に指示した。
 1	菅直人首相	菅直人首相	PROPN	名詞-固有名詞-人名-一般	_	39	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カン;ナオト;シュショウ,カン;ナオト;首相,菅;直人;首相,菅;直人;首相,カン;ナオト;シュショー,;;,;;,カン;ナオト;シュショウ,カンナオトシュショウ,菅直人首相
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9357,7 +9357,7 @@
 
 # newdoc id = test-s407
 # sent_id = test-s407
-# parallel_id = jagsdluw/test407
+# parallel_id = jagsd/test407
 # text = 現在では、観光客も多く訪れるようになっている。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9375,7 +9375,7 @@
 
 # newdoc id = test-s408
 # sent_id = test-s408
-# parallel_id = jagsdluw/test408
+# parallel_id = jagsd/test408
 # text = 代わりの人がやったからって上手くできるのかなという感じもあります。
 1	代わり	代わり	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カワリ,代わり,代わり,代わり,カワリ,,,カワリ,カワリ,代わり
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9399,7 +9399,7 @@
 
 # newdoc id = test-s409
 # sent_id = test-s409
-# parallel_id = jagsdluw/test409
+# parallel_id = jagsd/test409
 # text = 創価学会員も参加している運動を“左翼&唯物論”と言われても,意味がよくわかりません。
 1	創価学会員	創価学会員	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソウカ;ガッカイ;イン,創価;学会;員,創価;学会;員,創価;学会;員,ソーカ;ガッカイ;イン,;;,;;,ソウカ;ガッカイ;イン,ソウカガッカイイン,創価学会員
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -9426,7 +9426,7 @@
 
 # newdoc id = test-s410
 # sent_id = test-s410
-# parallel_id = jagsdluw/test410
+# parallel_id = jagsd/test410
 # text = 無邪気で素直な性格であるが、少し弱虫。
 1	無邪気	無邪気	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ムジャキ,無邪気,無邪気,無邪気,ムジャキ,,,ムジャキ,ムジャキ,無邪気
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -9442,7 +9442,7 @@
 
 # newdoc id = test-s411
 # sent_id = test-s411
-# parallel_id = jagsdluw/test411
+# parallel_id = jagsd/test411
 # text = 2011年8月に行われた韓国プロ野球ドラフト会議にて、LGツインズより8位指名を受けたが、宋は日本のドラフト会議でも指名の対象になっており、日本でのプレーを希望していることからLGの指名を拒否。
 1	2011年	2011年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;イチ;イチ;ネン,二;ゼロ;一;一;年,2;0;1;1;年,2;0;1;1;年,ニ;ゼロ;イチ;イチ;ネン,;;;;,;;;;,ニ;ゼロ;イチ;イチ;ネン,ニゼロイチイチネン,2011年
 2	8月	8月	NUM	名詞-数詞	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハチ;ガツ,八;月,8;月,8;月,ハチ;ガツ,;,;,ハチ;ガツ,ハチガツ,8月
@@ -9493,7 +9493,7 @@
 
 # newdoc id = test-s412
 # sent_id = test-s412
-# parallel_id = jagsdluw/test412
+# parallel_id = jagsd/test412
 # text = 小田急の通勤車両では初めて他事業者路線への乗り入れを前提とした車両になることから、それまでの小田急の通勤車両の標準仕様とは異なる新技術が採用された。
 1	小田急	小田急	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オダキュウ,小田急,小田急,小田急,オダキュー,,,オダキュウ,オダキュウ,小田急
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9536,7 +9536,7 @@
 
 # newdoc id = test-s413
 # sent_id = test-s413
-# parallel_id = jagsdluw/test413
+# parallel_id = jagsd/test413
 # text = 同じく11代目として登場したのが松熊由紀である。
 1	同じく	同じく	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オナジク,同じく,同じく,同じく,オナジク,,,オナジク,オナジク,同じく
 2	11代目	11代目	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;イチ;ダイ;メ,一;一;代;目,1;1;代;目,1;1;代;目,イチ;イチ;ダイ;メ,;;;,;;;,イチ;イチ;ダイ;メ,イチイチダイメ,11代目
@@ -9551,7 +9551,7 @@
 
 # newdoc id = test-s414
 # sent_id = test-s414
-# parallel_id = jagsdluw/test414
+# parallel_id = jagsd/test414
 # text = 神奈川県横浜市に所在するNPO法人。
 1	神奈川県	神奈川県	PROPN	名詞-固有名詞-地名-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カナガワ;ケン,カナガワ;県,神奈川;県,神奈川;県,カナガワ;ケン,;,;,カナガワ;ケン,カナガワケン,神奈川県
 2	横浜市	横浜市	PROPN	名詞-固有名詞-地名-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨコハマ;シ,ヨコハマ;市,横浜;市,横浜;市,ヨコハマ;シ,;,;,ヨコハマ;シ,ヨコハマシ,横浜市
@@ -9562,7 +9562,7 @@
 
 # newdoc id = test-s415
 # sent_id = test-s415
-# parallel_id = jagsdluw/test415
+# parallel_id = jagsd/test415
 # text = これはTPが南下される時,神様と約束された南北統一をなすことです。
 1	これ	此れ	PRON	代名詞	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9586,7 +9586,7 @@
 
 # newdoc id = test-s416
 # sent_id = test-s416
-# parallel_id = jagsdluw/test416
+# parallel_id = jagsd/test416
 # text = 気軽に立ち寄れるネイルサロンなので、初めての人でも是非通ってみてください。
 1	気軽	気軽	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=キガル,気軽,気軽,気軽,キガル,,,キガル,キガル,気軽
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -9608,7 +9608,7 @@
 
 # newdoc id = test-s418
 # sent_id = test-s418
-# parallel_id = jagsdluw/test418
+# parallel_id = jagsd/test418
 # text = ヒットメーカーに当たりが出ない。
 1	ヒットメーカー	ヒットメーカー	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒット;メーカー,ヒット;メーカー,ヒット;メーカー,ヒット;メーカー,ヒット;メーカー,;,;,ヒット;メーカー,ヒットメーカー,ヒットメーカー
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9620,7 +9620,7 @@
 
 # newdoc id = test-s419
 # sent_id = test-s419
-# parallel_id = jagsdluw/test419
+# parallel_id = jagsd/test419
 # text = 私は“あるんだ”という以外ないので,議論になります。
 1	私	私	PRON	代名詞	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9641,7 +9641,7 @@
 
 # newdoc id = test-s420
 # sent_id = test-s420
-# parallel_id = jagsdluw/test420
+# parallel_id = jagsd/test420
 # text = デドフスクにはM9幹線道路が通るほか、モスクワからリガに向かう鉄道も通る。
 1	デドフスク	デドフスク	PROPN	名詞-固有名詞-地名-一般	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=デドフスク,デドフスク,デドフスク,デドフスク,デドフスク,,,デドフスク,デドフスク,デドフスク
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9663,14 +9663,14 @@
 
 # newdoc id = test-s421
 # sent_id = test-s421
-# parallel_id = jagsdluw/test421
+# parallel_id = jagsd/test421
 # text = 日置藩領主。
 1	日置藩領主	日置藩領主	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ヒオキ;ハン;リョウシュ,ヒオキ;藩;領主,日置;藩;領主,日置;藩;領主,ヒオキ;ハン;リョーシュ,;;,;;,ヒオキ;ハン;リョウシュ,ヒオキハンリョウシュ,日置藩領主
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s422
 # sent_id = test-s422
-# parallel_id = jagsdluw/test422
+# parallel_id = jagsd/test422
 # text = 一旦はその考えを受け入れたが、CNRT率いる野党連合とフレティリンは、何週間も論争を繰り返したが合意には至らなかった。
 1	一旦	一旦	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッタン,一旦,一旦,一旦,イッタン,,,イッタン,イッタン,一旦
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9705,7 +9705,7 @@
 
 # newdoc id = test-s423
 # sent_id = test-s423
-# parallel_id = jagsdluw/test423
+# parallel_id = jagsd/test423
 # text = 1635年か36年にアントワープの画家組合に加入。
 1	1635年	1635年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ロク;サン;ゴ;ネン,一;六;三;五;年,1;6;3;5;年,1;6;3;5;年,イチ;ロク;サン;ゴ;ネン,;;;;,;;;;,イチ;ロク;サン;ゴ;ネン,イチロクサンゴネン,1635年
 2	か	か	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カ,か,か,か,カ,,,カ,カ,か
@@ -9720,7 +9720,7 @@
 
 # newdoc id = test-s424
 # sent_id = test-s424
-# parallel_id = jagsdluw/test424
+# parallel_id = jagsd/test424
 # text = 2004年の推計では100,771人に減少している。
 1	2004年	2004年	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ヨン;ネン,二;ゼロ;ゼロ;四;年,2;0;0;4;年,2;0;0;4;年,ニ;ゼロ;ゼロ;ヨ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ヨ;ネン,ニゼロゼロヨンネン,2004年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9735,7 +9735,7 @@
 
 # newdoc id = test-s425
 # sent_id = test-s425
-# parallel_id = jagsdluw/test425
+# parallel_id = jagsd/test425
 # text = 2007年3月にFIFA女子ワールドカップの出場権をかけた大陸間プレーオフで2003年と同様にメキシコとホーム・アンド・アウェーで対戦。
 1	2007年	2007年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;シチ;ネン,二;ゼロ;ゼロ;七;年,2;0;0;7;年,2;0;0;7;年,ニ;ゼロ;ゼロ;シチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;シチ;ネン,ニゼロゼロシチネン,2007年
 2	3月	3月	NUM	名詞-数詞	_	20	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サン;ガツ,三;月,3;月,3;月,サン;ガツ,;,;,サン;ガツ,サンガツ,3月
@@ -9761,7 +9761,7 @@
 
 # newdoc id = test-s426
 # sent_id = test-s426
-# parallel_id = jagsdluw/test426
+# parallel_id = jagsd/test426
 # text = 御手洗学園高等部入学直後にミステリー執筆技術を実践的に習えるものと勘違いし、実践ミステリ倶楽部に仮入部する。
 1	御手洗学園高等部入学直後	御手洗学園高等部入学直後	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミタライ;ガクエン;コウトウ;ブ;ニュウガク;チョクゴ,ミタライ;学園;高等;部;入学;直後,御手洗;学園;高等;部;入学;直後,御手洗;学園;高等;部;入学;直後,ミタライ;ガクエン;コートー;ブ;ニューガク;チョクゴ,;;;;;,;;;;;,ミタライ;ガクエン;コウトウ;ブ;ニュウガク;チョクゴ,ミタライガクエンコウトウブニュウガクチョクゴ,御手洗学園高等部入学直後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9781,7 +9781,7 @@
 
 # newdoc id = test-s427
 # sent_id = test-s427
-# parallel_id = jagsdluw/test427
+# parallel_id = jagsd/test427
 # text = 発表会などのイベントでは、生徒さんたちの演奏だけでなく、講師陣のセッションもかなり見応えがあります♪
 1	発表会	発表会	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハッピョウ;カイ,発表;会,発表;会,発表;会,ハッピョー;カイ,;,;,ハッピョウ;カイ,ハッピョウカイ,発表会
 2	など	など	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ナド,など,など,など,ナド,,,ナド,ナド,など
@@ -9808,14 +9808,14 @@
 
 # newdoc id = test-s428
 # sent_id = test-s428
-# parallel_id = jagsdluw/test428
+# parallel_id = jagsd/test428
 # text = 国民運動連合所属。
 1	国民運動連合所属	国民運動連合所属	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=コクミン;ウンドウ;レンゴウ;ショゾク,国民;運動;連合;所属,国民;運動;連合;所属,国民;運動;連合;所属,コクミン;ウンドー;レンゴー;ショゾク,;;;,;;;,コクミン;ウンドウ;レンゴウ;ショゾク,コクミンウンドウレンゴウショゾク,国民運動連合所属
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s429
 # sent_id = test-s429
-# parallel_id = jagsdluw/test429
+# parallel_id = jagsd/test429
 # text = まもなくしてミトライはラテンアメリカの芸術・文化に魅了されはじめた。
 1	ま	間	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マ,間,ま,ま,マ,,,マ,マ,間
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -9836,7 +9836,7 @@
 
 # newdoc id = test-s430
 # sent_id = test-s430
-# parallel_id = jagsdluw/test430
+# parallel_id = jagsd/test430
 # text = そこで、うなぎ屋が山伏を追っかけてその通りに言うと「わしゃ。
 1	そこ	其処	PRON	代名詞	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソコ,其処,そこ,そこ,ソコ,,,ソコ,ソコ,其処
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9858,7 +9858,7 @@
 
 # newdoc id = test-s431
 # sent_id = test-s431
-# parallel_id = jagsdluw/test431
+# parallel_id = jagsd/test431
 # text = 正午からのデモでは,紀尾井町の文芸春秋本社通用門前に30名程の信者が並び,初日からリーダーを務める井口氏の号令で一人ずつビルに向かい抗議の演説。
 1	正午	正午	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウゴ,正午,正午,正午,ショーゴ,,,ショウゴ,ショウゴ,正午
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -9899,7 +9899,7 @@
 
 # newdoc id = test-s432
 # sent_id = test-s432
-# parallel_id = jagsdluw/test432
+# parallel_id = jagsd/test432
 # text = 同大統領は、EU加盟および欧州統合を目指す意向を表明した。
 1	同大統領	同大統領	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;ダイトウリョウ,同;大統領,同;大統領,同;大統領,ドー;ダイトーリョー,;,;,ドウ;ダイトウリョウ,ドウダイトウリョウ,同大統領
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9917,7 +9917,7 @@
 
 # newdoc id = test-s433
 # sent_id = test-s433
-# parallel_id = jagsdluw/test433
+# parallel_id = jagsd/test433
 # text = したがって、横滑り側の片翼の揚力が反対側よりも大きくなり、エルロン操作を行なわなくとも傾きは回復する。
 1	したがって	従って	CCONJ	接続詞	_	22	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シタガウ;テ,従う;て,したがっ;て,したがう;て,シタガッ;テ,;,;,シタガウ;テ,シタガッテ,従って
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9945,7 +9945,7 @@
 
 # newdoc id = test-s434
 # sent_id = test-s434
-# parallel_id = jagsdluw/test434
+# parallel_id = jagsd/test434
 # text = その理由は“科学の無視”です。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	理由	理由	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=リユウ,理由,理由,理由,リユー,,,リユウ,リユウ,理由
@@ -9960,7 +9960,7 @@
 
 # newdoc id = test-s435
 # sent_id = test-s435
-# parallel_id = jagsdluw/test435
+# parallel_id = jagsd/test435
 # text = 艦名はエイの一種であるスケートに因む。
 1	艦名	艦名	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンメイ,艦名,艦名,艦名,カンメー,,,カンメイ,カンメイ,艦名
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9975,7 +9975,7 @@
 
 # newdoc id = test-s436
 # sent_id = test-s436
-# parallel_id = jagsdluw/test436
+# parallel_id = jagsd/test436
 # text = 脱線の原因は不明で、地元の消防局は、煙に有害物質が含まれている可能性があると周辺の住民に注意を呼びかけている。
 1	脱線	脱線	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダッセン,脱線,脱線,脱線,ダッセン,,,ダッセン,ダッセン,脱線
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10012,7 +10012,7 @@
 
 # newdoc id = test-s437
 # sent_id = test-s437
-# parallel_id = jagsdluw/test437
+# parallel_id = jagsd/test437
 # text = こうしたことは、後の大洪水時代においても同様であり、貴族共和制の弱点を突かれたと言える。
 1	こう	こう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウ,こう,こう,こう,コー,,,コウ,コウ,こう
 2	し	する	VERB	動詞-一般-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,スル,する
@@ -10041,7 +10041,7 @@
 
 # newdoc id = test-s438
 # sent_id = test-s438
-# parallel_id = jagsdluw/test438
+# parallel_id = jagsd/test438
 # text = 安徽省安慶出身。
 1	安徽省	安徽省	PROPN	名詞-固有名詞-地名-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アンキ;ショウ,アンキ;省,安徽;省,安徽;省,アンキ;ショー,;,;,アンキ;ショウ,アンキショウ,安徽省
 2	安慶出身	安慶出身	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=アンケイ;シュッシン,アンケイ;出身,安慶;出身,安慶;出身,アンケー;シュッシン,;,;,アンケイ;シュッシン,アンケイシュッシン,安慶出身
@@ -10049,7 +10049,7 @@
 
 # newdoc id = test-s439
 # sent_id = test-s439
-# parallel_id = jagsdluw/test439
+# parallel_id = jagsd/test439
 # text = ペリューは、1804年に少将に昇進した。
 1	ペリュー	ペリュー	PROPN	名詞-固有名詞-人名-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ペリー,ペリー,ペリュー,ペリュー,ペリュー,,,ペリュー,ペリュー,ペリュー
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10064,7 +10064,7 @@
 
 # newdoc id = test-s440
 # sent_id = test-s440
-# parallel_id = jagsdluw/test440
+# parallel_id = jagsd/test440
 # text = グレズリー式連動弁装置は実質上は付加装置であって、外側二気筒の弁装置の位置を逆向きに合成して中央シリンダーの弁位置を決めている。
 1	グレズリー式連動弁装置	グレズリー式連動弁装置	NOUN	名詞-普通名詞-一般	_	24	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=グレズリー;シキ;レンドウ;ベン;ソウチ,グレズリー;式;連動;弁;装置,グレズリー;式;連動;弁;装置,グレズリー;式;連動;弁;装置,グレズリー;シキ;レンドー;ベン;ソーチ,;;;;,;;;;,グレズリー;シキ;レンドウ;ベン;ソウチ,グレズリーシキレンドウベンソウチ,グレズリー式連動弁装置
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10095,7 +10095,7 @@
 
 # newdoc id = test-s441
 # sent_id = test-s441
-# parallel_id = jagsdluw/test441
+# parallel_id = jagsd/test441
 # text = 目標が超音速飛行している場合においても、その時だけ短時間飛行できれば問題無く、長時間の超音速飛行によって追尾する必要は無いからである。
 1	目標	目標	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モクヒョウ,目標,目標,目標,モクヒョー,,,モクヒョウ,モクヒョウ,目標
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -10128,7 +10128,7 @@
 
 # newdoc id = test-s442
 # sent_id = test-s442
-# parallel_id = jagsdluw/test442
+# parallel_id = jagsd/test442
 # text = 新快速の運行時間外などは快速としても運用され、稀に湘南色との混色編成などもあった。
 1	新快速	新快速	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シン;カイソク,新;快速,新;快速,新;快速,シン;カイソク,;,;,シン;カイソク,シンカイソク,新快速
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10155,7 +10155,7 @@
 
 # newdoc id = test-s443
 # sent_id = test-s443
-# parallel_id = jagsdluw/test443
+# parallel_id = jagsd/test443
 # text = 13歳の頃から数々の舞台に出演しており、アル・パチーノとの共演歴もある。
 1	13歳	13歳	NUM	名詞-数詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;サン;サイ,一;三;歳,1;3;歳,1;3;歳,イチ;サン;サイ,;;,;;,イチ;サン;サイ,イチサンサイ,13歳
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10178,7 +10178,7 @@
 
 # newdoc id = test-s444
 # sent_id = test-s444
-# parallel_id = jagsdluw/test444
+# parallel_id = jagsd/test444
 # text = 当初、民主党の西村智奈美が「審議に100時間は必要だ」と主張し、与党側も「重要法案」指定を見送ったことから、第171回国会での公文書管理法の成立は絶望視されていた。
 1	当初	当初	ADV	副詞	_	16	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10222,7 +10222,7 @@
 
 # newdoc id = test-s445
 # sent_id = test-s445
-# parallel_id = jagsdluw/test445
+# parallel_id = jagsd/test445
 # text = 神奈川県鎌倉市北鎌倉出身。
 1	神奈川県	神奈川県	PROPN	名詞-固有名詞-地名-一般	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カナガワ;ケン,カナガワ;県,神奈川;県,神奈川;県,カナガワ;ケン,;,;,カナガワ;ケン,カナガワケン,神奈川県
 2	鎌倉市	鎌倉市	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カマクラ;シ,カマクラ;市,鎌倉;市,鎌倉;市,カマクラ;シ,;,;,カマクラ;シ,カマクラシ,鎌倉市
@@ -10231,7 +10231,7 @@
 
 # newdoc id = test-s446
 # sent_id = test-s446
-# parallel_id = jagsdluw/test446
+# parallel_id = jagsd/test446
 # text = 唯一、最初から冥術を使用できるクラス。
 1	唯一	唯一	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ユイイツ,唯一,唯一,唯一,ユイイツ,,,ユイイツ,ユイイツ,唯一
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10245,7 +10245,7 @@
 
 # newdoc id = test-s447
 # sent_id = test-s447
-# parallel_id = jagsdluw/test447
+# parallel_id = jagsd/test447
 # text = 1883年に家族に連れられてドイツに移住。
 1	1883年	1883年	NUM	名詞-数詞	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ハチ;ハチ;サン;ネン,一;八;八;三;年,1;8;8;3;年,1;8;8;3;年,イチ;ハチ;ハチ;サン;ネン,;;;;,;;;;,イチ;ハチ;ハチ;サン;ネン,イチハチハチサンネン,1883年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -10261,7 +10261,7 @@
 
 # newdoc id = test-s448
 # sent_id = test-s448
-# parallel_id = jagsdluw/test448
+# parallel_id = jagsd/test448
 # text = 味は申し分ない。
 1	味	味	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アジ,味,味,味,アジ,,,アジ,アジ,味
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10271,7 +10271,7 @@
 
 # newdoc id = test-s449
 # sent_id = test-s449
-# parallel_id = jagsdluw/test449
+# parallel_id = jagsd/test449
 # text = そして5月にリリースした「Story」は8位初登場の後、売上枚数30万枚、ダウンロード件数400万件となり、同曲で初のNHK紅白歌合戦出場を果す。
 1	そして	そして	CCONJ	接続詞	_	28	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	5月	5月	NUM	名詞-数詞	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ;ガツ,五;月,5;月,5;月,ゴ;ガツ,;,;,ゴ;ガツ,ゴガツ,5月
@@ -10305,7 +10305,7 @@
 
 # newdoc id = test-s450
 # sent_id = test-s450
-# parallel_id = jagsdluw/test450
+# parallel_id = jagsd/test450
 # text = 詳細は槍槓を参照。
 1	詳細	詳細	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショウサイ,詳細,詳細,詳細,ショーサイ,,,ショウサイ,ショウサイ,詳細
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10316,7 +10316,7 @@
 
 # newdoc id = test-s451
 # sent_id = test-s451
-# parallel_id = jagsdluw/test451
+# parallel_id = jagsd/test451
 # text = プードルの女の子のキャラクター。
 1	プードル	プードル	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=プードル,プードル,プードル,プードル,プードル,,,プードル,プードル,プードル
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10327,7 +10327,7 @@
 
 # newdoc id = test-s452
 # sent_id = test-s452
-# parallel_id = jagsdluw/test452
+# parallel_id = jagsd/test452
 # text = 僕ができるのはクルマのフィードバックだけ。
 1	僕	僕	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ボク,僕,僕,僕,ボク,,,ボク,ボク,僕
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -10342,7 +10342,7 @@
 
 # newdoc id = test-s453
 # sent_id = test-s453
-# parallel_id = jagsdluw/test453
+# parallel_id = jagsd/test453
 # text = バスは園児19人と運転手、幼稚園の職員の計21人が乗車し、幼稚園に向かう途中だった。
 1	バス	バス	NOUN	名詞-普通名詞-一般	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バス,バス,バス,バス,バス,,,バス,バス,バス
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10369,7 +10369,7 @@
 
 # newdoc id = test-s454
 # sent_id = test-s454
-# parallel_id = jagsdluw/test454
+# parallel_id = jagsd/test454
 # text = 一般的にハニー・ライトニング・フレアより威力が高い。
 1	一般的	一般的	ADJ	形状詞-一般	_	7	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッパン;テキ,一般;的,一般;的,一般;的,イッパン;テキ,;,;,イッパン;テキ,イッパンテキ,一般的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -10382,7 +10382,7 @@
 
 # newdoc id = test-s455
 # sent_id = test-s455
-# parallel_id = jagsdluw/test455
+# parallel_id = jagsd/test455
 # text = この地形を利用している生物がアキアカネである。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	地形	地形	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チケイ,地形,地形,地形,チケー,,,チケイ,チケイ,地形
@@ -10397,7 +10397,7 @@
 
 # newdoc id = test-s456
 # sent_id = test-s456
-# parallel_id = jagsdluw/test456
+# parallel_id = jagsd/test456
 # text = 14日未明、ジャーヴィスはスペイン艦隊が風上35マイルにあることを知った。
 1	14日未明	14日未明	ADV	副詞	_	13	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ヨン;カ;ミメイ,一;四;日;未明,1;4;日;未明,1;4;日;未明,イチ;ヨッ;カ;ミメー,;;;,;;;,イチ;ヨ;カ;ミメイ,イチヨンカミメイ,14日未明
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10417,7 +10417,7 @@
 
 # newdoc id = test-s457
 # sent_id = test-s457
-# parallel_id = jagsdluw/test457
+# parallel_id = jagsd/test457
 # text = 考え方の源流は、アルキメデスが円周率の近似値を計算する際に用いた方法にまで遡るが、現代的な形での定式化はガウスによってなされた。
 1	考え方	考え方	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンガエル;カタ,考える;方,考え;方,考える;方,カンガエ;カタ,;,;,カンガエル;カタ,カンガエカタ,考え方
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10456,7 +10456,7 @@
 
 # newdoc id = test-s458
 # sent_id = test-s458
-# parallel_id = jagsdluw/test458
+# parallel_id = jagsd/test458
 # text = 非常に楽しみです。
 1	非常	非常	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒジョウ,非常,非常,非常,ヒジョー,,,ヒジョウ,ヒジョウ,非常
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -10466,7 +10466,7 @@
 
 # newdoc id = test-s459
 # sent_id = test-s459
-# parallel_id = jagsdluw/test459
+# parallel_id = jagsd/test459
 # text = MVPは打率.450、2本塁打、6打点の成績をあげたアラン・トランメルが初選出。
 1	MVP	MVP	NOUN	名詞-普通名詞-一般	_	15	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=エムブイピー,ＭＶＰ,MVP,MVP,エムブイピー,,,エムブイピー,エムブイピー,MVP
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10487,7 +10487,7 @@
 
 # newdoc id = test-s460
 # sent_id = test-s460
-# parallel_id = jagsdluw/test460
+# parallel_id = jagsd/test460
 # text = ラジカルは反応性が高く、生物学的環境ではたいていの場合あまり高濃度では存在せず、ラジカルに1電子を奪われた分子が他の分子から電子を引き抜くとその分子がさらにラジカルを形成するので反応は連鎖的に進行する。
 1	ラジカル	ラジカル	NOUN	名詞-普通名詞-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ラジカル,ラジカル,ラジカル,ラジカル,ラジカル,,,ラジカル,ラジカル,ラジカル
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10542,7 +10542,7 @@
 
 # newdoc id = test-s461
 # sent_id = test-s461
-# parallel_id = jagsdluw/test461
+# parallel_id = jagsd/test461
 # text = 会社の業務もナイフや刀剣の売買が主体となるが、いずれの名称も同好会的な誤解を生じ易いため、そうした誤解を上手く利用して業績を上げたようである。
 1	会社	会社	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイシャ,会社,会社,会社,カイシャ,,,カイシャ,カイシャ,会社
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10588,7 +10588,7 @@
 
 # newdoc id = test-s462
 # sent_id = test-s462
-# parallel_id = jagsdluw/test462
+# parallel_id = jagsd/test462
 # text = これは、学校教育や大手新聞やテレビや書籍で、「日本は韓国の優れた文化を受け入れるだけの文化劣等国」「有史以来一枚見下げるべき文化的劣等者」「韓半島に比べてみすぼらしくて短い歴史しか持たず、歴史を捏造するしかない日本」というような対日蔑視に基づいた誤った論評が日常的に行われたり、日本列島を指す「島国」という言葉が「劣等で未開」という意味で使われて、駐日韓国大使がテレビのインタビューで使うまでになっていることからも伺える。
 1	これ	此れ	PRON	代名詞	_	105	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10699,7 +10699,7 @@
 
 # newdoc id = test-s463
 # sent_id = test-s463
-# parallel_id = jagsdluw/test463
+# parallel_id = jagsd/test463
 # text = 同校は1923年に創立された、ヒューストンでは最も長い歴史を誇る法学校で、模擬裁判プログラムがつとに良く知られている。
 1	同校	同校	NOUN	名詞-普通名詞-一般	_	24	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウコウ,同校,同校,同校,ドーコー,,,ドウコウ,ドウコウ,同校
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10731,7 +10731,7 @@
 
 # newdoc id = test-s464
 # sent_id = test-s464
-# parallel_id = jagsdluw/test464
+# parallel_id = jagsd/test464
 # text = 横須賀線への転属後、主電動機を強力形に交換した7両が新形式のモハ53形を付与された。
 1	横須賀線	横須賀線	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨコスカ;セン,ヨコスカ;線,横須賀;線,横須賀;線,ヨコスカ;セン,;,;,ヨコスカ;セン,ヨコスカセン,横須賀線
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -10757,7 +10757,7 @@
 
 # newdoc id = test-s465
 # sent_id = test-s465
-# parallel_id = jagsdluw/test465
+# parallel_id = jagsd/test465
 # text = 変更点の詳細については、タイムクライシス4の項を参照のこと。
 1	変更点	変更点	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヘンコウ;テン,変更;点,変更;点,変更;点,ヘンコー;テン,;,;,ヘンコウ;テン,ヘンコウテン,変更点
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10777,7 +10777,7 @@
 
 # newdoc id = test-s466
 # sent_id = test-s466
-# parallel_id = jagsdluw/test466
+# parallel_id = jagsd/test466
 # text = 一部で9月中間期の連結営業利益が36億円前後と前年同期比35%程度増えたようだと伝えられたことが買い材料となった。
 1	一部	一部	NOUN	名詞-普通名詞-一般	_	16	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチブ,一部,一部,一部,イチブ,,,イチブ,イチブ,一部
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -10807,7 +10807,7 @@
 
 # newdoc id = test-s467
 # sent_id = test-s467
-# parallel_id = jagsdluw/test467
+# parallel_id = jagsd/test467
 # text = 便宜的に分類したがもちろん複数のケースにまたがった適応を示す動物も多い。
 1	便宜的	便宜的	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ベンギ;テキ,便宜;的,便宜;的,便宜;的,ベンギ;テキ,;,;,ベンギ;テキ,ベンギテキ,便宜的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -10831,7 +10831,7 @@
 
 # newdoc id = test-s468
 # sent_id = test-s468
-# parallel_id = jagsdluw/test468
+# parallel_id = jagsd/test468
 # text = 12月2日の午後、ドイツ空軍パイロット、ヴェルナー・ハーンはMe210でバーリを上空から偵察した。
 1	12月	12月	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;ニ;ガツ,一;二;月,1;2;月,1;2;月,イチ;ニ;ガツ,;;,;;,イチ;ニ;ガツ,イチニガツ,12月
 2	2日	2日	NUM	名詞-数詞	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=フタ;カ,二;日,2;日,2;日,フツ;カ,;,;,フツ;カ,フタカ,2日
@@ -10854,7 +10854,7 @@
 
 # newdoc id = test-s469
 # sent_id = test-s469
-# parallel_id = jagsdluw/test469
+# parallel_id = jagsd/test469
 # text = 暴騰する食料価格や大災害で人心は荒廃し、食料目当ての暴動や若者の退廃が進行。
 1	暴騰する	暴騰する	VERB	動詞-一般-サ行変格	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ボウトウ;スル,暴騰;為る,暴騰;する,暴騰;する,ボートー;スル,;,;,ボウトウ;スル,ボウトウスル,暴騰する
 2	食料価格	食料価格	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ショクリョウ;カカク,食料;価格,食料;価格,食料;価格,ショクリョー;カカク,;,;,ショクリョウ;カカク,ショクリョウカカク,食料価格
@@ -10878,7 +10878,7 @@
 
 # newdoc id = test-s470
 # sent_id = test-s470
-# parallel_id = jagsdluw/test470
+# parallel_id = jagsd/test470
 # text = 幸福の科学学園の毎時4.20マイクロシーベルトというこの基準を上回ります。
 1	幸福の科学学園	幸福の科学学園	PROPN	名詞-固有名詞-一般	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウフク;ノ;カガク;ガクエン,幸福;の;科学;学園,幸福;の;科学;学園,幸福;の;科学;学園,コーフク;ノ;カガク;ガクエン,;;;,;;;,コウフク;ノ;カガク;ガクエン,コウフクノカガクガクエン,幸福の科学学園
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10894,7 +10894,7 @@
 
 # newdoc id = test-s471
 # sent_id = test-s471
-# parallel_id = jagsdluw/test471
+# parallel_id = jagsd/test471
 # text = 長時間拘束され半軟禁状態の女性もいた。
 1	長時間	長時間	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チョウ;ジカン,長;時間,長;時間,長;時間,チョー;ジカン,;,;,チョウ;ジカン,チョウジカン,長時間
 2	拘束さ	拘束する	VERB	動詞-一般-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウソク;スル,拘束;為る,拘束;さ,拘束;する,コーソク;サ,;,;,コウソク;スル,コウソクスル,拘束する
@@ -10909,7 +10909,7 @@
 
 # newdoc id = test-s472
 # sent_id = test-s472
-# parallel_id = jagsdluw/test472
+# parallel_id = jagsd/test472
 # text = 同発電所は老朽化した小規模の発電所で、警備は手薄だった。
 1	同発電所	同発電所	NOUN	名詞-普通名詞-一般	_	12	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドウ;ハツデン;ショ,同;発電;所,同;発電;所,同;発電;所,ドー;ハツデン;ショ,;;,;;,ドウ;ハツデン;ショ,ドウハツデンショ,同発電所
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10929,7 +10929,7 @@
 
 # newdoc id = test-s473
 # sent_id = test-s473
-# parallel_id = jagsdluw/test473
+# parallel_id = jagsd/test473
 # text = 回転ジェットによる体当たり攻撃。
 1	回転ジェット	回転ジェット	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイテン;ジェット,回転;ジェット,回転;ジェット,回転;ジェット,カイテン;ジェット,;,;,カイテン;ジェット,カイテンジェット,回転ジェット
 2	による	による	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル,に;因る,に;よる,に;よる,ニ;ヨル,;,;,ニ;ヨル,ニヨル,による
@@ -10938,7 +10938,7 @@
 
 # newdoc id = test-s474
 # sent_id = test-s474
-# parallel_id = jagsdluw/test474
+# parallel_id = jagsd/test474
 # text = 屋根のアンテナにカラスが止まっていたずらをするし、屋根が汚れてこまるからと、調査の依頼がありました。
 1	屋根	屋根	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤネ,屋根,屋根,屋根,ヤネ,,,ヤネ,ヤネ,屋根
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10972,7 +10972,7 @@
 
 # newdoc id = test-s475
 # sent_id = test-s475
-# parallel_id = jagsdluw/test475
+# parallel_id = jagsd/test475
 # text = そのカステラは,表面に“祝3.16広宣流布記念の日”と印字されており,これを買うと,創価学会のシンボルである3色デザインの紙袋に入れてくれます。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	カステラ	カステラ	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カステラ,カステラ,カステラ,カステラ,カステラ,,,カステラ,カステラ,カステラ
@@ -11011,7 +11011,7 @@
 
 # newdoc id = test-s476
 # sent_id = test-s476
-# parallel_id = jagsdluw/test476
+# parallel_id = jagsd/test476
 # text = 13世紀の建築は1456年から1466年にかけて新しいサンクチュアリに合うように改築された。
 1	13世紀	13世紀	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;サン;セイキ,一;三;世紀,1;3;世紀,1;3;世紀,イチ;サン;セーキ,;;,;;,イチ;サン;セイキ,イチサンセイキ,13世紀
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11036,7 +11036,7 @@
 
 # newdoc id = test-s477
 # sent_id = test-s477
-# parallel_id = jagsdluw/test477
+# parallel_id = jagsd/test477
 # text = インクは、大きく分けてビン入りとカートリッジ入りの2種類の形態で流通している。
 1	インク	インク	NOUN	名詞-普通名詞-一般	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=インク,インク,インク,インク,インク,,,インク,インク,インク
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11058,7 +11058,7 @@
 
 # newdoc id = test-s478
 # sent_id = test-s478
-# parallel_id = jagsdluw/test478
+# parallel_id = jagsd/test478
 # text = 勧誘員と勧誘対象者。
 1	勧誘員	勧誘員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンユウ;イン,勧誘;員,勧誘;員,勧誘;員,カンユー;イン,;,;,カンユウ;イン,カンユウイン,勧誘員
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -11067,7 +11067,7 @@
 
 # newdoc id = test-s479
 # sent_id = test-s479
-# parallel_id = jagsdluw/test479
+# parallel_id = jagsd/test479
 # text = また、攻撃手法としてはJava Scriptの難読化による手口や、PDFを利用した攻撃が引き続き増加しており、フィッシング詐欺の発生件数は2009年のピーク時に比べて82%減少したが、依然として金融機関が主要ターゲットとして脅威に晒されているとしている。
 1	また	又	CCONJ	接続詞	_	51	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -11125,7 +11125,7 @@
 
 # newdoc id = test-s480
 # sent_id = test-s480
-# parallel_id = jagsdluw/test480
+# parallel_id = jagsd/test480
 # text = これがまた,うまい。
 1	これ	此れ	PRON	代名詞	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -11136,7 +11136,7 @@
 
 # newdoc id = test-s481
 # sent_id = test-s481
-# parallel_id = jagsdluw/test481
+# parallel_id = jagsd/test481
 # text = 艦長は、爆薬をリモコンによる遠隔操作で爆発させて艦内の機材や機密文書等を爆破処分し、証拠を隠滅しようとしたが、効果は不十分に終わった。
 1	艦長	艦長	NOUN	名詞-普通名詞-一般	_	25	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カンチョウ,艦長,艦長,艦長,カンチョー,,,カンチョウ,カンチョウ,艦長
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11176,7 +11176,7 @@
 
 # newdoc id = test-s482
 # sent_id = test-s482
-# parallel_id = jagsdluw/test482
+# parallel_id = jagsd/test482
 # text = アイドルユニットとしても売り出され、フリーランスになってからは主演Vシネマの主題歌CDもだし、歌手デビューも果たす。
 1	アイドルユニット	アイドルユニット	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アイドル;ユニット,アイドル;ユニット,アイドル;ユニット,アイドル;ユニット,アイドル;ユニット,;,;,アイドル;ユニット,アイドルユニット,アイドルユニット
 2	として	として	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト;スル;テ,と;為る;て,と;し;て,と;する;て,ト;シ;テ,;;,;;,ト;スル;テ,トシテ,として
@@ -11203,7 +11203,7 @@
 
 # newdoc id = test-s483
 # sent_id = test-s483
-# parallel_id = jagsdluw/test483
+# parallel_id = jagsd/test483
 # text = 毛布にくるまって寒さをしのぎ、おにぎり1個を家族4人で分け合った。
 1	毛布	毛布	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モウフ,毛布,毛布,毛布,モーフ,,,モウフ,モウフ,毛布
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11225,7 +11225,7 @@
 
 # newdoc id = test-s484
 # sent_id = test-s484
-# parallel_id = jagsdluw/test484
+# parallel_id = jagsd/test484
 # text = 動きは緩慢だが常にスーパーアーマー状態であり、ほとんどの攻撃を受けてもひるまない。
 1	動き	動き	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウゴキ,動き,動き,動き,ウゴキ,,,ウゴキ,ウゴキ,動き
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11250,7 +11250,7 @@
 
 # newdoc id = test-s485
 # sent_id = test-s485
-# parallel_id = jagsdluw/test485
+# parallel_id = jagsd/test485
 # text = よく見ると、背中や腹にあるぶち模様がいずれもハートの形をしており「体全体にハートがある猫」と口コミで広がったという。
 1	よく	良く	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨク,良く,よく,よく,ヨク,,,ヨク,ヨク,良く
 2	見る	見る	VERB	動詞-一般-上一段-マ行	_	18	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|PrevUDLemma=みる|SpaceAfter=No|UnidicInfo=ミル,見る,見る,見る,ミル,,,ミル,ミル,見る
@@ -11290,7 +11290,7 @@
 
 # newdoc id = test-s486
 # sent_id = test-s486
-# parallel_id = jagsdluw/test486
+# parallel_id = jagsd/test486
 # text = タダで留学生が韓国料理をふるまい,韓国語も教えるので,日本語を教えてもらったり,友達になってもらいたい。
 1	タダ	只	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダ,只,タダ,タダ,タダ,,,タダ,タダ,只
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11320,7 +11320,7 @@
 
 # newdoc id = test-s487
 # sent_id = test-s487
-# parallel_id = jagsdluw/test487
+# parallel_id = jagsd/test487
 # text = 「VANITY DANCE」と「Labyrinth」は、オムニバスアルバム『漆黒のシンフォニー』に収録されたもののリミックスバージョンである。
 1	「	「	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	VANITY DANCE	VANITY DANCE	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バニティ;ダンス,バニティ;ダンス,VANITY;DANCE,;DANCE,バニティ;ダンス,;,;,バニティ;ダンス,バニティダンス,VANITYDANCE
@@ -11349,7 +11349,7 @@
 
 # newdoc id = test-s488
 # sent_id = test-s488
-# parallel_id = jagsdluw/test488
+# parallel_id = jagsd/test488
 # text = そのうちの幾つかはイギリス当局がケニア人を抑圧した方法をそのまま転用したものだった。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	うち	家	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ウチ,内,うち,うち,ウチ,,,ウチ,ウチ,家
@@ -11376,7 +11376,7 @@
 
 # newdoc id = test-s489
 # sent_id = test-s489
-# parallel_id = jagsdluw/test489
+# parallel_id = jagsd/test489
 # text = 縦に並ぶ4門の砲台から、それぞれバウンド弾、ブーメラン弾、誘導弾、レーザーを発射する。
 1	縦	縦	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タテ,縦,縦,縦,タテ,,,タテ,タテ,縦
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11400,7 +11400,7 @@
 
 # newdoc id = test-s490
 # sent_id = test-s490
-# parallel_id = jagsdluw/test490
+# parallel_id = jagsd/test490
 # text = 木炭デッサンにおいて消しゴムは硬くて紙を傷めるために使用できず、柔らかく油分の少ない食パンを代用している。
 1	木炭デッサン	木炭デッサン	NOUN	名詞-普通名詞-一般	_	20	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モクタン;デッサン,木炭;デッサン,木炭;デッサン,木炭;デッサン,モクタン;デッサン,;,;,モクタン;デッサン,モクタンデッサン,木炭デッサン
 2	において	において	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;オク;テ,に;於く;て,に;おい;て,に;おく;て,ニ;オイ;テ,;;,;;,ニ;オク;テ,ニオイテ,において
@@ -11427,7 +11427,7 @@
 
 # newdoc id = test-s491
 # sent_id = test-s491
-# parallel_id = jagsdluw/test491
+# parallel_id = jagsd/test491
 # text = 大変,卑怯といわざるをえない。
 1	大変	大変	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タイヘン,大変,大変,大変,タイヘン,,,タイヘン,タイヘン,大変
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,，,,,,,,,,，
@@ -11439,7 +11439,7 @@
 
 # newdoc id = test-s492
 # sent_id = test-s492
-# parallel_id = jagsdluw/test492
+# parallel_id = jagsd/test492
 # text = いろんなメニューがあり、どんどん頼みたくなっちゃいますね!
 1	いろんな	色んな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イロンナ,色んな,いろんな,いろんな,イロンナ,,,イロンナ,イロンナ,色んな
 2	メニュー	メニュー	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=メニュー,メニュー,メニュー,メニュー,メニュー,,,メニュー,メニュー,メニュー
@@ -11457,7 +11457,7 @@
 
 # newdoc id = test-s493
 # sent_id = test-s493
-# parallel_id = jagsdluw/test493
+# parallel_id = jagsd/test493
 # text = この手の本が翻訳されることは少ないと思っていたのだが,昨今のソーシャル流行りが要因かはわからないが,翻訳本が原書から1年もしないでリリースされたのはよい知らせだ。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	手	手	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テ,手,手,手,テ,,,テ,テ,手
@@ -11508,7 +11508,7 @@
 
 # newdoc id = test-s494
 # sent_id = test-s494
-# parallel_id = jagsdluw/test494
+# parallel_id = jagsd/test494
 # text = 「1997〜1999」とは、FBIがデビューした年から本作が発売された年を意味する。
 1	「	「	PUNCT	補助記号-括弧開	_	4	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	1997	1997	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;キュウ;キュウ;ナナ,一;九;九;七,1;9;9;7,1;9;9;7,イチ;キュー;キュー;ナナ,;;;,;;;,イチ;キュウ;キュウ;ナナ,イチキュウキュウナナ,1997
@@ -11536,7 +11536,7 @@
 
 # newdoc id = test-s495
 # sent_id = test-s495
-# parallel_id = jagsdluw/test495
+# parallel_id = jagsd/test495
 # text = 生きていくことは美しいことだといつも思う。
 1	生き	生きる	VERB	動詞-一般-上一段-カ行	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イキル,生きる,生き,生きる,イキ,,,イキル,イキル,生きる
 2	ていく	ていく	AUX	助動詞-五段-カ行	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ;イク,て;行く,て;いく,て;いく,テ;イク,;,;,テ;イク,テイク,ていく
@@ -11553,7 +11553,7 @@
 
 # newdoc id = test-s496
 # sent_id = test-s496
-# parallel_id = jagsdluw/test496
+# parallel_id = jagsd/test496
 # text = ドラゴンズは9番チェンからの打順だったが、代打に水田を送る。
 1	ドラゴンズ	ドラゴンズ	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ドラゴン,ドラゴン,ドラゴンズ,ドラゴンズ,ドラゴンズ,,,ドラゴンズ,ドラゴンズ,ドラゴンズ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11575,7 +11575,7 @@
 
 # newdoc id = test-s497
 # sent_id = test-s497
-# parallel_id = jagsdluw/test497
+# parallel_id = jagsd/test497
 # text = ダウンタウンの17ブロックにわたって広がるシアター・ディストリクトには9つの著名な演技芸術団体が本部を置き、6ヶ所のホールが立地している。
 1	ダウンタウン	ダウンタウン	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダウンタウン,ダウンタウン,ダウンタウン,ダウンタウン,ダウンタウン,,,ダウンタウン,ダウンタウン,ダウンタウン
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11605,7 +11605,7 @@
 
 # newdoc id = test-s498
 # sent_id = test-s498
-# parallel_id = jagsdluw/test498
+# parallel_id = jagsd/test498
 # text = 昔ながらの「売りっぱなし」商売をしている。
 1	昔ながら	昔乍ら	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ムカシ;ナガラ,昔;乍ら,昔;ながら,昔;ながら,ムカシ;ナガラ,;,;,ムカシ;ナガラ,ムカシナガラ,昔乍ら
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11617,7 +11617,7 @@
 
 # newdoc id = test-s499
 # sent_id = test-s499
-# parallel_id = jagsdluw/test499
+# parallel_id = jagsd/test499
 # text = 中学ではシェークスピア・ギリシア哲学・演劇にも熱中した。
 1	中学	中学	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウガク,中学,中学,中学,チューガク,,,チュウガク,チュウガク,中学
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11631,7 +11631,7 @@
 
 # newdoc id = test-s500
 # sent_id = test-s500
-# parallel_id = jagsdluw/test500
+# parallel_id = jagsd/test500
 # text = 後の稲川組幹部)と知り合い、出口辰夫と兄弟分となった。
 1	後	後	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ノチ,後,後,後,ノチ,,,ノチ,ノチ,後
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11650,7 +11650,7 @@
 
 # newdoc id = test-s501
 # sent_id = test-s501
-# parallel_id = jagsdluw/test501
+# parallel_id = jagsd/test501
 # text = 会議後は資料作成などに着手し、退社は夜12時前後。
 1	会議後	会議後	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カイギ;ゴ,会議;後,会議;後,会議;後,カイギ;ゴ,;,;,カイギ;ゴ,カイギゴ,会議後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11667,7 +11667,7 @@
 
 # newdoc id = test-s502
 # sent_id = test-s502
-# parallel_id = jagsdluw/test502
+# parallel_id = jagsd/test502
 # text = 現在の計画停電の3時間であれば、つけっぱなしにしても大丈夫そうだ。
 1	現在	現在	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11689,7 +11689,7 @@
 
 # newdoc id = test-s503
 # sent_id = test-s503
-# parallel_id = jagsdluw/test503
+# parallel_id = jagsd/test503
 # text = 皮肉なことに信濃町は,共産党タウン以上に北朝鮮的な街なのである。
 1	皮肉	皮肉	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヒニク,皮肉,皮肉,皮肉,ヒニク,,,ヒニク,ヒニク,皮肉
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -11709,7 +11709,7 @@
 
 # newdoc id = test-s504
 # sent_id = test-s504
-# parallel_id = jagsdluw/test504
+# parallel_id = jagsd/test504
 # text = 一般的に、貧栄養な外洋では生物過程による全エネルギー・炭素フラックスに占める微生物環の割合が沿岸や内湾よりも高い。
 1	一般的	一般的	ADJ	形状詞-一般	_	23	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッパン;テキ,一般;的,一般;的,一般;的,イッパン;テキ,;,;,イッパン;テキ,イッパンテキ,一般的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -11738,7 +11738,7 @@
 
 # newdoc id = test-s505
 # sent_id = test-s505
-# parallel_id = jagsdluw/test505
+# parallel_id = jagsd/test505
 # text = ストリンガー氏は震災発生時は米国におり、被災現場を訪れたのは初めて。
 1	ストリンガー氏	ストリンガー氏	PROPN	名詞-固有名詞-人名-一般	_	15	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ストリンガー;シ,ストリンガー;氏,ストリンガー;氏,ストリンガー;氏,ストリンガー;シ,;,;,ストリンガー;シ,ストリンガーシ,ストリンガー氏
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11759,7 +11759,7 @@
 
 # newdoc id = test-s506
 # sent_id = test-s506
-# parallel_id = jagsdluw/test506
+# parallel_id = jagsd/test506
 # text = ジョージ・ハリスンの作品。
 1	ジョージ・ハリスン	ジョージ・ハリスン	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジョージ;;ハリソン,ジョージ;・;ハリソン,ジョージ;・;ハリスン,ジョージ;・;ハリスン,ジョージ;;ハリスン,;;,;;,ジョージ;;ハリスン,ジョージハリスン,ジョージ・ハリスン
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11768,7 +11768,7 @@
 
 # newdoc id = test-s507
 # sent_id = test-s507
-# parallel_id = jagsdluw/test507
+# parallel_id = jagsd/test507
 # text = 前作では10枚以上コインを取るとスーパーキノコが出てきたが、本作ではコインが5枚散らばるようになっている。
 1	前作	前作	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゼンサク,前作,前作,前作,ゼンサク,,,ゼンサク,ゼンサク,前作
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11800,7 +11800,7 @@
 
 # newdoc id = test-s508
 # sent_id = test-s508
-# parallel_id = jagsdluw/test508
+# parallel_id = jagsd/test508
 # text = 籾井王子から紀州街道旧道を西に1.5kmほど進み、海営宮池という池の近くの交差点を北に向かう脇道に入ったところに墓地があり、その北側に石碑と説明板がある。
 1	籾井王子	籾井王子	PROPN	名詞-固有名詞-地名-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=モロイ;オウジ,モロイ;オウジ,籾井;王子,籾井;王子,モロイ;オージ,;,;,モロイ;オウジ,モロイオウジ,籾井王子
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -11845,7 +11845,7 @@
 
 # newdoc id = test-s509
 # sent_id = test-s509
-# parallel_id = jagsdluw/test509
+# parallel_id = jagsd/test509
 # text = 2006年11月8日、関東地方から東北地方にかけてカリオペとリヌスによる恒星の掩蔽がアマチュア天文家たちによって観測され、カリオペとリヌスの正確な大きさと位置が求められた。
 1	2006年	2006年	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ロク;ネン,二;ゼロ;ゼロ;六;年,2;0;0;6;年,2;0;0;6;年,ニ;ゼロ;ゼロ;ロク;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ロク;ネン,ニゼロゼロロクネン,2006年
 2	11月	11月	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=イチ;イチ;ガツ,一;一;月,1;1;月,1;1;月,イチ;イチ;ガツ,;;,;;,イチ;イチ;ガツ,イチイチガツ,11月
@@ -11887,7 +11887,7 @@
 
 # newdoc id = test-s510
 # sent_id = test-s510
-# parallel_id = jagsdluw/test510
+# parallel_id = jagsd/test510
 # text = 一方、東海地方北陸地方以東の東日本は、比較的広い沖積平野に恵まれていた上に、太平洋側を中心に低開発状態の洪積台地や河岸段丘面の農地開発の余地が大きく、日本海側を中心に扇状地でも開発の余地が広く存在したため、江戸時代に至っても、急峻な山地の傾斜面を切り開いて棚田をつくるまでに至らなかったところが多く、棚田はあまりつくられないか、つくられた場合でも畔や土手は傾斜が緩やかな土盛りとなり、西日本とは対照的な棚田風景となった。
 1	一方	一方	CCONJ	接続詞	_	106	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -12000,7 +12000,7 @@
 
 # newdoc id = test-s511
 # sent_id = test-s511
-# parallel_id = jagsdluw/test511
+# parallel_id = jagsd/test511
 # text = 帰り道、あまり気持ちよかったのでフワフワしちゃいましたよ。
 1	帰り道	帰り道	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=カエリミチ,帰り道,帰り道,帰り道,カエリミチ,,,カエリミチ,カエリミチ,帰り道
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -12018,7 +12018,7 @@
 
 # newdoc id = test-s512
 # sent_id = test-s512
-# parallel_id = jagsdluw/test512
+# parallel_id = jagsd/test512
 # text = 当駅の所在する地名より。
 1	当駅	当駅	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウエキ,当駅,当駅,当駅,トーエキ,,,トウエキ,トウエキ,当駅
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12029,7 +12029,7 @@
 
 # newdoc id = test-s513
 # sent_id = test-s513
-# parallel_id = jagsdluw/test513
+# parallel_id = jagsd/test513
 # text = 右腕からチャージショットを放つ「ハイパーZEROブラスター」は火力が高く、空中でのけん制にも使えるなどゼロにとって重要な技となる。
 1	右腕	右腕	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミギウデ,右腕,右腕,右腕,ミギウデ,,,ミギウデ,ミギウデ,右腕
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -12063,7 +12063,7 @@
 
 # newdoc id = test-s514
 # sent_id = test-s514
-# parallel_id = jagsdluw/test514
+# parallel_id = jagsd/test514
 # text = 本当に焼いただけでいただけるというところが気に入っています。
 1	本当	本当	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ホントウ,本当,本当,本当,ホントー,,,ホントウ,ホントウ,本当
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -12084,7 +12084,7 @@
 
 # newdoc id = test-s515
 # sent_id = test-s515
-# parallel_id = jagsdluw/test515
+# parallel_id = jagsd/test515
 # text = 安くて早いから、この系列店をよく使わせてもらっているが、ここはカットが下手過ぎる。
 1	安く	安い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヤスイ,安い,安く,安い,ヤスク,,,ヤスイ,ヤスイ,安い
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -12110,7 +12110,7 @@
 
 # newdoc id = test-s516
 # sent_id = test-s516
-# parallel_id = jagsdluw/test516
+# parallel_id = jagsd/test516
 # text = また利用したいです。
 1	また	又	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	利用し	利用する	VERB	動詞-一般-サ行変格	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=リヨウ;スル,利用;為る,利用;し,利用;する,リヨー;シ,;,;,リヨウ;スル,リヨウスル,利用する
@@ -12120,7 +12120,7 @@
 
 # newdoc id = test-s517
 # sent_id = test-s517
-# parallel_id = jagsdluw/test517
+# parallel_id = jagsd/test517
 # text = 天理教は,新宿区高田馬場にある牛込大教会を開放。
 1	天理教	天理教	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=テンリ;キョウ,テンリ;教,天理;教,天理;教,テンリ;キョー,;,;,テンリ;キョウ,テンリキョウ,天理教
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12136,7 +12136,7 @@
 
 # newdoc id = test-s518
 # sent_id = test-s518
-# parallel_id = jagsdluw/test518
+# parallel_id = jagsd/test518
 # text = 馬鹿な事を続けていれば信者からの求心力がどんどん失われていくでしょうから,そのままカルト崩壊へGO!
 1	馬鹿	馬鹿	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バカ,馬鹿,馬鹿,馬鹿,バカ,,,バカ,バカ,馬鹿
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -12166,7 +12166,7 @@
 
 # newdoc id = test-s519
 # sent_id = test-s519
-# parallel_id = jagsdluw/test519
+# parallel_id = jagsd/test519
 # text = 生理的に嫌。
 1	生理的	生理的	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=セイリ;テキ,生理;的,生理;的,生理;的,セーリ;テキ,;,;,セイリ;テキ,セイリテキ,生理的
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -12175,7 +12175,7 @@
 
 # newdoc id = test-s520
 # sent_id = test-s520
-# parallel_id = jagsdluw/test520
+# parallel_id = jagsd/test520
 # text = 言い回しや態度が妙に芝居がかっており、プレイヤーからは「キモイ」と言われていた。
 1	言い回し	言い回し	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イイマワシ,言い回し,言い回し,言い回し,イーマワシ,,,イイマワシ,イイマワシ,言い回し
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -12201,7 +12201,7 @@
 
 # newdoc id = test-s521
 # sent_id = test-s521
-# parallel_id = jagsdluw/test521
+# parallel_id = jagsd/test521
 # text = 十メートル長の巨大なライフルと、周囲の景色に同化する機能を持つマントを駆使するスナイパー。
 1	十メートル長	十メートル長	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ジュウ;メートル;チョウ,十;メートル;長,十;メートル;長,十;メートル;長,ジュー;メートル;チョー,;;,;;,ジュウ;メートル;チョウ,ジュウメートルチョウ,十メートル長
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12226,7 +12226,7 @@
 
 # newdoc id = test-s522
 # sent_id = test-s522
-# parallel_id = jagsdluw/test522
+# parallel_id = jagsd/test522
 # text = 猫が亡くなった今でも心から感謝しています。
 1	猫	猫	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ネコ,猫,猫,猫,ネコ,,,ネコ,ネコ,猫
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -12244,7 +12244,7 @@
 
 # newdoc id = test-s523
 # sent_id = test-s523
-# parallel_id = jagsdluw/test523
+# parallel_id = jagsd/test523
 # text = 2008年1月から6月に振り込め詐欺・オレオレ詐欺で使用された携帯電話約2,300台のうち約7割がソフトバンク携帯だったとの報道が12月にあった。
 1	2008年	2008年	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ハチ;ネン,二;ゼロ;ゼロ;八;年,2;0;0;8;年,2;0;0;8;年,ニ;ゼロ;ゼロ;ハチ;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ハチ;ネン,ニゼロゼロハチネン,2008年
 2	1月	1月	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=イチ;ガツ,一;月,1;月,1;月,イチ;ガツ,;,;,イチ;ガツ,イチガツ,1月
@@ -12277,7 +12277,7 @@
 
 # newdoc id = test-s524
 # sent_id = test-s524
-# parallel_id = jagsdluw/test524
+# parallel_id = jagsd/test524
 # text = これにより業務協力で会員社の経営の効率化を図った。
 1	これ	此れ	PRON	代名詞	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	により	により	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル,に;因る,に;より,に;よる,ニ;ヨリ,;,;,ニ;ヨル,ニヨリ,により
@@ -12295,7 +12295,7 @@
 
 # newdoc id = test-s525
 # sent_id = test-s525
-# parallel_id = jagsdluw/test525
+# parallel_id = jagsd/test525
 # text = 水牛のような角を持つ漆黒の巨人の姿をしており、目から放つ光線であらゆる物を砂に変えて崩壊させる。
 1	水牛	水牛	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スイギュウ,水牛,水牛,水牛,スイギュー,,,スイギュウ,スイギュウ,水牛
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12331,7 +12331,7 @@
 
 # newdoc id = test-s526
 # sent_id = test-s526
-# parallel_id = jagsdluw/test526
+# parallel_id = jagsd/test526
 # text = ただし、書いていないのか未採択なのかの区別をつけるために「研究」節内で「*私立大学学術研究高度化推進事業の採択はない。
 1	ただし	但し	CCONJ	接続詞	_	25	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -12362,7 +12362,7 @@
 
 # newdoc id = test-s527
 # sent_id = test-s527
-# parallel_id = jagsdluw/test527
+# parallel_id = jagsd/test527
 # text = 男は女の為に闘い抜いたとき女は心を寄せるのであって,何もしないで足の長さで女を釣ろうとするのはルンペンのやることである。
 1	男	男	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=オトコ,男,男,男,オトコ,,,オトコ,オトコ,男
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12406,7 +12406,7 @@
 
 # newdoc id = test-s528
 # sent_id = test-s528
-# parallel_id = jagsdluw/test528
+# parallel_id = jagsd/test528
 # text = 後続の車両の方がBAの番号は若いが、BA-27の27は開発年度から来ているものと以降の車両はほぼ製作順に番号が並んでいる。
 1	後続	後続	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウゾク,後続,後続,後続,コーゾク,,,コウゾク,コウゾク,後続
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12446,7 +12446,7 @@
 
 # newdoc id = test-s529
 # sent_id = test-s529
-# parallel_id = jagsdluw/test529
+# parallel_id = jagsd/test529
 # text = ご理解とご協力,よろしくお願いいたします。
 1	ご理解	御理解	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴ;リカイ,御;理解,ご;理解,ご;理解,ゴ;リカイ,;,;,ゴ;リカイ,ゴリカイ,御理解
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -12459,7 +12459,7 @@
 
 # newdoc id = test-s530
 # sent_id = test-s530
-# parallel_id = jagsdluw/test530
+# parallel_id = jagsd/test530
 # text = 亜大の東浜も6回で12三振を奪った。
 1	亜大	亜大	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アダイ,亜大,亜大,亜大,アダイ,,,アダイ,アダイ,亜大
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12475,7 +12475,7 @@
 
 # newdoc id = test-s531
 # sent_id = test-s531
-# parallel_id = jagsdluw/test531
+# parallel_id = jagsd/test531
 # text = 直人の妻。
 1	直人	直人	PROPN	名詞-固有名詞-人名-名	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナオト,ナオト,直人,直人,ナオト,,,ナオト,ナオト,直人
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12484,7 +12484,7 @@
 
 # newdoc id = test-s532
 # sent_id = test-s532
-# parallel_id = jagsdluw/test532
+# parallel_id = jagsd/test532
 # text = まあAIDMA,AISASをはじめとするSIPSみたいな言葉には最近嫌悪感すらするのだけど,モデルとしては判りやすい。
 1	まあ	まあ	ADV	副詞	_	25	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マア,まあ,まあ,まあ,マー,,,マア,マア,まあ
 2	AIDMA	AIDMA	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アイドマ,ＡＩＤＭＡ,AIDMA,AIDMA,アイドマ,,,アイドマ,アイドマ,AIDMA
@@ -12515,7 +12515,7 @@
 
 # newdoc id = test-s533
 # sent_id = test-s533
-# parallel_id = jagsdluw/test533
+# parallel_id = jagsd/test533
 # text = 2006年には柏レイソルの監督に就任。
 1	2006年	2006年	NUM	名詞-数詞	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニ;ゼロ;ゼロ;ロク;ネン,二;ゼロ;ゼロ;六;年,2;0;0;6;年,2;0;0;6;年,ニ;ゼロ;ゼロ;ロク;ネン,;;;;,;;;;,ニ;ゼロ;ゼロ;ロク;ネン,ニゼロゼロロクネン,2006年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -12529,7 +12529,7 @@
 
 # newdoc id = test-s534
 # sent_id = test-s534
-# parallel_id = jagsdluw/test534
+# parallel_id = jagsd/test534
 # text = ポッドキャスト用アグリゲータの主な目的はRSSに関連付けされているポッドキャスト・ファイルのダウンロードだが、音楽再生機能を持ち、ダウンロードしたファイルを直接再生できるものも多い。
 1	ポッドキャスト用アグリゲータ	ポッドキャスト用	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ポッド;キャスト;ヨウ;アグリゲーター,ポッド;キャスト;用;アグリゲーター,ポッド;キャスト;用;アグリゲータ,ポッド;キャスト;用;アグリゲータ,ポッド;キャスト;ヨー;アグリゲータ,;;;,;;;,ポッド;キャスト;ヨウ;アグリゲータ,ポッドキャストヨウ,ポッドキャスト用
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12564,7 +12564,7 @@
 
 # newdoc id = test-s535
 # sent_id = test-s535
-# parallel_id = jagsdluw/test535
+# parallel_id = jagsd/test535
 # text = 味付けは、あっさり目で、かなり調味料に気を使っているのかもしれません。
 1	味付け	味付け	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=アジツケ,味付け,味付け,味付け,アジツケ,,,アジツケ,アジツケ,味付け
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12586,7 +12586,7 @@
 
 # newdoc id = test-s536
 # sent_id = test-s536
-# parallel_id = jagsdluw/test536
+# parallel_id = jagsd/test536
 # text = ブラジルだけが、モーターやエンジンなど各国の先端技術を組み合わせることで、数千メートルの環境変化に耐えられる独自技術を開発した。
 1	ブラジル	ブラジル	PROPN	名詞-固有名詞-地名-国	_	25	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ブラジル,ブラジル,ブラジル,ブラジル,ブラジル,,,ブラジル,ブラジル,ブラジル
 2	だけ	だけ	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダケ,だけ,だけ,だけ,ダケ,,,ダケ,ダケ,だけ
@@ -12618,7 +12618,7 @@
 
 # newdoc id = test-s537
 # sent_id = test-s537
-# parallel_id = jagsdluw/test537
+# parallel_id = jagsd/test537
 # text = こうした理由で,例えプラセボとしても,医療関係者がホメオパシーを治療に使用することは認められません。
 1	こう	こう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コウ,こう,こう,こう,コー,,,コウ,コウ,こう
 2	し	する	VERB	動詞-一般-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,スル,する
@@ -12648,7 +12648,7 @@
 
 # newdoc id = test-s538
 # sent_id = test-s538
-# parallel_id = jagsdluw/test538
+# parallel_id = jagsd/test538
 # text = 新聞は,助産師が所属する団体名や療法名を報じていませんが,ホメオパシーを用いる団体と思われます。
 1	新聞	新聞	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シンブン,新聞,新聞,新聞,シンブン,,,シンブン,シンブン,新聞
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12678,7 +12678,7 @@
 
 # newdoc id = test-s539
 # sent_id = test-s539
-# parallel_id = jagsdluw/test539
+# parallel_id = jagsd/test539
 # text = 支持者によって20世紀最大の神学者と称される新正統主義のカール・バルトは、未完の主著「教会教義学」全4巻における第3巻、邦訳全36分冊中11冊分を創造説に割いている。
 1	支持者	支持者	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シジ;シャ,支持;者,支持;者,支持;者,シジ;シャ,;,;,シジ;シャ,シジシャ,支持者
 2	によって	によって	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ;ヨル;テ,に;因る;て,に;よっ;て,に;よる;て,ニ;ヨッ;テ,;;,;;,ニ;ヨル;テ,ニヨッテ,によって
@@ -12714,7 +12714,7 @@
 
 # newdoc id = test-s540
 # sent_id = test-s540
-# parallel_id = jagsdluw/test540
+# parallel_id = jagsd/test540
 # text = 日産は8月6日、軽自動車「オッティ」の一部仕様を変更し、同日より発売した。
 1	日産	日産	PROPN	名詞-固有名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ニッサン,日産,日産,日産,ニッサン,,,ニッサン,ニッサン,日産
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12735,7 +12735,7 @@
 
 # newdoc id = test-s541
 # sent_id = test-s541
-# parallel_id = jagsdluw/test541
+# parallel_id = jagsd/test541
 # text = 翼端に付けていた増槽は機体の重心が前に寄り過ぎるために使用されず、主翼中央下面に滑らかな形状で装着できるように再設計された。
 1	翼端	翼端	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ヨクタン,翼端,翼端,翼端,ヨクタン,,,ヨクタン,ヨクタン,翼端
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -12772,7 +12772,7 @@
 
 # newdoc id = test-s542
 # sent_id = test-s542
-# parallel_id = jagsdluw/test542
+# parallel_id = jagsd/test542
 # text = 若い頃は土司の小作人や軍の人夫をして過ごす。
 1	若い	若い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ワカイ,若い,若い,若い,ワカイ,,,ワカイ,ワカイ,若い
 2	頃	頃	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=コロ,頃,頃,頃,コロ,,,コロ,コロ,頃
@@ -12792,7 +12792,7 @@
 
 # newdoc id = test-s543
 # sent_id = test-s543
-# parallel_id = jagsdluw/test543
+# parallel_id = jagsd/test543
 # text = クールな性格で、自らを「いやな子」と称する。
 1	クール	クール	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=クール,クール,クール,クール,クール,,,クール,クール,クール
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -12812,7 +12812,7 @@
 
 # newdoc id = test-s544
 # sent_id = test-s544
-# parallel_id = jagsdluw/test544
+# parallel_id = jagsd/test544
 # text = ヴァランゲル半島の北東部に位置する。
 1	ヴァランゲル半島	ヴァランゲル半島	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=バランゲル;ハントウ,バランゲル;半島,ヴァランゲル;半島,ヴァランゲル;半島,バランゲル;ハントー,;,;,バランゲル;ハントウ,バランゲルハントウ,ヴァランゲル半島
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12823,7 +12823,7 @@
 
 # newdoc id = test-s545
 # sent_id = test-s545
-# parallel_id = jagsdluw/test545
+# parallel_id = jagsd/test545
 # text = 統一教会足立教会の週報でも今回のイベントが信者に対して告知されていることから,集会の参加者にも統一教会信者が動員されるものと思われます。
 1	統一教会足立教会	統一教会足立教会	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=トウイツ;キョウカイ;アダチ;キョウカイ,統一;教会;アダチ;教会,統一;教会;足立;教会,統一;教会;足立;教会,トーイツ;キョーカイ;アダチ;キョーカイ,;;;,;;;,トウイツ;キョウカイ;アダチ;キョウカイ,トウイツキョウカイアダチキョウカイ,統一教会足立教会
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12860,7 +12860,7 @@
 
 # newdoc id = test-s546
 # sent_id = test-s546
-# parallel_id = jagsdluw/test546
+# parallel_id = jagsd/test546
 # text = 第7回以降の大会で、サッカーのビクトリーゴールのように条件を満たした時点で勝ちとなる特別な勝利条件が加えられることが度々あった。
 1	第7回以降	第7回以降	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ダイ;ナナ;カイ;イコウ,第;七;回;以降,第;7;回;以降,第;7;回;以降,ダイ;ナナ;カイ;イコー,;;;,;;;,ダイ;ナナ;カイ;イコウ,ダイナナカイイコウ,第7回以降
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12897,7 +12897,7 @@
 
 # newdoc id = test-s547
 # sent_id = test-s547
-# parallel_id = jagsdluw/test547
+# parallel_id = jagsd/test547
 # text = 反乱軍の一人。
 1	反乱軍	反乱軍	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ハンラン;グン,反乱;軍,反乱;軍,反乱;軍,ハンラン;グン,;,;,ハンラン;グン,ハンラングン,反乱軍
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12906,14 +12906,14 @@
 
 # newdoc id = test-s548
 # sent_id = test-s548
-# parallel_id = jagsdluw/test548
+# parallel_id = jagsd/test548
 # text = 建築評論家。
 1	建築評論家	建築評論家	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|SpaceAfter=No|UnidicInfo=ケンチク;ヒョウロン;カ,建築;評論;家,建築;評論;家,建築;評論;家,ケンチク;ヒョーロン;カ,;;,;;,ケンチク;ヒョウロン;カ,ケンチクヒョウロンカ,建築評論家
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = test-s549
 # sent_id = test-s549
-# parallel_id = jagsdluw/test549
+# parallel_id = jagsd/test549
 # text = しかし中松氏については警察関係者も苦笑い。
 1	しかし	然し	CCONJ	接続詞	_	7	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	中松氏	中松氏	PROPN	名詞-固有名詞-人名-姓	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ナカマツ;シ,ナカマツ;氏,中松;氏,中松;氏,ナカマツ;シ,;,;,ナカマツ;シ,ナカマツシ,中松氏
@@ -12926,7 +12926,7 @@
 
 # newdoc id = test-s550
 # sent_id = test-s550
-# parallel_id = jagsdluw/test550
+# parallel_id = jagsd/test550
 # text = 終盤のツール・ド・おきなわでは鳩村と共に最後まで走りぬき、30位に入る健闘を見せる。
 1	終盤	終盤	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=シュウバン,終盤,終盤,終盤,シューバン,,,シュウバン,シュウバン,終盤
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12951,7 +12951,7 @@
 
 # newdoc id = test-s551
 # sent_id = test-s551
-# parallel_id = jagsdluw/test551
+# parallel_id = jagsd/test551
 # text = 護符の由来どころか,そもそも杉山先生の気功能力の出自もナゾです。
 1	護符	護符	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ゴフ,護符,護符,護符,ゴフ,,,ゴフ,ゴフ,護符
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12972,7 +12972,7 @@
 
 # newdoc id = test-s552
 # sent_id = test-s552
-# parallel_id = jagsdluw/test552
+# parallel_id = jagsd/test552
 # text = 見学がてらの面接後も、電話で見学してみた印象を確認してくださって後で比較検討しやすいようにとアドバイスしてくださいました。
 1	見学がてら	見学がてら	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ケンガク;ガテラ,見学;がてら,見学;がてら,見学;がてら,ケンガク;ガテラ,;,;,ケンガク;ガテラ,ケンガクガテラ,見学がてら
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13003,7 +13003,7 @@
 
 # newdoc id = test-s553
 # sent_id = test-s553
-# parallel_id = jagsdluw/test553
+# parallel_id = jagsd/test553
 # text = プラスミドを改変してベクターとして利用する。
 1	プラスミド	プラスミド	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=プラスミド,プラスミド,プラスミド,プラスミド,プラスミド,,,プラスミド,プラスミド,プラスミド
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -13016,7 +13016,7 @@
 
 # newdoc id = test-s554
 # sent_id = test-s554
-# parallel_id = jagsdluw/test554
+# parallel_id = jagsd/test554
 # text = 駐車場は狭いので混みあう時間帯は注意ですが、事前に電話をして到着時間を伝えておけば良いですね。
 1	駐車場	駐車場	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=チュウシャ;ジョウ,駐車;場,駐車;場,駐車;場,チューシャ;ジョー,;,;,チュウシャ;ジョウ,チュウシャジョウ,駐車場
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -13046,7 +13046,7 @@
 
 # newdoc id = test-s555
 # sent_id = test-s555
-# parallel_id = jagsdluw/test555
+# parallel_id = jagsd/test555
 # text = 散髪のやり方次第で頭脳は発達すると考えて、どの店の散髪がよいか理髪店を絶えず替えていた。
 1	散髪	散髪	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=サンパツ,散髪,散髪,散髪,サンパツ,,,サンパツ,サンパツ,散髪
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13077,7 +13077,7 @@
 
 # newdoc id = test-s556
 # sent_id = test-s556
-# parallel_id = jagsdluw/test556
+# parallel_id = jagsd/test556
 # text = 見上げる程の大きさの弧形が地表に露出しているが、これですら全体の一部でしかなく、全体は地殻を貫通して星の核にまで達している。
 1	見上げる	見上げる	VERB	動詞-一般-下一段-ガ行	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=ミアゲル,見上げる,見上げる,見上げる,ミアゲル,,,ミアゲル,ミアゲル,見上げる
 2	程	ほど	PART	助詞-副助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|SpaceAfter=No|UnidicInfo=ホド,ほど,程,程,ホド,,,ホド,ホド,ほど
@@ -13118,7 +13118,7 @@
 
 # newdoc id = test-s557
 # sent_id = test-s557
-# parallel_id = jagsdluw/test557
+# parallel_id = jagsd/test557
 # text = また、顕彰当時現役の選手も存在したが、いずれも既に全女を退団していた。
 1	また	又	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、


### PR DESCRIPTION
 update README metadata and add parallel IDs
     - add "Parallel: "jagsd" to indicate parallel data availability
 add " parallel_id = jagsd/{dev{n}, test{n}, train{n}}/part{n} alt{n}" format to support automated parallel sentences identification, where n = any number (positive intergers, arabic numerals, starts with 1)